### PR TITLE
Add SPDK submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "spdk"]
+	path = spdk
+	url = https://github.com/ceph/spdk.git
+	branch = ceph-nvmeof


### PR DESCRIPTION
 Uses a fork of the SPDK github repo, so we're free to commit branches as

needed, as in this repo. The default branch in the SPDK fork repo will be wip-ceph-nvmeof.

Signed-off-by: Scott Peterson <scott.d.peterson@intel.com>