### PR TITLE
nvme_gw_server: allow to change rpc socket address

### DIFF
--- a/nvme_gw.config
+++ b/nvme_gw.config
@@ -25,8 +25,7 @@ client_cert = ./client.crt
 
 [spdk]
 
-spdk_server_addr = /var/tmp/spdk.sock
-spdk_port = 5260
+rpc_socket = /var/tmp/spdk.sock
 timeout = 60.0
 log_level = ERROR
 conn_retries = 3


### PR DESCRIPTION
Previously it was supposed that you could change the address by using
spdk_server_addr and spdk_port configuration parameters. But the
parameters were used only by rcp client, while the spdk target was
always started with the default socket address. This commit fixes it.

Additionally, there is no sense to provide the port configuration
option because the target is always listening on a unix socket
only. So the two parameters spdk_server_addr and spdk_port are
replaced with one rpc_socket. There is not much sense to add "spdk_"
prefix to the option name, because it is in [spdk] section.

And while here remove unused "all" argument in nvme_tgt command, which
seemed to be unintentionally committed after testing with "-L all".

Signed-off-by: Mykola Golub <mykola.golub@clyso.com>