### PR TITLE
nvme_gw_server: allow to pass additional options to spdk target

### DIFF
--- a/nvme_gw.config
+++ b/nvme_gw.config
@@ -29,3 +29,4 @@ rpc_socket = /var/tmp/spdk.sock
 timeout = 60.0
 log_level = ERROR
 conn_retries = 3
+tgt_cmd_args =

--- a/nvme_gw_server.py
+++ b/nvme_gw_server.py
@@ -8,6 +8,7 @@
 #
 
 import os
+import shlex
 import sys
 import subprocess
 import grpc
@@ -37,8 +38,11 @@ class GWService(pb2_grpc.NVMEGatewayServicer):
         spdk_tgt = self.nvme_config.get("config", "spdk_tgt")
         spdk_cmd = os.path.join(spdk_path, spdk_tgt)
         spdk_rpc_socket = self.nvme_config.get("spdk", "rpc_socket")
+        spdk_tgt_cmd_args = self.nvme_config.get("spdk", "tgt_cmd_args")
 
         cmd = [spdk_cmd, "-u", "-r", spdk_rpc_socket]
+        if spdk_tgt_cmd_args:
+            cmd += shlex.split(spdk_tgt_cmd_args)
         self.logger.info(f"Starting {' '.join(cmd)}")
 
         try:


### PR DESCRIPTION
A user might want to pass some additional arguments to nvmf_tgt
command, not covered by our options. Provide this possibility by
introducing tgt_cmd_args configuration parameter.

Signed-off-by: Mykola Golub <mykola.golub@clyso.com>