### PR TITLE
nvme_gw_server: do not redirect tgt stderr/out to pipe

### DIFF
--- a/nvme_gw_server.py
+++ b/nvme_gw_server.py
@@ -167,8 +167,6 @@ class GWService(pb2_grpc.NVMEGatewayServicer):
 
         try:
             self.spdk_process = subprocess.Popen(cmd,
-                                                 stderr=subprocess.PIPE,
-                                                 stdout=subprocess.PIPE,
                                                  preexec_fn=set_pdeathsig(
                                                      signal.SIGTERM))
 


### PR DESCRIPTION
Currently we do not read it and it may dead lock when
there is much output.

In future we might want a better solution, e.g. to write it to
a log file.

Signed-off-by: Mykola Golub <mykola.golub@clyso.com>