### PR TITLE
nvme_gw: implicitly create transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Run the tool with the -h flag to see a list of available commands:
 	
 	$ python3 ./nvme_gw_cli.py -h
 	usage: python3 ./nvme_gw_cli.py [-h] [-c CONFIG]
-			{create_bdev,delete_bdev,create_subsystem,delete_subsystem,create_namespace,delete_namespace,add_host,delete_host,create_transport,create_listener,delete_listener,get_subsystems} ...
+			{create_bdev,delete_bdev,create_subsystem,delete_subsystem,create_namespace,delete_namespace,add_host,delete_host,create_listener,delete_listener,get_subsystems} ...
 
 	CLI to manage NVMe gateways
 
 	positional arguments:
-	{create_bdev,delete_bdev,create_subsystem,delete_subsystem,create_namespace,delete_namespace,add_host,delete_host,create_transport,create_listener,delete_listener,get_subsystems}
+	{create_bdev,delete_bdev,create_subsystem,delete_subsystem,create_namespace,delete_namespace,add_host,delete_host,create_listener,delete_listener,get_subsystems}
 
 	optional arguments:
 	-h, --help            			show this help message and exit
@@ -135,9 +135,6 @@ Indicate the location of the keys and certificates in the config file:
 		
 		$ python3 ./nvme_gw_cli.py add_host -n nqn.2016-06.io.spdk:cnode1 -t *
 		INFO:root:Allow open host access to nqn.2016-06.io.spdk:cnode1: True
-		
-		$ python3 ./nvme_gw_cli.py create_transport -t TCP
-		INFO:root:Created TCP transport: True
 		
 		$ python3 ./nvme_gw_cli.py create_listener -n nqn.2016-06.io.spdk:cnode1 -a 192.168.50.4 -s 5001
 		INFO:root:Created nqn.2016-06.io.spdk:cnode1 listener: True

--- a/nvme_gw.config
+++ b/nvme_gw.config
@@ -36,3 +36,5 @@ timeout = 60.0
 log_level = ERROR
 conn_retries = 3
 tgt_cmd_extra_args =
+transports = tcp
+# transport_tcp_options = {"max_queue_depth" : 16, "max_io_size" : 4194304, "io_unit_size" : 1048576, "zcopy" : false}

--- a/nvme_gw_cli.py
+++ b/nvme_gw_cli.py
@@ -273,17 +273,6 @@ class GatewayClient:
         except Exception as error:
             self.logger.error(f"Failed to remove host: \n {error}")
 
-    @cli.cmd([argument("-t", "--trtype", help="Transport type", default="TCP")])
-    def create_transport(self, args):
-        """Sets a transport type."""
-
-        try:
-            create_req = pb2.create_transport_req(trtype=args.trtype)
-            ret = self.stub.nvmf_create_transport(create_req)
-            self.logger.info(f"Created {args.trtype} transport: {ret.status}")
-        except Exception as error:
-            self.logger.error(f"Failed to create transport: \n {error}")
-
     @cli.cmd([
         argument("-n", "--subnqn", help="Subsystem NQN", required=True),
         argument("-a", "--traddr", help="NVMe host IP", required=True),

--- a/nvme_gw_config.py
+++ b/nvme_gw_config.py
@@ -33,3 +33,15 @@ class NVMeGWConfig:
 
     def getfloat(self, section, param):
         return self.nvme_gw_config.getfloat(section, param)
+
+    def get_with_default(self, section, param, value):
+        return self.nvme_gw_config.get(section, param, fallback=value)
+
+    def getboolean_with_default(self, section, param, value):
+        return self.nvme_gw_config.getboolean(section, param, fallback=value)
+
+    def getint_with_default(self, section, param, value):
+        return self.nvme_gw_config.getint(section, param, fallback=value)
+
+    def getfloat_with_default(self, section, param, value):
+        return self.nvme_gw_config.getfloat(section, param, fallback=value)

--- a/nvme_gw_persistence.py
+++ b/nvme_gw_persistence.py
@@ -59,14 +59,6 @@ class PersistentConfig(ABC):
         pass
 
     @abstractmethod
-    def set_transport(self, trtype: str, val: str):
-        pass
-
-    @abstractmethod
-    def delete_transport(self, trtype: str):
-        pass
-
-    @abstractmethod
     def delete_config(self):
         pass
 
@@ -100,7 +92,6 @@ class OmapPersistentConfig(PersistentConfig):
     NAMESPACE_PREFIX = "namespace_"
     SUBSYSTEM_PREFIX = "subsystem_"
     HOST_PREFIX = "host_"
-    TRANSPORT_PREFIX = "transport_"
     LISTENER_PREFIX = "listener_"
 
     def __init__(self, nvme_config):
@@ -275,29 +266,6 @@ class OmapPersistentConfig(PersistentConfig):
                 req = json_format.Parse(val, pb2.subsystem_add_listener_req())
                 callback(req)
 
-    def set_transport(self, trtype: str, val: str):
-        """Sets transport type in the persistent config."""
-        key = self.TRANSPORT_PREFIX + trtype
-        self._write_key(key, val)
-
-    def delete_transport(self, trtype: str):
-        """Delete transport type in the persistent config."""
-        key = self.TRANSPORT_PREFIX + trtype
-        self._delete_key(key)
-
-    def get_transport(self, trtype: str):
-        """Read existing transport type from the persistent config."""
-        key = self.TRANSPORT_PREFIX + trtype
-        return self._read_key(key)
-
-    def _restore_transports(self, omap_dict, callback):
-        """Restores a transport from the persistent config."""
-
-        for (key, val) in omap_dict.items():
-            if key.startswith(self.TRANSPORT_PREFIX):
-                req = json_format.Parse(val, pb2.create_transport_req())
-                callback(req)
-
     def _read_key(self, key) -> Optional[str]:
         """Reads single key from persistent config and returns its value."""
 
@@ -343,8 +311,6 @@ class OmapPersistentConfig(PersistentConfig):
             self._restore_namespaces(omap_dict,
                                      callbacks[self.NAMESPACE_PREFIX])
             self._restore_hosts(omap_dict, callbacks[self.HOST_PREFIX])
-            self._restore_transports(omap_dict,
-                                     callbacks[self.TRANSPORT_PREFIX])
             self._restore_listeners(omap_dict, callbacks[self.LISTENER_PREFIX])
             self.version = int(omap_dict[self.OMAP_VERSION_KEY])
             self.logger.info("Restore complete.")

--- a/proto/nvme_gw.proto
+++ b/proto/nvme_gw.proto
@@ -14,9 +14,6 @@ service NVMEGateway {
 	// start the SPDK target
 	rpc start_spdk(spdk_start_req) returns(spdk_status) {}
 
-	// Create Transport
-	rpc nvmf_create_transport(create_transport_req) returns(req_status) {}
-
 	// Create bdev/ NVMe Namespace from an RBD image
 	rpc bdev_rbd_create(bdev_create_req) returns (bdev_info) {}
 
@@ -129,10 +126,6 @@ message host_delete_req {
 
 message req_status {
 	bool status = 1;
-}
-
-message create_transport_req {
-	string trtype = 1; //NVMe Transport Type (eg: tcp. rdma, etc)
 }
 
 message subsystem_add_listener_req {

--- a/test_cli.py
+++ b/test_cli.py
@@ -36,10 +36,6 @@ class TestCreate:
         cli(["-c", config, "add_host", "-n", subsystem, "-t", host])
         assert "Failed to add" not in caplog.text
 
-    def test_create_transport(self, caplog):
-        cli(["-c", config, "create_transport", "-t", trtype])
-        assert "Failed to create" not in caplog.text
-
     def test_create_listener(self, caplog):
         cli(["-c", config, "create_listener", "-n", subsystem, "-a", addr, "-s", port])
         assert "Failed to create" not in caplog.text


### PR DESCRIPTION
Instead of providing create_transport command, implicitly create
transports that are specified in spdk/transports config option
(space separated values).

Additionally one may use spdk/transport_{name}_options to
specify transport specific options (space separated key=val)

Fixes: https://github.com/ceph/ceph-nvmeof/issues/12
Signed-off-by: Mykola Golub <mykola.golub@clyso.com>