### PR TITLE
nvme_gw_server: use only one grpc worker thread

### DIFF
--- a/nvme_gw.config
+++ b/nvme_gw.config
@@ -13,7 +13,6 @@ enable_auth = False
 gateway_addr = [::]
 gateway_port = 5500
 gateway_group =
-grpc_server_max_workers = 10
 
 [ceph]
 

--- a/nvme_gw_server.py
+++ b/nvme_gw_server.py
@@ -100,12 +100,9 @@ class GWService(pb2_grpc.NVMEGatewayServicer):
         enable_auth = self.nvme_config.getboolean("config", "enable_auth")
         gateway_addr = self.nvme_config.get("config", "gateway_addr")
         gateway_port = self.nvme_config.get("config", "gateway_port")
-        grpc_max_workers = self.nvme_config.getint("config",
-                                                   "grpc_server_max_workers")
 
         # Create server and check for existing NVMeoF target configuration
-        self.server = grpc.server(
-            futures.ThreadPoolExecutor(max_workers=grpc_max_workers))
+        self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
         self.start_spdk()
         self.restore_config()
         pb2_grpc.add_NVMEGatewayServicer_to_server(self, self.server)


### PR DESCRIPTION
Having several threads is racy. It could be fixed but
right now it is not clear we need more than one thread,
so it may be improved later.

Fixes: https://github.com/ceph/ceph-nvmeof/issues/22
Signed-off-by: Mykola Golub <mykola.golub@clyso.com>