### PR TITLE
spdk: update to 23.01

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This daemon runs as root. It provides the ability to export existing RBD images 
 		
 	    $ make grpc 
 
-5. SPDK v21.04 is included in this repository. Edit the config file to set:
+5. SPDK is included in this repository as a submodule. Edit the config file to set:
 
 		spdk_path = <complete path to SPDK parent directory>
 		spdk_tgt = <relative path to SPDK target executable>

--- a/control/server.py
+++ b/control/server.py
@@ -144,9 +144,9 @@ class GatewayServer:
 
         # Get path and import SPDK's RPC modules
         spdk_path = self.config.get("spdk", "spdk_path")
-        sys.path.append(spdk_path)
+        sys.path.append(os.path.join(spdk_path, "spdk/python"))
         self.logger.info(f"SPDK PATH: {spdk_path}")
-        import spdk.scripts.rpc as spdk_rpc
+        import spdk.rpc as spdk_rpc
         self.spdk_rpc = spdk_rpc
 
         # Start target


### PR DESCRIPTION
As discussed, I bumped SPDK to 23.01 in https://github.com/ceph/spdk.  @sskaur please run this through your tests to pick up any SPDK RPC changes that might impact the gateway.