### PR TITLE
retry on OMAP add/remove

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -14,6 +14,7 @@ group =
 addr = 127.0.0.1
 port = 5500
 enable_auth = False
+state_update_retries = 3
 state_update_notify = True
 state_update_interval_sec = 5
 

--- a/control/server.py
+++ b/control/server.py
@@ -92,7 +92,7 @@ class GatewayServer:
 
         # Register service implementation with server
         omap_state = OmapGatewayState(self.config)
-        local_state = LocalGatewayState()
+        local_state = LocalGatewayState(self.config)
         gateway_state = GatewayStateHandler(self.config, local_state,
                                             omap_state, self.gateway_rpc_caller)
         self.gateway_rpc = GatewayService(self.config, gateway_state,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -17,9 +17,9 @@ def ioctx(config):
 
 
 @pytest.fixture
-def local_state():
+def local_state(config):
     """Returns local state object."""
-    return LocalGatewayState()
+    return LocalGatewayState(config)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR builds upon #29 as outlined in https://github.com/ceph/ceph-nvmeof/issues/56 and implements a 2-step OMAP update for incoming requests and attempts to update from the OMAP if out-of-date during the handling of those requests. It also handles cleanup of excess OMAP keys on startup.

At this time, the PR doesn't include logic to wait for conflicting in-progress requests to complete. If there aren't many changes requested, we can add it on.