### PR TITLE
ceph-nvmeof.conf: comment out transports option

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -36,5 +36,5 @@ timeout = 60.0
 log_level = ERROR
 # conn_retries = 10
 tgt_cmd_extra_args =
-transports = tcp
+# transports = tcp
 # transport_tcp_options = {"max_queue_depth" : 16, "max_io_size" : 4194304, "io_unit_size" : 1048576, "zcopy" : false}


### PR DESCRIPTION
For consistency with other defaulted options (it defaults to tcp).