### PR TITLE
server: provide a default for tgt_cmd_extra_args option

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -42,4 +42,6 @@ log_level = ERROR
 # tgt_cmd_extra_args =
 
 # transports = tcp
-# transport_tcp_options = {"max_queue_depth" : 16, "max_io_size" : 4194304, "io_unit_size" : 1048576, "zcopy" : false}
+
+# Example value: {"max_queue_depth" : 16, "max_io_size" : 4194304, "io_unit_size" : 1048576, "zcopy" : false}
+# transport_tcp_options =

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -37,6 +37,9 @@ rpc_socket = /var/tmp/spdk.sock
 timeout = 60.0
 log_level = ERROR
 # conn_retries = 10
-tgt_cmd_extra_args =
+
+# Example value: -m 0x3 -L all
+# tgt_cmd_extra_args =
+
 # transports = tcp
 # transport_tcp_options = {"max_queue_depth" : 16, "max_io_size" : 4194304, "io_unit_size" : 1048576, "zcopy" : false}

--- a/control/server.py
+++ b/control/server.py
@@ -156,7 +156,8 @@ class GatewayServer:
         # Start target
         tgt_path = self.config.get("spdk", "tgt_path")
         spdk_rpc_socket = self.config.get("spdk", "rpc_socket")
-        spdk_tgt_cmd_extra_args = self.config.get("spdk", "tgt_cmd_extra_args")
+        spdk_tgt_cmd_extra_args = self.config.get_with_default(
+            "spdk", "tgt_cmd_extra_args", "")
         spdk_cmd = os.path.join(spdk_path, tgt_path)
         cmd = [spdk_cmd, "-u", "-r", spdk_rpc_socket]
         if spdk_tgt_cmd_extra_args:


### PR DESCRIPTION
The default of "no extra args" is reflected in ceph-nvmeof.conf.  An example value is provided to demonstrate syntax.