### PR TITLE
server: Don't mute exceptions

### DIFF
--- a/control/server.py
+++ b/control/server.py
@@ -83,7 +83,6 @@ class GatewayServer:
             self.server.stop(None)
 
         self.logger.info("Exiting the gateway process.")
-        return True
 
     def serve(self):
         """Starts gateway server."""


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph-nvmeof/issues/97

From https://docs.python.org/3/reference/datamodel.html#object.__exit__:

```
object.__exit__(self, exc_type, exc_value, traceback)

(...)

If an exception is supplied, and the method wishes to suppress the exception
(i.e., prevent it from being propagated), it should return a true value.
Otherwise, the exception will be processed normally upon exit from this method.
```