### PR TITLE
build: check PR deps

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -1,0 +1,15 @@
+# Blocks PR merging if PR description contains "depends on" or "blocked by"
+# pointing to another PR until that PR is merged
+
+on: [pull_request]
+
+jobs:
+  check-deps:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+    # https://github.com/marketplace/actions/pr-dependency-check
+    # Pinned to v1.2.4 SHA-1 for security reasons
+    - uses: gregsdennis/dependencies-action@71c5cc14fab62389a600c0a6e37584dc4916799c
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub Action will block any PR containing `depends on #PR`  or `blocked by #PR` until that given PR is merged.

More info: https://github.com/marketplace/actions/pr-dependency-check