### PR TITLE
build: add Reviewed-by trailer

### DIFF
--- a/.github/workflows/add-reviewed-by.yml
+++ b/.github/workflows/add-reviewed-by.yml
@@ -1,0 +1,14 @@
+# Add "Reviewed-by" trailer to PR description whenever a reviewer approves a PR
+name: Add Reviewed-by
+on:
+  pull_request_review:
+    types:
+      - submitted
+jobs:
+  approved:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/add-reviewed-by
+      # Pinned to non-tag SHA-1 (86dcf10d5d2aadd1a2c78084a5d6598c84539843)
+      - uses: ntessore/add-reviewed-by-action@86dcf10d5d2aadd1a2c78084a5d6598c84539843


### PR DESCRIPTION
This change automates the addition of the `Reviewed-by` trailer. Whenever a user approves a PR, it adds such a trailer to the PR description. If the PR description is used to generate the merge commit summary (which is not the GitHub default), then the `Reviewer-by` trailer becomes automatically appended to the merge commit.

The main con is that the username is the GitHub one, not the one used for the signed-off-by.

Example [PR](https://github.com/epuertat/ceph-nvmeof/pull/2) and [resulting merge commit](https://github.com/epuertat/ceph-nvmeof/commit/4f8ef6e8295ec24f1d93534d005477d46581121e).

![image](https://github.com/ceph/ceph-nvmeof/assets/37327689/436721e3-2aab-4817-9df8-9178b5636f31)

![image](https://github.com/ceph/ceph-nvmeof/assets/37327689/0b7c8730-ab51-48a0-a74d-d31db1f03b03)