### PR TITLE
feat(control): allow specifying max_namespaces on subsystem creation

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -166,13 +166,15 @@ class GatewayClient:
     @cli.cmd([
         argument("-n", "--subnqn", help="Subsystem NQN", required=True),
         argument("-s", "--serial", help="Serial number", required=True),
+        argument("-m", "--max-namespaces", help="Maximum number of namespaces", type=int, default=0, required=False),
     ])
     def create_subsystem(self, args):
         """Creates a subsystem."""
 
         try:
             req = pb2.create_subsystem_req(subsystem_nqn=args.subnqn,
-                                           serial_number=args.serial)
+                                           serial_number=args.serial,
+                                           max_namespaces=args.max_namespaces)
             ret = self.stub.create_subsystem(req)
             self.logger.info(f"Created subsystem {args.subnqn}: {ret.status}")
         except Exception as error:

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -117,6 +117,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 self.spdk_rpc_client,
                 nqn=request.subsystem_nqn,
                 serial_number=request.serial_number,
+                max_namespaces=request.max_namespaces,
             )
             self.logger.info(f"create_subsystem {request.subsystem_nqn}: {ret}")
         except Exception as ex:

--- a/proto/gateway.proto
+++ b/proto/gateway.proto
@@ -61,6 +61,7 @@ message delete_bdev_req {
 message create_subsystem_req {
 	string subsystem_nqn = 1;
 	string serial_number = 2;
+	int32 max_namespaces = 3;
 }
 
 message delete_subsystem_req {


### PR DESCRIPTION
This PR gives user a flexibility to specify maximum number of namespaces in a subsystem

Fixes https://github.com/ceph/ceph-nvmeof/issues/146