### PR TITLE
fix(grpc): throw error on wrong gateway listener

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -391,6 +391,9 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     adrfam=request.adrfam,
                 )
                 self.logger.info(f"create_listener: {ret}")
+            else:
+                raise Exception(f"Gateway name must match current gateway"
+                                f" ({self.gateway_name})")
         except Exception as ex:
             self.logger.error(f"create_listener failed with: \n {ex}")
             if context:
@@ -432,6 +435,9 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     adrfam=request.adrfam,
                 )
                 self.logger.info(f"delete_listener: {ret}")
+            else:
+                raise Exception(f"Gateway name must match current gateway"
+                                f" ({self.gateway_name})")
         except Exception as ex:
             self.logger.error(f"delete_listener failed with: \n {ex}")
             if context:


### PR DESCRIPTION
This PR adds an exception in cases of `create/delete_listener` where the gateway name is supplied along with traddr but the gateway name does not match the current gateway. Previously, no SPDK call would be made but the listener request would return successfully.

Thanks to @pgerv12 and @SeanP-2023 for finding this issue.
