### PR TITLE
cephadm compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ LABEL io.ceph.component="$NVMEOF_NAME" \
       io.ceph.git.branch="$NVMEOF_GIT_BRANCH" \
       io.ceph.git.commit="$NVMEOF_GIT_COMMIT"
 
+RUN echo echo $NVMEOF_NAME $NVMEOF_VERSION $NVMEOF_GIT_COMMIT > /bin/ceph
+RUN chmod 755 /bin/ceph
+
 ENV PYTHONPATH=$APPDIR/proto:$APPDIR/__pypackages__/$PYTHON_MAJOR.$PYTHON_MINOR/lib
 
 WORKDIR $APPDIR


### PR DESCRIPTION
## Add `ceph` executable printing this component version, required by cephadm

cephadm [`command_pull()`](https://github.com/ceph/ceph/blob/fd62a8dfcb345fabed3eea6b3a461f1ca848a239/src/cephadm/cephadm.py#L4944-L4954), during pulling the container images, calls to [`command_inspect_image()`](https://github.com/ceph/ceph/blob/fd62a8dfcb345fabed3eea6b3a461f1ca848a239/src/cephadm/cephadm.py#L4995-L5011) which execs in container ["ceph --version"](https://github.com/ceph/ceph/blob/fd62a8dfcb345fabed3eea6b3a461f1ca848a239/src/cephadm/cephadm.py#L5007):

```python
    ver = CephContainer(ctx, ctx.image, 'ceph', ['--version']).run().strip()
```

## Example error:
```shell
RuntimeError: Failed command: /usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --entrypoint ceph --init -e CONTAINER_IMAGE=quay.io/ceph/nvmeof:0.0.1 -e NODE_NAME=centos9 quay.io/ceph/nvmeof:0.0.1 --version: ERROR (catatonit:2): failed to exec pid1: No such file or directory
```

## Teuthology
- test:  https://pulpito.ceph.com/baum-2023-07-17_11:58:59-rbd:nvmeof-wip-baum-cephadm-nvmeof-distro-default-smithi/7341352/ 
- suite: https://github.com/baum/ceph/tree/wip-baum-cephadm-nvmeof-rebase-20230715

## [Previous discussions](https://github.com/ceph/ceph-nvmeof/pull/90#discussion_r1242709355)