### PR TITLE
CI workflow for existing pytest tests

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,28 +1,39 @@
 name: "CI"
 on:
   push:
-    branches:
-      - devel
   pull_request:
-    branches:
-      - devel
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-env:
-  HUGEPAGES: 256
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          # git submodule update --init --recursive
           submodules: recursive
 
       - name: Build container images
         run: make build SVC="spdk nvmeof nvmeof-cli ceph"
+
+      - name: Save container images
+        run: |
+          . .env
+          docker save quay.io/ceph/nvmeof:$NVMEOF_VERSION > nvmeof.tar
+          docker save quay.io/ceph/nvmeof-cli:$NVMEOF_VERSION > nvmeof-cli.tar
+          docker save quay.io/ceph/vstart-cluster:$CEPH_VERSION  > vstart-cluster.tar
+
+      - name: Upload container images
+        uses: actions/upload-artifact@v3
+        with:
+          name: images
+          path: |
+            nvmeof.tar
+            nvmeof-cli.tar
+            vstart-cluster.tar
 
       - name: Build stand-alone packages (RPMs and Python wheel)
         id: build-standalone-packages
@@ -39,8 +50,98 @@ jobs:
           path: |
             ${{ env.EXPORT_DIR }}/**
 
+  pytest:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+          test: ["cli", "state", "multi_gateway"]
+    runs-on: ubuntu-latest
+    env:
+      HUGEPAGES: 512 # for multi gateway test, approx 256 per gateway instance
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup huge pages
+        run: |
+          make setup HUGEPAGES=$HUGEPAGES
+
+      - name: Download container images
+        uses: actions/download-artifact@v3
+        with:
+          name: images
+
+      - name: Load container images
+        run: |
+          docker load < nvmeof.tar
+          docker load < vstart-cluster.tar
+
+      - name: Start ceph cluster
+        run: |
+          make up SVC=ceph OPTS="--detach"
+
+      - name: Wait for the ceph cluster container to become healthy
+        run: |
+          while true; do
+            container_status=$(docker inspect --format='{{.State.Health.Status}}' ceph)
+            if [[ $container_status == "healthy" ]]; then
+            break
+          else
+            # Wait for a specific time before checking again
+            sleep 1
+            echo -n .
+          fi
+          done
+          echo
+
+      - name: Create RBD image
+        run: |
+          echo "💁 ceph list pools:"
+          make exec SVC=ceph OPTS="-T" CMD="ceph osd lspools"
+          echo "💁 rbd create:"
+          make exec SVC=ceph OPTS="-T" CMD="rbd create rbd/mytestdevimage --size 16"
+          echo "💁 ls rbd:"
+          make exec SVC=ceph OPTS="-T" CMD="rbd ls rbd"
+
+      - name: Run ${{ matrix.test }} test
+        run: |
+          # Run tests code in current dir
+          # Managing pytest’s output: https://docs.pytest.org/en/7.1.x/how-to/output.html
+          make run SVC="nvmeof-devel" OPTS="--volume=$(pwd)/tests:/src/tests --entrypoint=python3" CMD="-m pytest --full-trace -vv -ra -s tests/test_${{ matrix.test }}.py"
+
+      - name: Display Logs
+        run: |
+          make logs OPTS=""
+
+      - name: Compose Down
+        run: make down
+
+      - name: Compose Clean
+        run: make clean
+
+  demo:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      HUGEPAGES: 256
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES
+
+      - name: Download container images
+        uses: actions/download-artifact@v3
+        with:
+          name: images
+
+      - name: Load container images
+        run: |
+          docker load < nvmeof.tar
+          docker load < nvmeof-cli.tar
+          docker load < vstart-cluster.tar
 
       - name: Start containers
         run: |
@@ -50,8 +151,8 @@ jobs:
         timeout-minutes: 1
         run: |
           . .env
-          HOST_PORT=$(make -s port OPTS="--index=1" CMD="nvmeof $NVMEOF_GW_PORT" | tr ":" " ")
-          until nc -z $HOST_PORT; do
+          echo using gateway $NVMEOF_IP_ADDRESS port $NVMEOF_GW_PORT
+          until nc -z $NVMEOF_IP_ADDRESS $NVMEOF_GW_PORT; do
             echo -n .
             sleep 1
           done
@@ -65,8 +166,7 @@ jobs:
 
       - name: Test
         run: |
-          . .env
-          make demo SERVER_ADDRESS=$NVMEOF_IP_ADDRESS OPTS=-T # Disable TTY
+          make demo OPTS=-T || (make logs OPTS=''; exit 1)
 
       - name: Get subsystems
         run: |

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ setup: ## Configure huge-pages (requires sudo/root password)
 	@echo Actual Hugepages allocation: $$(cat $(HUGEPAGES_DIR))
 	@[ $$(cat $(HUGEPAGES_DIR)) -eq $(HUGEPAGES) ]
 
-build push pull: SVC ?= spdk nvmeof nvmeof-cli ceph
+build push pull logs: SVC ?= spdk nvmeof nvmeof-cli ceph
 
 build: export NVMEOF_GIT_BRANCH != git name-rev --name-only HEAD
 build: export NVMEOF_GIT_COMMIT != git rev-parse HEAD
@@ -27,9 +27,10 @@ build: export SPDK_GIT_BRANCH != git -C spdk name-rev --name-only HEAD
 build: export SPDK_GIT_COMMIT != git rev-parse HEAD:spdk
 build: export BUILD_DATE != date -u +"%Y-%m-%dT%H:%M:%SZ"
 
-up: SVC = nvmeof ## Services
-up: OPTS ?= --abort-on-container-exit
-up: override OPTS += --no-build --remove-orphans --scale nvmeof=$(SCALE)
+up: ## Launch services
+up: SVC ?= ceph nvmeof ## Services
+up: OPTS ?= --abort-on-container-exit --exit-code-from $(SVC) --remove-orphans
+up: override OPTS += --scale nvmeof=$(SCALE)
 
 clean: override HUGEPAGES = 0
 clean: $(CLEAN) setup  ## Clean-up environment

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/ceph/ceph-nvmeof/actions/workflows/build-container.yml/badge.svg)](https://github.com/ceph/ceph-nvmeof/actions/workflows/build-container.yml)
 # Ceph NVMe over Fabrics (NVMe-oF) Gateway
 
 This project provides block storage on top of Ceph for platforms (e.g.: VMWare) without

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -10,7 +10,7 @@
 [gateway]
 name =
 group =
-addr = 192.168.13.3
+addr = 0.0.0.0
 port = 5500
 enable_auth = False
 state_update_notify = True

--- a/mk/containerized.mk
+++ b/mk/containerized.mk
@@ -6,7 +6,6 @@ DOCKER_COMPOSE = docker-compose ## Docker-compose command
 DOCKER_COMPOSE_COMMANDS = pull build push up run exec ps top images logs port \
 	pause unpause stop restart down events
 
-SVC ?= ## Docker-compose services
 OPTS ?= ## Docker-compose subcommand options
 SCALE ?= 1 ## Number of instances
 CMD ?= ## Command to run with run/exec targets
@@ -22,10 +21,7 @@ build: DOCKER_COMPOSE_ENV = DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1
 
 push: ## Push SVC container images to a registry. Requires previous "docker login"
 
-up: ## Launch services
-
 run: ## Run command CMD inside SVC containers
-run: SVC ?=
 run: override OPTS += --rm
 run: DOCKER_COMPOSE_ENV = DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1
 
@@ -43,7 +39,7 @@ port: ## Print public port for a port binding
 
 logs: ## View SVC logs
 logs: MAX_LOGS = 40
-logs: OPTS += --follow --tail=$(MAX_LOGS)
+logs: OPTS ?= --follow --tail=$(MAX_LOGS)
 
 images: ## List images
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,6 +2,18 @@
 # It is not intended for manual editing.
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+summary = "Cross-platform colored terminal text."
+
+[[package]]
+name = "exceptiongroup"
+version = "1.1.2"
+requires_python = ">=3.7"
+summary = "Backport of PEP 654 (exception groups)"
+
+[[package]]
 name = "grpcio"
 version = "1.53.2"
 requires_python = ">=3.7"
@@ -19,10 +31,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+requires_python = ">=3.7"
+summary = "brain-dead simple config-ini parsing"
+
+[[package]]
+name = "packaging"
+version = "23.1"
+requires_python = ">=3.7"
+summary = "Core utilities for Python packages"
+
+[[package]]
+name = "pluggy"
+version = "1.2.0"
+requires_python = ">=3.7"
+summary = "plugin and hook calling mechanisms for python"
+
+[[package]]
 name = "protobuf"
 version = "4.22.3"
 requires_python = ">=3.7"
 summary = ""
+
+[[package]]
+name = "pytest"
+version = "7.4.0"
+requires_python = ">=3.7"
+summary = "pytest: simple powerful testing with Python"
+dependencies = [
+    "colorama; sys_platform == \"win32\"",
+    "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
+    "iniconfig",
+    "packaging",
+    "pluggy<2.0,>=0.12",
+    "tomli>=1.0.0; python_version < \"3.11\"",
+]
 
 [[package]]
 name = "setuptools"
@@ -30,13 +74,25 @@ version = "67.6.1"
 requires_python = ">=3.7"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
 
+[[package]]
+name = "tomli"
+version = "2.0.1"
+requires_python = ">=3.7"
+summary = "A lil' TOML parser"
+
 [metadata]
 lock_version = "4.2"
 cross_platform = true
 groups = ["default"]
-content_hash = "sha256:621a30cdcd83d4ee3e9a41f67156e18c6a20f4c322799ac51961f3d8902736aa"
+content_hash = "sha256:f5e6ece46234e1754af42cc4483ac0ecbc8c695cadfd60c8f961e69d308760cb"
 
 [metadata.files]
+"colorama 0.4.6" = [
+    {url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+]
+"exceptiongroup 1.1.2" = [
+    {url = "https://files.pythonhosted.org/packages/fe/17/f43b7c9ccf399d72038042ee72785c305f6c6fdc6231942f8ab99d995742/exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
+]
 "grpcio 1.53.2" = [
     {url = "https://files.pythonhosted.org/packages/05/71/fd97d7aca7b3d476de623073f89598ba06213340fe816efe0383b248061f/grpcio-1.53.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d9c51ca201326b49cfee38336c6e7dd1cb8a6b6d0dcf84aeaecbae310a736dbc"},
     {url = "https://files.pythonhosted.org/packages/0e/84/5dee051586b07acd0384550c7b67842900bcba97295d58ecde23df49c2db/grpcio-1.53.2-cp38-cp38-win_amd64.whl", hash = "sha256:b676c4365a5753bc8c49f922a5f88bdb5df6746c670a9d859d2ba2f5f97d9269"},
@@ -129,6 +185,15 @@ content_hash = "sha256:621a30cdcd83d4ee3e9a41f67156e18c6a20f4c322799ac51961f3d89
     {url = "https://files.pythonhosted.org/packages/ee/26/18c09bd2a4ba37d602fed3c6369009e8099bf1172ed3f6e0f6bb45eda2b2/grpcio_tools-1.53.2-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:fa58925e12c82e86a9206533cc19d92df888f5878e07e08c56dca31c894d88a4"},
     {url = "https://files.pythonhosted.org/packages/f8/86/b45101e24e5cce9259d73ce2994dc33886a64e71735976e4707f9e1ef6c7/grpcio_tools-1.53.2-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:c0055ba3408f48b6d930b51cf565a072c7bdb7cacee32ef07c8997ae82f33f0e"},
 ]
+"iniconfig 2.0.0" = [
+    {url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+]
+"packaging 23.1" = [
+    {url = "https://files.pythonhosted.org/packages/ab/c3/57f0601a2d4fe15de7a553c00adbc901425661bf048f2a22dfc500caf121/packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+]
+"pluggy 1.2.0" = [
+    {url = "https://files.pythonhosted.org/packages/51/32/4a79112b8b87b21450b066e102d6608907f4c885ed7b04c3fdb085d4d6ae/pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
+]
 "protobuf 4.22.3" = [
     {url = "https://files.pythonhosted.org/packages/25/ca/79af03ceec0f9439d8fb5c2c8d99454c5c4f8c7fe00c8e7dbb280a8177c8/protobuf-4.22.3-cp38-cp38-win_amd64.whl", hash = "sha256:f2f4710543abec186aee332d6852ef5ae7ce2e9e807a3da570f36de5a732d88e"},
     {url = "https://files.pythonhosted.org/packages/2f/db/42950497852aa35940a33e29118d8a2117fb20072bee08728f0948b70d7a/protobuf-4.22.3-cp38-cp38-win32.whl", hash = "sha256:f08aa300b67f1c012100d8eb62d47129e53d1150f4469fd78a29fa3cb68c66f2"},
@@ -143,6 +208,12 @@ content_hash = "sha256:621a30cdcd83d4ee3e9a41f67156e18c6a20f4c322799ac51961f3d89
     {url = "https://files.pythonhosted.org/packages/f4/fd/d8d309382c71c5e83a1920ae9840410396e595e3b36229d96e3ba755687e/protobuf-4.22.3-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:13233ee2b9d3bd9a5f216c1fa2c321cd564b93d8f2e4f521a85b585447747997"},
     {url = "https://files.pythonhosted.org/packages/f8/70/6291e75633eeaa24fed46c9f66091bec184644e6159f392ac32eb92b1f65/protobuf-4.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:e0e630d8e6a79f48c557cd1835865b593d0547dce221c66ed1b827de59c66c97"},
 ]
+"pytest 7.4.0" = [
+    {url = "https://files.pythonhosted.org/packages/33/b2/741130cbcf2bbfa852ed95a60dc311c9e232c7ed25bac3d9b8880a8df4ae/pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+]
 "setuptools 67.6.1" = [
     {url = "https://files.pythonhosted.org/packages/0b/fc/8781442def77b0aa22f63f266d4dadd486ebc0c5371d6290caf4320da4b7/setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
+]
+"tomli 2.0.1" = [
+    {url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,9 @@ maintainers = []
 keywords = []
 classifiers = [] # https://pypi.org/classifiers/
 dependencies = [
-  "grpcio ~= 1.53.0",
-  "grpcio_tools ~= 1.53.0"
+    "grpcio ~= 1.53.0",
+    "grpcio_tools ~= 1.53.0",
+    "pytest>=7.4.0",
 ]
 
 [tool.pdm.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
 import pytest
+from control.server import GatewayServer
 import socket
 from control.cli import main as cli
 
-image = "iscsidevimage"
+image = "mytestdevimage"
 pool = "rbd"
 bdev = "Ceph0"
 subsystem = "nqn.2016-06.io.spdk:cnode1"
@@ -12,57 +13,72 @@ nsid = "1"
 trtype = "TCP"
 gateway_name = socket.gethostname()
 addr = "127.0.0.1"
-listener = ["-g", gateway_name, "-a", addr, "-s", "5001"]
+listener_list = [["-g", gateway_name, "-a", addr, "-s", "5001"], ["-g", gateway_name, "-a", addr,"-s", "5002"]]
 config = "ceph-nvmeof.conf"
 
+@pytest.fixture(scope="module")
+def gateway(config):
+    """Sets up and tears down Gateway"""
+
+    # Start gateway
+    gateway = GatewayServer(config)
+    gateway.serve()
+
+    yield
+
+    # Stop gateway
+    gateway.server.stop(grace=1)
+    gateway.gateway_rpc.gateway_state.delete_state()
 
 class TestGet:
-    def test_get_subsystems(self, caplog):
-        cli(["-c", config, "get_subsystems"])
+    def test_get_subsystems(self, caplog, gateway):
+        cli(["--server-address", "localhost", "get_subsystems"])
         assert "Failed to get" not in caplog.text
 
 
 class TestCreate:
-    def test_create_bdev(self, caplog):
-        cli(["-c", config, "create_bdev", "-i", image, "-p", pool, "-b", bdev])
+    def test_create_bdev(self, caplog, gateway):
+        cli(["--server-address", "localhost", "create_bdev", "-i", image, "-p", pool, "-b", bdev])
         assert "Failed to create" not in caplog.text
 
-    def test_create_subsystem(self, caplog):
-        cli(["-c", config, "create_subsystem", "-n", subsystem, "-s", serial])
+    def test_create_subsystem(self, caplog, gateway):
+        cli(["--server-address", "localhost", "create_subsystem", "-n", subsystem, "-s", serial])
         assert "Failed to create" not in caplog.text
 
-    def test_add_namespace(self, caplog):
-        cli(["-c", config, "add_namespace", "-n", subsystem, "-b", bdev])
+    def test_add_namespace(self, caplog, gateway):
+        cli(["--server-address", "localhost", "add_namespace", "-n", subsystem, "-b", bdev])
         assert "Failed to add" not in caplog.text
 
     @pytest.mark.parametrize("host", host_list)
     def test_add_host(self, caplog, host):
-        cli(["-c", config, "add_host", "-n", subsystem, "-t", host])
+        cli(["--server-address", "localhost", "add_host", "-n", subsystem, "-t", host])
         assert "Failed to add" not in caplog.text
 
-    def test_create_listener(self, caplog):
-        cli(["-c", config, "create_listener", "-n", subsystem] + listener)
+    @pytest.mark.parametrize("listener", listener_list)
+    def test_create_listener(self, caplog, listener, gateway):
+        cli(["--server-address", "localhost", "create_listener", "-n", subsystem] + listener)
         assert "Failed to create" not in caplog.text
 
 
 class TestDelete:
     @pytest.mark.parametrize("host", host_list)
-    def test_remove_host(self, caplog, host):
-        cli(["-c", config, "remove_host", "-n", subsystem, "-t", host])
+    def test_remove_host(self, caplog, host, gateway):
+        cli(["--server-address", "localhost", "remove_host", "-n", subsystem, "-t", host])
         assert "Failed to remove" not in caplog.text
 
-    def test_delete_listener(self, caplog):
-        cli(["-c", config, "delete_listener", "-n", subsystem] + listener)
+    @pytest.mark.parametrize("listener", listener_list)
+    def test_delete_listener(self, caplog, listener, gateway):
+        cli(["--server-address", "localhost", "delete_listener", "-n", subsystem] + listener)
         assert "Failed to delete" not in caplog.text
 
-    def test_remove_namespace(self, caplog):
-        cli(["-c", config, "remove_namespace", "-n", subsystem, "-i", nsid])
+    def test_remove_namespace(self, caplog, gateway):
+        cli(["--server-address", "localhost", "remove_namespace", "-n", subsystem, "-i", nsid])
         assert "Failed to remove" not in caplog.text
 
-    def test_delete_bdev(self, caplog):
-        cli(["-c", config, "delete_bdev", "-b", bdev])
+    def test_delete_bdev(self, caplog, gateway):
+        cli(["--server-address", "localhost", "delete_bdev", "-b", bdev])
         assert "Failed to delete" not in caplog.text
 
-    def test_delete_subsystem(self, caplog):
-        cli(["-c", config, "delete_subsystem", "-n", subsystem])
+    def test_delete_subsystem(self, caplog, gateway):
+        cli(["--server-address", "localhost", "delete_subsystem", "-n", subsystem])
         assert "Failed to delete" not in caplog.text

--- a/tests/test_multi_gateway.py
+++ b/tests/test_multi_gateway.py
@@ -4,8 +4,8 @@ import grpc
 import json
 import time
 from control.server import GatewayServer
-from control.generated import gateway_pb2 as pb2
-from control.generated import gateway_pb2_grpc as pb2_grpc
+from proto import gateway_pb2 as pb2
+from proto import gateway_pb2_grpc as pb2_grpc
 
 update_notify = True
 update_interval_sec = 5
@@ -50,7 +50,6 @@ def conn(config):
     gatewayA.server.stop(grace=1)
     gatewayB.server.stop(grace=1)
     gatewayB.gateway_rpc.gateway_state.delete_state()
-
 
 def test_multi_gateway_coordination(config, image, conn):
     """Tests state coordination in a gateway group.


### PR DESCRIPTION
## CI workflow for existing pytest tests

The idea is to incorporate the current pytest suite into the GitHub CI workflow, ensuring the continuous validation of both the evolving codebase and the tests themselves, which have [tendency to rot](https://en.wikipedia.org/wiki/Software_rot) if not used. 

extracted from:

- PR #134 
- Code: https://github.com/baum/ceph-nvmeof/tree/build-container-ci

### Multi-job workflow
A single workflow with a common build images job, using GitHub artifacts to share the container images between the jobs.

```mermaid
graph LR
    B(build) -->D[demo]
    B -->P[pytest matrix]
    P-->C(cli)
    P-->S(state)
    P-->M(multi gateway)
```
