### PR TITLE
control/state: add name to rados.Rados object initialization

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -19,6 +19,7 @@ state_update_interval_sec = 5
 [ceph]
 pool = rbd
 config_file = /etc/ceph/ceph.conf
+id =
 
 [mtls]
 server_key = ./server.key

--- a/control/state.py
+++ b/control/state.py
@@ -172,9 +172,10 @@ class OmapGatewayState(GatewayState):
         self.omap_name = f"nvmeof.{gateway_group}.state" if gateway_group else "nvmeof.state"
         ceph_pool = self.config.get("ceph", "pool")
         ceph_conf = self.config.get("ceph", "config_file")
+        rados_id = self.config.get_with_default("ceph", "id", "")
 
         try:
-            conn = rados.Rados(conffile=ceph_conf)
+            conn = rados.Rados(conffile=ceph_conf, rados_id=rados_id)
             conn.connect()
             self.ioctx = conn.open_ioctx(ceph_pool)
             # Create a new gateway persistence OMAP object


### PR DESCRIPTION
If we want to use a keyring that isn't the client.admin keyring, we need to provide the name. The rados.Rados object defaults the name to client.admin, and if that doesn't match the provided keyring you end up hitting an error like
```
ERROR:control.state:Unable to create omap: [errno 13] RADOS permission denied (error connecting to the cluster). Exiting! INFO:control.server:Terminating SPDK...
INFO:control.server:Exiting the gateway process.
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/src/control/__main__.py", line 35, in <module>
    gateway.serve()
  File "/src/control/server.py", line 99, in serve
    omap_state = OmapGatewayState(self.config)
  File "/src/control/state.py", line 178, in __init__
    conn.connect()
  File "rados.pyx", line 680, in rados.Rados.connect
rados.PermissionDeniedError: [errno 13] RADOS permission denied (error connecting to the cluster)
```
Setting the correct name gets around this and allows other keyrings with the correct name and permissions to be used