### PR TITLE
build: create stand-alone packages

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build container images
         run: make build
 
+      - name: Build stand-alone packages (RPMs and Python wheel)
+        run: make export-rpms export-python EXPORT_DIR=$(mktemp -d)
+
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -22,10 +22,22 @@ jobs:
           submodules: recursive
 
       - name: Build container images
-        run: make build
+        run: make build SVC="spdk nvmeof nvmeof-cli ceph"
 
       - name: Build stand-alone packages (RPMs and Python wheel)
-        run: make export-rpms export-python EXPORT_DIR=$(mktemp -d)
+        id: build-standalone-packages
+        run: |
+          export EXPORT_DIR=$(mktemp -d)
+          make export-rpms
+          make export-python
+          echo "EXPORT_DIR=$EXPORT_DIR" >> "$GITHUB_ENV"
+        
+      - name: Upload stand-alone packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: ceph_nvmeof-${{ github.run_number }}
+          path: |
+            ${{ env.EXPORT_DIR }}/**
 
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,8 @@ ARG PDM_VERSION=2.7.4 \
     PDM_INSTALL_FLAGS="-v --no-isolation --no-self --no-editable"
 ENV PDM_INSTALL_FLAGS=$PDM_INSTALL_FLAGS
 
+ENV PDM_CHECK_UPDATE=0
+
 # https://pdm.fming.dev/latest/usage/advanced/#use-pdm-in-a-multi-stage-dockerfile
 RUN \
     --mount=type=cache,target=/var/cache/dnf \

--- a/Dockerfile.spdk
+++ b/Dockerfile.spdk
@@ -51,6 +51,10 @@ RUN \
     rpmbuild/rpm.sh $SPDK_CONFIGURE_ARGS
 
 #------------------------------------------------------------------------------
+FROM registry.access.redhat.com/ubi9/ubi AS rpm-export
+COPY --from=build /root/rpmbuild/rpm /rpm
+
+#------------------------------------------------------------------------------
 FROM registry.access.redhat.com/ubi9/ubi
 
 ARG SPDK_CEPH_VERSION \

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ export-rpms: run ## Build SPDK RPMs and copy them to $(EXPORT_DIR)/rpm
 	@echo RPMs exported to:
 	@find $(strip $(EXPORT_DIR))/rpm -type f
 
-export-python: SVC=nvmeof-builder
+export-python: SVC=nvmeof-python-export
 export-python: OPTS=--entrypoint=pdm -v $(strip $(EXPORT_DIR)):/tmp
-export-python: CMD=build --no-sdist -d /tmp
+export-python: CMD=build --no-sdist --no-clean -d /tmp
 export-python: run ## Build Ceph NVMe-oF Gateway Python package and copy it to /tmp
 	@echo Python wheel exported to:
 	@find $(EXPORT_DIR) -name "ceph_nvmeof-*.whl" -type f

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,25 @@ up: override OPTS += --no-build --remove-orphans --scale nvmeof=$(SCALE)
 clean: override HUGEPAGES = 0
 clean: $(CLEAN) setup  ## Clean-up environment
 
-update-lockfile: SVC=nvmeof-builder
+update-lockfile: SVC=nvmeof-builder-base
 update-lockfile: override OPTS+=--entrypoint=pdm
 update-lockfile: CMD=update --no-sync --no-isolation --no-self --no-editable
 update-lockfile: pyproject.toml run ## Update dependencies in lockfile (pdm.lock)
+
+EXPORT_DIR ?= /tmp ## Directory to export packages (RPM and Python wheel)
+export-rpms: SVC=spdk-rpm-export
+export-rpms: OPTS=--entrypoint=cp -v $(strip $(EXPORT_DIR)):/tmp
+export-rpms: CMD=-r /rpm /tmp
+export-rpms: run ## Build SPDK RPMs and copy them to $(EXPORT_DIR)/rpm
+	@echo RPMs exported to:
+	@find $(strip $(EXPORT_DIR))/rpm -type f
+
+export-python: SVC=nvmeof-builder
+export-python: OPTS=--entrypoint=pdm -v $(strip $(EXPORT_DIR)):/tmp
+export-python: CMD=build --no-sdist -d /tmp
+export-python: run ## Build Ceph NVMe-oF Gateway Python package and copy it to /tmp
+	@echo Python wheel exported to:
+	@find $(EXPORT_DIR) -name "ceph_nvmeof-*.whl" -type f
 
 help: AUTOHELP_SUMMARY = Makefile to build and deploy the Ceph NVMe-oF Gateway
 help: autohelp

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ sudo sed -i -E 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 
 ### Building
 
+#### Containers
+
 To avoid having to deal with `docker-compose` commands, this provides a `Makefile` that wraps those as regular `make` targets:
 
 To build the container images from the local sources:
@@ -336,6 +338,20 @@ For building a specific service:
 
 ```bash
 make build SVC=nvmeof
+```
+
+#### Stand-alone Packages
+
+To generate independent RPM and Python wheel packages:
+
+```bash
+make export-rpms export-python
+RPMs exported to:
+/tmp/rpm/x86_64/spdk-libs-23.01-0.x86_64.rpm
+/tmp/rpm/x86_64/spdk-devel-23.01-0.x86_64.rpm
+/tmp/rpm/x86_64/spdk-23.01-0.x86_64.rpm
+Python wheel exported to:
+/tmp/ceph_nvmeof-0.0.1-py3-none-any.whl
 ```
 
 ### Development containers
@@ -374,11 +390,14 @@ Targets:
 
   Basic targets:
       clean           Clean-up environment
+      export-python   Build Ceph NVMe-oF Gateway Python package and copy it to /tmp
+      export-rpms     Build SPDK RPMs and copy them to $(EXPORT_DIR)/rpm
       setup           Configure huge-pages (requires sudo/root password)
       up              Services
       update-lockfile Update dependencies in lockfile (pdm.lock)
 
     Options:
+      EXPORT_DIR      Directory to export packages (RPM and Python wheel) (Default: /tmp)
       up: SVC         Services (Default: nvmeof)
 
   Deployment commands (docker-compose):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,12 @@ services:
         SPDK_GIT_COMMIT:
       labels:
         io.ceph.nvmeof:
+  # Used to export RPM packages externally (via bind mount)
+  spdk-rpm-export:
+    extends:
+      service: spdk
+    build:
+      target: rpm-export
   ceph:
     image: quay.io/ceph/vstart-cluster:$CEPH_CLUSTER_VERSION
     container_name: ceph
@@ -99,14 +105,24 @@ services:
     depends_on:
       ceph:
         condition: service_healthy
+  # Used to update lockfile (make update-lockfile)
+  nvmeof-builder-base:
+    extends:
+      service: nvmeof-base
+    image: nvmeof-builder-base
+    build:
+      target: builder-base
+    volumes:
+      - .:/src
+  # Used to export Python package
   nvmeof-builder:
     extends:
       service: nvmeof-base
     image: nvmeof-builder
     build:
-      target: builder-base
-    volumes:
-      - .:/src
+      target: builder
+      args:
+        NVMEOF_TARGET: cli
   nvmeof-devel:
     # Runs from source code in current dir
     extends:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
   spdk-rpm-export:
     extends:
       service: spdk
+    image: spdk-rpm-export
     build:
       target: rpm-export
   ceph:
@@ -115,10 +116,10 @@ services:
     volumes:
       - .:/src
   # Used to export Python package
-  nvmeof-builder:
+  nvmeof-python-export:
     extends:
       service: nvmeof-base
-    image: nvmeof-builder
+    image: nvmeof-python-export
     build:
       target: builder
       args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "ceph-nvmeof"
-dynamic = ["version"]
+version = "0.0.1"
 description = "Service to provide Ceph storage over NVMe-oF protocol"
 readme = "README.md"
 requires-python = "~=3.9"


### PR DESCRIPTION
## Usage

### RPM packages (SPDK)

```sh
> make export-rpms
RPMs exported to:
/tmp/rpm/x86_64/spdk-libs-23.01-0.x86_64.rpm
/tmp/rpm/x86_64/spdk-devel-23.01-0.x86_64.rpm
/tmp/rpm/x86_64/spdk-23.01-0.x86_64.rpm

```

### Python Wheel package (NVMe-oF Gateway and CLI)

```sh
make export-python
Python wheel exported to:
/tmp/ceph_nvmeof-0.0.1-py3-none-any.whl
``` 

Fixes: #168