### PR TITLE
🧹ci: pytests cleanups

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-
+env:
+  WAIT_INTERVAL_SECS: 1
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,10 +18,11 @@ jobs:
           submodules: recursive
 
       - name: Build container images
-        run: make build SVC="spdk bdevperf nvmeof nvmeof-cli ceph"
+        run: make build
 
       - name: Save container images
         run: |
+          docker save nvmeof-devel > nvmeof-devel.tar
           . .env
           docker save quay.io/ceph/nvmeof:$NVMEOF_VERSION > nvmeof.tar
           docker save quay.io/ceph/nvmeof-cli:$NVMEOF_VERSION > nvmeof-cli.tar
@@ -30,10 +32,11 @@ jobs:
       - name: Upload container images
         uses: actions/upload-artifact@v3
         with:
-          name: images
+          name: ceph_nvmeof_container_images-${{ github.run_number }}
           path: |
             nvmeof.tar
             nvmeof-cli.tar
+            nvmeof-devel.tar
             vstart-cluster.tar
             bdevperf.tar
 
@@ -48,7 +51,7 @@ jobs:
       - name: Upload stand-alone packages
         uses: actions/upload-artifact@v3
         with:
-          name: ceph_nvmeof-${{ github.run_number }}
+          name: ceph_nvmeof_standalone_packages-${{ github.run_number }}
           path: |
             ${{ env.EXPORT_DIR }}/**
 
@@ -72,11 +75,11 @@ jobs:
       - name: Download container images
         uses: actions/download-artifact@v3
         with:
-          name: images
+          name: ceph_nvmeof_container_images-${{ github.run_number }}
 
       - name: Load container images
         run: |
-          docker load < nvmeof.tar
+          docker load < nvmeof-devel.tar
           docker load < vstart-cluster.tar
 
       - name: Start ceph cluster
@@ -84,18 +87,19 @@ jobs:
           make up SVC=ceph OPTS="--detach"
 
       - name: Wait for the ceph cluster container to become healthy
+        timeout-minutes: 3
         run: |
           while true; do
             container_status=$(docker inspect --format='{{.State.Health.Status}}' ceph)
             if [[ $container_status == "healthy" ]]; then
-            break
-          else
-            # Wait for a specific time before checking again
-            sleep 1
-            echo -n .
-          fi
+              # success
+              exit 0
+            else
+              # Wait for a specific time before checking again
+              sleep ${{ env.WAIT_INTERVAL_SECS }}
+              echo -n .
+            fi
           done
-          echo
 
       - name: Create RBD image
         run: |
@@ -110,17 +114,32 @@ jobs:
         run: |
           # Run tests code in current dir
           # Managing pytest’s output: https://docs.pytest.org/en/7.1.x/how-to/output.html
-          make run SVC="nvmeof-devel" OPTS="--volume=$(pwd)/tests:/src/tests --entrypoint=python3" CMD="-m pytest --full-trace -vv -ra -s tests/test_${{ matrix.test }}.py"
+          make run SVC="nvmeof-devel" OPTS="--volume=$(pwd)/tests:/src/tests --entrypoint=python3" CMD="-m pytest --show-capture=all -s --full-trace -vv -rA tests/test_${{ matrix.test }}.py"
 
-      - name: Display Logs
+      - name: Check coredump existence
+        if: success() || failure()
+        id: check_coredumps
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2, pinned to SHA for security reasons
+        with:
+          files: "/var/lib/systemd/coredump/*"
+
+      - name: Upload ${{ matrix.test }} test core dumps
+        if: steps.check_coredumps.outputs.files_exists == 'true'
+        uses: actions/upload-artifact@v1
+        with:
+          name: ceph_nvmeof_pytest_${{ matrix.test }}_cores-${{ github.run_number }}
+          path: /var/lib/systemd/coredump/*
+
+      - name: Display logs
+        if: success() || failure()
         run: |
           make logs OPTS=""
 
-      - name: Compose Down
-        run: make down
-
-      - name: Compose Clean
-        run: make clean
+      - name: Tear down
+        if: success() || failure()
+        run: |
+          make down
+          make clean
 
   demo:
     needs: build
@@ -137,7 +156,7 @@ jobs:
       - name: Download container images
         uses: actions/download-artifact@v3
         with:
-          name: images
+          name: ceph_nvmeof_container_images-${{ github.run_number }}
 
       - name: Load container images
         run: |
@@ -148,28 +167,30 @@ jobs:
 
       - name: Start containers
         run: |
-          make up OPTS=--detach || (make logs OPTS=''; exit 1)
+          make up OPTS=--detach
 
       - name: Wait for the Gateway to be listening
-        timeout-minutes: 1
+        timeout-minutes: 3
         run: |
           . .env
-          echo using gateway $NVMEOF_IP_ADDRESS port $NVMEOF_GW_PORT
+
+          echo using gateway $NVMEOF_IP_ADDRESS port $NVMEOF_GW_PORT timeout ${{ env.WAIT_TIMEOUT_MINS }}
           until nc -z $NVMEOF_IP_ADDRESS $NVMEOF_GW_PORT; do
             echo -n .
-            sleep 1
+            sleep ${{ env.WAIT_INTERVAL_SECS }}
           done
-          echo
 
       - name: List containers
+        if: success() || failure()
         run: make ps
 
       - name: List processes
+        if: success() || failure()
         run: make top
 
       - name: Test
         run: |
-          make demo OPTS=-T || (make logs OPTS=''; exit 1)
+          make demo OPTS=-T
 
       - name: Get subsystems
         run: |
@@ -200,6 +221,20 @@ jobs:
           bdevperf="/usr/libexec/spdk/scripts/bdevperf.py"
           make exec SVC=bdevperf OPTS=-T CMD="$bdevperf -v -t $timeout -s $BDEVPERF_SOCKET perform_tests"
 
+      - name: Check coredump existence
+        if: success() || failure()
+        id: check_coredumps
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2, pinned to SHA for security reasons
+        with:
+            files: "/var/lib/systemd/coredump/*"
+
+      - name: Upload demo core dumps
+        if: steps.check_coredumps.outputs.files_exists == 'true'
+        uses: actions/upload-artifact@v1
+        with:
+          name: ceph_nvmeof_demo_cores-${{ github.run_number }}
+          path: /var/lib/systemd/coredump/*
+
       #- name: Test mounting nvmeof device locally
       #  run: |
       #    . .env
@@ -222,10 +257,11 @@ jobs:
       #    limit-access-to-actor: true
 
       - name: Display logs
+        if: success() || failure()
         run: make logs OPTS=''
 
-      - name: Shut containers down
-        run: make down
-
-      - name: Clean up environment
-        run: make clean
+      - name: Tear down
+        if: success() || failure()
+        run: |
+          make down
+          make clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,9 @@ WORKDIR $APPDIR
 FROM python-intermediate AS builder-base
 ARG PDM_VERSION=2.7.4 \
     PDM_INSTALL_CMD=sync \
-    PDM_INSTALL_FLAGS="-v --no-isolation --no-self --no-editable"
-ENV PDM_INSTALL_FLAGS=$PDM_INSTALL_FLAGS
+    PDM_INSTALL_FLAGS="-v --no-isolation --no-self --no-editable" \
+    PDM_INSTALL_DEV=""
+ENV PDM_INSTALL_FLAGS="$PDM_INSTALL_FLAGS $PDM_INSTALL_DEV"
 
 ENV PDM_CHECK_UPDATE=0
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ setup: ## Configure huge-pages (requires sudo/root password)
 	@echo Actual Hugepages allocation: $$(cat $(HUGEPAGES_DIR))
 	@[ $$(cat $(HUGEPAGES_DIR)) -eq $(HUGEPAGES) ]
 
-build push pull logs: SVC ?= spdk bdevperf nvmeof nvmeof-cli ceph
+build pull logs: SVC ?= spdk bdevperf nvmeof nvmeof-devel nvmeof-cli ceph
 
 build: export NVMEOF_GIT_BRANCH != git name-rev --name-only HEAD
 build: export NVMEOF_GIT_COMMIT != git rev-parse HEAD

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -147,13 +147,15 @@ services:
       args:
         NVMEOF_TARGET: cli
   nvmeof-devel:
+    image: nvmeof-devel
     # Runs from source code in current dir
     extends:
       service: nvmeof-base
-    image: quay.io/ceph/nvmeof:$NVMEOF_VERSION
-    depends_on:
-      ceph:
-        condition: service_healthy
+    build:
+      target: builder
+      args:
+        # https://daobook.github.io/pdm/usage/dependency/#add-development-only-dependencies
+        PDM_INSTALL_DEV: "-d"
     volumes:
       - ./control:/src/control
   nvmeof-cli:

--- a/mk/containerized.mk
+++ b/mk/containerized.mk
@@ -20,6 +20,7 @@ build:  ## Build SVC images
 build: DOCKER_COMPOSE_ENV = DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1
 
 push: ## Push SVC container images to a registry. Requires previous "docker login"
+push: SVC ?= nvmeof nvmeof-cli ceph
 
 run: ## Run command CMD inside SVC containers
 run: override OPTS += --rm

--- a/pdm.lock
+++ b/pdm.lock
@@ -83,8 +83,8 @@ summary = "A lil' TOML parser"
 [metadata]
 lock_version = "4.2"
 cross_platform = true
-groups = ["default"]
-content_hash = "sha256:f5e6ece46234e1754af42cc4483ac0ecbc8c695cadfd60c8f961e69d308760cb"
+groups = ["default", "dev", "test"]
+content_hash = "sha256:4778dd0d603dbe6e4958b9fbcfaada966a132a64bb5aab32941c648b1e86a7b6"
 
 [metadata.files]
 "colorama 0.4.6" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [] # https://pypi.org/classifiers/
 dependencies = [
     "grpcio ~= 1.53.0",
     "grpcio_tools ~= 1.53.0",
-    "pytest>=7.4.0",
 ]
 
 [tool.pdm.scripts]
@@ -36,6 +35,11 @@ log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+
+[tool.pdm.dev-dependencies]
+test = [
+    "pytest>=7.4.0",
+]
 
 [project.urls]
 #homepage = ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,53 +32,53 @@ def gateway(config):
 
 class TestGet:
     def test_get_subsystems(self, caplog, gateway):
-        cli(["--server-address", "localhost", "get_subsystems"])
+        cli(["get_subsystems"])
         assert "Failed to get" not in caplog.text
 
 
 class TestCreate:
     def test_create_bdev(self, caplog, gateway):
-        cli(["--server-address", "localhost", "create_bdev", "-i", image, "-p", pool, "-b", bdev])
+        cli(["create_bdev", "-i", image, "-p", pool, "-b", bdev])
         assert "Failed to create" not in caplog.text
 
     def test_create_subsystem(self, caplog, gateway):
-        cli(["--server-address", "localhost", "create_subsystem", "-n", subsystem, "-s", serial])
+        cli(["create_subsystem", "-n", subsystem, "-s", serial])
         assert "Failed to create" not in caplog.text
 
     def test_add_namespace(self, caplog, gateway):
-        cli(["--server-address", "localhost", "add_namespace", "-n", subsystem, "-b", bdev])
+        cli(["add_namespace", "-n", subsystem, "-b", bdev])
         assert "Failed to add" not in caplog.text
 
     @pytest.mark.parametrize("host", host_list)
     def test_add_host(self, caplog, host):
-        cli(["--server-address", "localhost", "add_host", "-n", subsystem, "-t", host])
+        cli(["add_host", "-n", subsystem, "-t", host])
         assert "Failed to add" not in caplog.text
 
     @pytest.mark.parametrize("listener", listener_list)
     def test_create_listener(self, caplog, listener, gateway):
-        cli(["--server-address", "localhost", "create_listener", "-n", subsystem] + listener)
+        cli(["create_listener", "-n", subsystem] + listener)
         assert "Failed to create" not in caplog.text
 
 
 class TestDelete:
     @pytest.mark.parametrize("host", host_list)
     def test_remove_host(self, caplog, host, gateway):
-        cli(["--server-address", "localhost", "remove_host", "-n", subsystem, "-t", host])
+        cli(["remove_host", "-n", subsystem, "-t", host])
         assert "Failed to remove" not in caplog.text
 
     @pytest.mark.parametrize("listener", listener_list)
     def test_delete_listener(self, caplog, listener, gateway):
-        cli(["--server-address", "localhost", "delete_listener", "-n", subsystem] + listener)
+        cli(["delete_listener", "-n", subsystem] + listener)
         assert "Failed to delete" not in caplog.text
 
     def test_remove_namespace(self, caplog, gateway):
-        cli(["--server-address", "localhost", "remove_namespace", "-n", subsystem, "-i", nsid])
+        cli(["remove_namespace", "-n", subsystem, "-i", nsid])
         assert "Failed to remove" not in caplog.text
 
     def test_delete_bdev(self, caplog, gateway):
-        cli(["--server-address", "localhost", "delete_bdev", "-b", bdev])
+        cli(["delete_bdev", "-b", bdev])
         assert "Failed to delete" not in caplog.text
 
     def test_delete_subsystem(self, caplog, gateway):
-        cli(["--server-address", "localhost", "delete_subsystem", "-n", subsystem])
+        cli(["delete_subsystem", "-n", subsystem])
         assert "Failed to delete" not in caplog.text


### PR DESCRIPTION
## 🧹 Pytests cleanups

- pytest as dev dependency, do not install in the target environment, nvmeof-devel promoted to be a real image/artifact, installs dev dependencies
- test cli cleanup, do not pass explicitly default values
- ci: artifacts by run number consistently, add potential test coredump archiving

Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>

## Previous discussions
- [here](https://github.com/ceph/ceph-nvmeof/pull/165#discussion_r1286934827)