### PR TITLE
push nvmeof images to quay on release/tag create

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,11 @@
 # Globals
-VERSION="0.0.3"
 CEPH_VERSION="17.2.6"
 SPDK_VERSION="23.01.1"
+CONTAINER_REGISTRY="quay.io/ceph"
+QUAY_SPDK="${CONTAINER_REGISTRY}/spdk"
+QUAY_CEPH="${CONTAINER_REGISTRY}/vstart-cluster"
+QUAY_NVMEOF="${CONTAINER_REGISTRY}/nvmeof"
+QUAY_NVMEOFCLI="${CONTAINER_REGISTRY}/nvmeof-cli"
 MAINTAINER="Ceph Developers <dev@ceph.io>"
 
 # Performance
@@ -10,7 +14,6 @@ HUGEPAGES=1024 # 2 GB
 HUGEPAGES_DIR="/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
 
 # NVMe-oF
-NVMEOF_VERSION="${VERSION}"
 NVMEOF_CONFIG="./ceph-nvmeof.conf"
 NVMEOF_SPDK_VERSION="${SPDK_VERSION}"
 NVMEOF_NAME="ceph-nvmeof"
@@ -28,7 +31,6 @@ NVMEOF_EXPOSE_SERVICES="${NVMEOF_IO_PORT}/tcp:nvme,${NVMEOF_GW_PORT}/tcp:grpc,${
 NVMEOF_GIT_REPO="https://github.com/ceph/ceph-nvmeof.git"
 
 # NVMe-oF CLI
-MVMEOF_CLI_VERSION="${VERSION}"
 NVMEOF_CLI_NAME="ceph-nvmeof-cli"
 NVMEOF_CLI_SUMMARY="Ceph NVMe over Fabrics CLI"
 NVMEOF_CLI_DESCRIPTION="Command line interface for Ceph NVMe over Fabrics Gateway"

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,10 +1,15 @@
 name: "CI"
 on:
   push:
+    branches:
+      - '*'
+    tags:
+      - 'v*'
   pull_request:
-#  schedule:
-#    - cron: '0 0 * * *'
   workflow_dispatch:
+  release:
+    types:
+      - created
 env:
   WAIT_INTERVAL_SECS: 1
 jobs:
@@ -14,6 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           # git submodule update --init --recursive
           submodules: recursive
 
@@ -22,12 +28,13 @@ jobs:
 
       - name: Save container images
         run: |
-          docker save nvmeof-devel > nvmeof-devel.tar
           . .env
-          docker save quay.io/ceph/nvmeof:$NVMEOF_VERSION > nvmeof.tar
-          docker save quay.io/ceph/nvmeof-cli:$NVMEOF_VERSION > nvmeof-cli.tar
-          docker save quay.io/ceph/vstart-cluster:$CEPH_VERSION  > vstart-cluster.tar
+          export NVMEOF_VERSION=$(git describe --tags --abbrev=0)
+          docker save $QUAY_NVMEOF:$NVMEOF_VERSION > nvmeof.tar
+          docker save $QUAY_NVMEOFCLI:$NVMEOF_VERSION > nvmeof-cli.tar
+          docker save $QUAY_CEPH:$CEPH_VERSION  > vstart-cluster.tar
           docker save bdevperf > bdevperf.tar
+          docker save nvmeof-devel > nvmeof-devel.tar
 
       - name: Upload container images
         uses: actions/upload-artifact@v3
@@ -47,7 +54,7 @@ jobs:
           make export-rpms
           make export-python
           echo "EXPORT_DIR=$EXPORT_DIR" >> "$GITHUB_ENV"
-        
+
       - name: Upload stand-alone packages
         uses: actions/upload-artifact@v3
         with:
@@ -67,6 +74,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup huge pages
         run: |
@@ -149,6 +158,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES
@@ -194,6 +205,7 @@ jobs:
 
       - name: Get subsystems
         run: |
+          export NVMEOF_VERSION=$(git describe --tags --abbrev=0)
           # https://github.com/actions/toolkit/issues/766
           shopt -s expand_aliases
           eval $(make alias)
@@ -265,3 +277,33 @@ jobs:
         run: |
           make down
           make clean
+
+  push-to-registry:
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+    needs: [pytest, demo]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Download container images
+        uses: actions/download-artifact@v3
+        with:
+          name: images
+
+      - name: Load container images
+        run: |
+          docker load < nvmeof.tar
+          docker load < nvmeof-cli.tar
+
+      - name: Login to quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.CONTAINER_REGISTRY }}
+          username: '${{ vars.CONTAINER_REGISTRY_USERNAME }}'
+          password: '${{ secrets.CONTAINER_REGISTRY_PASSWORD }}'
+
+      - name: Publish nvmeof containers when release/tag is created
+        run: |
+          make push
+

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ setup: ## Configure huge-pages (requires sudo/root password)
 	@[ $$(cat $(HUGEPAGES_DIR)) -eq $(HUGEPAGES) ]
 
 build pull logs: SVC ?= spdk bdevperf nvmeof nvmeof-devel nvmeof-cli ceph
-
+build up demo run logs push: export NVMEOF_VERSION != git describe --tags --abbrev=0
 build: export NVMEOF_GIT_BRANCH != git name-rev --name-only HEAD
 build: export NVMEOF_GIT_COMMIT != git rev-parse HEAD
 build: export SPDK_GIT_REPO != git -C spdk remote get-url origin

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Targets:
       port            Print public port for a port binding
       ps              Display status of SVC containers
       pull            Download SVC images
-      push            Push SVC container images to a registry. Requires previous "docker login"
+      push            Push nvmeof and nvmeof-cli containers images to quay.io registries
       restart         Restart SVC
       run             Run command CMD inside SVC containers
       shell           Exec shell inside running SVC containers

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   spdk:
-    image: quay.io/ceph/spdk:$SPDK_VERSION
+    image: $QUAY_SPDK:$SPDK_VERSION
     profiles:
       - build
     build:
@@ -52,7 +52,7 @@ services:
       nofile: $NVMEOF_NOFILE
       memlock: -1
   ceph:
-    image: quay.io/ceph/vstart-cluster:$CEPH_CLUSTER_VERSION
+    image: $QUAY_CEPH:$CEPH_CLUSTER_VERSION
     container_name: ceph
     build:
       context: .
@@ -122,7 +122,7 @@ services:
   nvmeof:
     extends:
       service: nvmeof-base
-    image: quay.io/ceph/nvmeof:$NVMEOF_VERSION
+    image: $QUAY_NVMEOF:$NVMEOF_VERSION
     depends_on:
       ceph:
         condition: service_healthy
@@ -159,7 +159,7 @@ services:
     volumes:
       - ./control:/src/control
   nvmeof-cli:
-    image: quay.io/ceph/nvmeof-cli:$NVMEOF_VERSION
+    image: $QUAY_NVMEOFCLI:$NVMEOF_VERSION
     build:
       context: .
       args:

--- a/mk/containerized.mk
+++ b/mk/containerized.mk
@@ -19,8 +19,9 @@ pull: ## Download SVC images
 build:  ## Build SVC images
 build: DOCKER_COMPOSE_ENV = DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1
 
-push: ## Push SVC container images to a registry. Requires previous "docker login"
-push: SVC ?= nvmeof nvmeof-cli ceph
+push: ## Push nvmeof and nvmeof-cli containers images to quay.io registries
+	docker push $(QUAY_NVMEOF):$(NVMEOF_VERSION)
+	docker push $(QUAY_NVMEOFCLI):$(NVMEOF_VERSION)
 
 run: ## Run command CMD inside SVC containers
 run: override OPTS += --rm


### PR DESCRIPTION
Related to [issue174](https://github.com/ceph/ceph-nvmeof/issues/174).

Providing a github action to push nvmeof and nvmeof-cli images to the quay.io registries (only) when creating new github releases or tags.

- github action workflow will run on any new commit (as before) and on a new release/tag add.
- I checked the push part through my quay.io registry, we need to make sure this repo quay login user/password secrets parameters have the correct values for the production registries.





