### PR TITLE
Add a persistent UUID in create_bdev.

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -48,7 +48,10 @@ class GatewayService(pb2_grpc.GatewayServicer):
     def create_bdev(self, request, context=None):
         """Creates a bdev from an RBD image."""
 
-        name = str(uuid.uuid4()) if not request.bdev_name else request.bdev_name
+        if not request.uuid:
+            request.uuid = str(uuid.uuid4())
+
+        name = request.uuid if not request.bdev_name else request.bdev_name
         self.logger.info(f"Received request to create bdev {name} from"
                          f" {request.rbd_pool_name}/{request.rbd_image_name}"
                          f" with block size {request.block_size}")
@@ -59,6 +62,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 pool_name=request.rbd_pool_name,
                 rbd_name=request.rbd_image_name,
                 block_size=request.block_size,
+                uuid=request.uuid,
             )
             self.logger.info(f"create_bdev: {bdev_name}")
         except Exception as ex:

--- a/proto/gateway.proto
+++ b/proto/gateway.proto
@@ -52,6 +52,7 @@ message create_bdev_req {
 	string rbd_pool_name = 2;
 	string rbd_image_name = 3;
 	int32 block_size = 4;
+	optional string uuid = 5;
 }
 
 message delete_bdev_req {


### PR DESCRIPTION
We want the generated UUID to be persistent. So, whenever the gateway restarts or in case we connect from two gateways the same UUID would be used. So, whenever a bdev is created we generate a UUID in case we don't have one already. This UUID is written to the OMAP file so in case we restore a connection we fetch the UUID value from the OMAP file and use it.