### PR TITLE
spdk exception handling

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          test: ["cli", "state", "multi_gateway"]
+          test: ["cli", "state", "multi_gateway", "server"]
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 512 # for multi gateway test, approx 256 per gateway instance

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -35,7 +35,6 @@ rpc_socket = /var/tmp/spdk.sock
 #tgt_cmd_extra_args = --env-context="--no-huge -m1024" --iova-mode=va
 timeout = 60.0
 log_level = WARN
-# conn_retries = 10
 
 # Example value: -m 0x3 -L all
 # tgt_cmd_extra_args =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dependencies = [
 [tool.pdm.scripts]
 protoc = {call = "grpc_tools.command:build_package_protos('proto')"}
 
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+
 [project.urls]
 #homepage = ""
 # documentation = ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,15 +20,15 @@ config = "ceph-nvmeof.conf"
 def gateway(config):
     """Sets up and tears down Gateway"""
 
-    # Start gateway
-    gateway = GatewayServer(config)
-    gateway.serve()
+    with GatewayServer(config) as gateway:
 
-    yield
+        # Start gateway
+        gateway.serve()
+        yield
 
-    # Stop gateway
-    gateway.server.stop(grace=1)
-    gateway.gateway_rpc.gateway_state.delete_state()
+        # Stop gateway
+        gateway.server.stop(grace=1)
+        gateway.gateway_rpc.gateway_state.delete_state()
 
 class TestGet:
     def test_get_subsystems(self, caplog, gateway):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,56 @@
+import copy
+import pytest
+import re
+import unittest
+from control.server import GatewayServer
+
+class TestServer(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def _config(self, config):
+        self.config = config
+
+    def validate_exception(self, e):
+        pattern = r'spdk subprocess terminated pid=(\d+) exit_code=(\d+)'
+        m = re.match(pattern, e.code)
+        assert(m)
+        pid = int(m.group(1))
+        code = int(m.group(2))
+        assert(pid > 0)
+        assert(code == 1)
+
+    def test_spdk_exception(self):
+        """Tests spdk sub process exiting with error."""
+        config_spdk_exception = copy.deepcopy(self.config)
+
+        # invalid arg, spdk would exit with code 1 at start up
+        config_spdk_exception.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x343435545"
+
+        with self.assertRaises(SystemExit) as cm:
+            with GatewayServer(config_spdk_exception) as gateway:
+                gateway.serve()
+        self.validate_exception(cm.exception)
+
+    def test_spdk_multi_gateway_exception(self):
+        """Tests spdk sub process exiting with error, in multi gateway configuration."""
+        configA = copy.deepcopy(self.config)
+        configA.config["gateway"]["name"] = "GatewayA"
+        configA.config["gateway"]["group"] = "Group1"
+
+        configB = copy.deepcopy(configA)
+        configB.config["gateway"]["name"] = "GatewayB"
+        configB.config["gateway"]["port"] = str(configA.getint("gateway", "port") + 1)
+        configB.config["spdk"]["rpc_socket"] = "/var/tmp/spdk_GatewayB.sock"
+        # invalid arg, spdk would exit with code 1 at start up
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x343435545"
+
+        with self.assertRaises(SystemExit) as cm:
+            with (
+                GatewayServer(configA) as gatewayA,
+                GatewayServer(configB) as gatewayB,
+             ):
+                gatewayA.serve()
+                gatewayB.serve()
+        self.validate_exception(cm.exception)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### spdk exception handling
The reason behind this change is to offer a dependable asynchronous notification of the termination of the spdk process. This will be achieved while collecting troubleshooting information and ensuring a graceful shutdown of the gateway process.
- pytests
  - using Python "with" GatewayServer
  - ini options
  - add spdk exception test
- extract _stop_spdk
- SIGCHLD signal handler
  - waitpid query of exit code
  - remove prctl code
  - terminate the process by raising SystemExit

### example
- [CI run](https://github.com/ceph/ceph-nvmeof/actions/runs/5819443618/job/15778322841):
```
------------------------------ Captured log setup ------------------------------
ERROR    control.server:server.py:220 Unable to initialize SPDK: 
 Timeout: file '/var/tmp/spdk.sock' not found after 60.0 seconds.
ERROR    control.server:server.py:165 SPDK return code: -4
ERROR    control.server:server.py:166 SPDK stdout:
 None
ERROR    control.server:server.py:167 SPDK stderr:
 None
```

### previous discussion

- [here](https://github.com/ceph/ceph-nvmeof/pull/176#discussion_r1293369972)