### PR TITLE
 Add controller id range to ceph-nvmeof.conf and pass to gateway

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -15,8 +15,8 @@ port = 5500
 enable_auth = False
 state_update_notify = True
 state_update_interval_sec = 5
-min_cntlid = 1
-max_cntlid = 65519
+#min_controller_id = 1
+#max_controller_id = 65519
 
 [ceph]
 pool = rbd

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -15,6 +15,8 @@ port = 5500
 enable_auth = False
 state_update_notify = True
 state_update_interval_sec = 5
+min_cntlid = 1
+max_cntlid = 65519
 
 [ceph]
 pool = rbd

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -118,12 +118,16 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
         self.logger.info(
             f"Received request to create subsystem {request.subsystem_nqn}")
+        min_cntlid = self.config.getint_with_default("gateway", "min_cntlid", 1)
+        max_cntlid = self.config.getint_with_default("gateway", "max_cntlid", 65519)
         try:
             ret = rpc_nvmf.nvmf_create_subsystem(
                 self.spdk_rpc_client,
                 nqn=request.subsystem_nqn,
                 serial_number=request.serial_number,
                 max_namespaces=request.max_namespaces,
+                min_cntlid=min_cntlid,
+                max_cntlid=max_cntlid,
             )
             self.logger.info(f"create_subsystem {request.subsystem_nqn}: {ret}")
         except Exception as ex:

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -118,8 +118,8 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
         self.logger.info(
             f"Received request to create subsystem {request.subsystem_nqn}")
-        min_cntlid = self.config.getint_with_default("gateway", "min_cntlid", 1)
-        max_cntlid = self.config.getint_with_default("gateway", "max_cntlid", 65519)
+        min_cntlid = self.config.getint_with_default("gateway", "min_controller_id", 1)
+        max_cntlid = self.config.getint_with_default("gateway", "max_controller_id", 65519)
         try:
             ret = rpc_nvmf.nvmf_create_subsystem(
                 self.spdk_rpc_client,


### PR DESCRIPTION
 Add controller id range to ceph-nvmeof.conf and pass to gateway. This allows using the partioning of controller id range between gateways, to be done later by Ceph-adm.

Related to issue #121 