### PR TITLE
Add spdk bdevperf build, container and ci test

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: Build container images
-        run: make build SVC="spdk nvmeof nvmeof-cli ceph"
+        run: make build SVC="spdk bdevperf nvmeof nvmeof-cli ceph"
 
       - name: Save container images
         run: |
@@ -25,6 +25,7 @@ jobs:
           docker save quay.io/ceph/nvmeof:$NVMEOF_VERSION > nvmeof.tar
           docker save quay.io/ceph/nvmeof-cli:$NVMEOF_VERSION > nvmeof-cli.tar
           docker save quay.io/ceph/vstart-cluster:$CEPH_VERSION  > vstart-cluster.tar
+          docker save bdevperf > bdevperf.tar
 
       - name: Upload container images
         uses: actions/upload-artifact@v3
@@ -34,6 +35,7 @@ jobs:
             nvmeof.tar
             nvmeof-cli.tar
             vstart-cluster.tar
+            bdevperf.tar
 
       - name: Build stand-alone packages (RPMs and Python wheel)
         id: build-standalone-packages
@@ -124,7 +126,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      HUGEPAGES: 256
+      HUGEPAGES: 512
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -142,6 +144,7 @@ jobs:
           docker load < nvmeof.tar
           docker load < nvmeof-cli.tar
           docker load < vstart-cluster.tar
+          docker load < bdevperf.tar
 
       - name: Start containers
         run: |
@@ -174,6 +177,28 @@ jobs:
           shopt -s expand_aliases
           eval $(make alias)
           nvmeof-cli get_subsystems
+
+      - name: Run bdevperf
+        run: |
+          # see https://spdk.io/doc/nvmf_multipath_howto.html
+          . .env
+          echo -n "ℹ️  Starting bdevperf container"
+          make up  SVC=bdevperf OPTS="--detach"
+          sleep 10
+          echo "ℹ️  bdevperf start up logs"
+          make logs SVC=bdevperf
+          eval $(make run SVC=bdevperf OPTS="--entrypoint=env" | grep BDEVPERF_SOCKET | tr -d '\n\r' )
+
+          rpc="/usr/libexec/spdk/scripts/rpc.py"
+          echo "ℹ️  bdevperf bdev_nvme_set_options"
+          make exec SVC=bdevperf OPTS=-T CMD="$rpc -v -s $BDEVPERF_SOCKET bdev_nvme_set_options -r -1"
+          echo "ℹ️  bdevperf tcp connect ip: $NVMEOF_IP_ADDRESS port: $NVMEOF_IO_PORT nqn: $NQN"
+          make exec SVC=bdevperf OPTS=-T CMD="$rpc -v -s $BDEVPERF_SOCKET bdev_nvme_attach_controller -b Nvme0 -t tcp -a $NVMEOF_IP_ADDRESS -s $NVMEOF_IO_PORT -f ipv4 -n $NQN -l -1 -o 10"
+          echo "ℹ️  bdevperf perform_tests"
+          eval $(make run SVC=bdevperf OPTS="--entrypoint=env" | grep BDEVPERF_TEST_DURATION | tr -d '\n\r' )
+          timeout=$(expr $BDEVPERF_TEST_DURATION \* 2)
+          bdevperf="/usr/libexec/spdk/scripts/bdevperf.py"
+          make exec SVC=bdevperf OPTS=-T CMD="$bdevperf -v -t $timeout -s $BDEVPERF_SOCKET perform_tests"
 
       #- name: Test mounting nvmeof device locally
       #  run: |

--- a/Dockerfile.spdk
+++ b/Dockerfile.spdk
@@ -50,12 +50,15 @@ RUN \
     MAKEFLAGS=$SPDK_MAKEFLAGS \
     rpmbuild/rpm.sh $SPDK_CONFIGURE_ARGS
 
+# build bdevperf example, will not be a part of generated rpm
+RUN make -C ./examples/bdev/bdevperf
+
 #------------------------------------------------------------------------------
 FROM registry.access.redhat.com/ubi9/ubi AS rpm-export
 COPY --from=build /root/rpmbuild/rpm /rpm
 
 #------------------------------------------------------------------------------
-FROM registry.access.redhat.com/ubi9/ubi
+FROM registry.access.redhat.com/ubi9/ubi as spdk
 
 ARG SPDK_CEPH_VERSION \
     SPDK_VERSION
@@ -116,3 +119,32 @@ RUN \
 
 ENTRYPOINT [ "/usr/local/bin/nvmf_tgt" ]
 CMD [ "-u", "-r", "/var/tmp/spdk.sock" ]
+
+#------------------------------------------------------------------------------
+FROM spdk AS bdevperf
+
+# Default test run duration in secs
+ENV BDEVPERF_TEST_DURATION="90"
+
+# RPC socket path
+ENV BDEVPERF_SOCKET="/tmp/bdevperf.sock"
+
+# IO Queue depth
+ENV BDEVPERF_IO_QUEUE="128"
+
+# IO Block size
+ENV BDEVPERF_IO_BS="4096"
+
+# Type of I/O pattern, see https://spdk.io/doc/bdevperf.html
+# for available types
+ENV BDEVPERF_IO_TYPE="verify"
+
+COPY --from=build /src/build/examples/bdevperf /usr/local/bin/bdevperf
+COPY --from=build /src/examples/bdev/bdevperf/bdevperf.py /usr/libexec/spdk/scripts/bdevperf.py
+RUN echo "#!/bin/sh -x"                                                 > /entrypoint
+RUN echo "bdevperf -z -r \$BDEVPERF_SOCKET \\"                         >> /entrypoint
+RUN echo "         -q \$BDEVPERF_IO_QUEUE -o \$BDEVPERF_IO_BS \\"      >> /entrypoint
+RUN echo "         -w \$BDEVPERF_IO_TYPE -t \$BDEVPERF_TEST_DURATION"  >> /entrypoint
+RUN chmod 755 /entrypoint
+
+ENTRYPOINT [ "/entrypoint" ]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ setup: ## Configure huge-pages (requires sudo/root password)
 	@echo Actual Hugepages allocation: $$(cat $(HUGEPAGES_DIR))
 	@[ $$(cat $(HUGEPAGES_DIR)) -eq $(HUGEPAGES) ]
 
-build push pull logs: SVC ?= spdk nvmeof nvmeof-cli ceph
+build push pull logs: SVC ?= spdk bdevperf nvmeof nvmeof-cli ceph
 
 build: export NVMEOF_GIT_BRANCH != git name-rev --name-only HEAD
 build: export NVMEOF_GIT_COMMIT != git rev-parse HEAD

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     build:
       context: spdk/
       dockerfile: ../Dockerfile.spdk
+      target: spdk
       args:
         SPDK_VERSION:
         SPDK_CEPH_VERSION:
@@ -31,6 +32,25 @@ services:
     image: spdk-rpm-export
     build:
       target: rpm-export
+  bdevperf:
+    extends:
+      service: spdk
+    image: bdevperf
+    build:
+      target: bdevperf
+    volumes:
+      # sudo bash -c 'echo 1024 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages'
+      # https://spdk.io/doc/containers.html
+      # TODO: Pending of https://github.com/spdk/spdk/issues/2973
+      - /dev/hugepages:/dev/hugepages
+      - /dev/vfio/vfio:/dev/vfio/vfio
+    cap_add:
+      - SYS_ADMIN # huge-pages
+      - CAP_SYS_NICE # RTE
+      - SYS_PTRACE # gdb
+    ulimits:
+      nofile: $NVMEOF_NOFILE
+      memlock: -1
   ceph:
     image: quay.io/ceph/vstart-cluster:$CEPH_CLUSTER_VERSION
     container_name: ceph


### PR DESCRIPTION
### Add spdk bdevperf build, container and ci test
## Docs
- https://spdk.io/doc/bdevperf.html
- https://spdk.io/doc/nvmf_multipath_howto.html

## Env variables exposed by the `bdevperf` container
```shell
# Default test run duration in secs
BDEVPERF_TEST_DURATION="90"

# RPC socket path
BDEVPERF_SOCKET="/tmp/bdevperf.sock"

# IO Queue depth
BDEVPERF_IO_QUEUE="128"

# IO Block size
BDEVPERF_IO_BS="4096"

# Type of I/O pattern, see https://spdk.io/doc/bdevperf.html
# for available types
BDEVPERF_IO_TYPE="verify"

```
## Sample test
```shell
 . .env
 echo -n "ℹ️  Starting bdevperf container"
 make up  SVC=bdevperf OPTS="--detach"
 sleep 10
 echo "ℹ️  bdevperf start up logs"
 make logs SVC=bdevperf
 eval $(make run SVC=bdevperf OPTS="--entrypoint=env" | grep BDEVPERF_SOCKET | tr -d '\n\r')
 rpc="/usr/libexec/spdk/scripts/rpc.py"
 echo "ℹ️  bdevperf bdev_nvme_set_options"
 make exec SVC=bdevperf OPTS=-T CMD="$rpc -v -s $BDEVPERF_SOCKET bdev_nvme_set_options -r -1"
 echo "ℹ️  bdevperf tcp connect ip: $NVMEOF_IP_ADDRESS port: $NVMEOF_IO_PORT nqn: $NQN"
 make exec SVC=bdevperf OPTS=-T CMD="$rpc -v -s $BDEVPERF_SOCKET bdev_nvme_attach_controller -b Nvme0 -t tcp -a $NVMEOF_IP_ADDRESS -s $NVMEOF_IO_PORT -f ipv4 -n $NQN -l -1 -o 10"
 echo "ℹ️  bdevperf perform_tests"
 eval $(make run SVC=bdevperf OPTS="--entrypoint=env" | grep BDEVPERF_TEST_DURATION | tr -d '\n\r')
 timeout=$(expr $BDEVPERF_TEST_DURATION \* 2)
 bdevperf="/usr/libexec/spdk/scripts/bdevperf.py"
 make exec SVC=bdevperf OPTS=-T CMD="$bdevperf -v -t $timeout -s $BDEVPERF_SOCKET perform_tests"
```
## Sample run
```log
[2023-08-17 17:30:01.713163] Starting SPDK v23.01.1 / DPDK 22.11.1 initialization...
[2023-08-17 17:30:01.713298] [ DPDK EAL parameters: bdevperf --no-shconf -c 0x1 --huge-unlink --log-level=lib.eal:6 --log-level=lib.cryptodev:5 --log-level=user1:6 --iova-mode=pa --base-virtaddr=0x200000000000 --match-allocations --file-prefix=spdk_pid1 ]
EAL: Cannot open VFIO container /dev/vfio/vfio, error 1 (Operation not permitted)
 EAL: VFIO support could not be initialized
TELEMETRY: No legacy callbacks, legacy socket not created
[2023-08-17 17:30:01.840264] app.c: 712:spdk_app_start: *NOTICE*: Total cores available: 1
[2023-08-17 17:30:01.974578] reactor.c: 926:reactor_run: *NOTICE*: Reactor started on core 0
[2023-08-17 17:30:02.045838] accel_sw.c: 681:sw_accel_module_init: *NOTICE*: Accel framework software module initialized.
Running I/O for 90 seconds...
 
                                                                                                 Latency(us)
 
Device Information          : runtime(s)       IOPS      MiB/s     Fail/s     TO/s    Average        min        max
 
Job: Nvme0n1 (Core Mask 0x1)
 	 Verification LBA range: start 0x0 length 0xa00
	 Nvme0n1             :      90.06    2133.91       8.34       0.00     0.00   59957.68    3340.06 1101207.23

 ===================================================================================================================
  Total                      :               2133.91       8.34       0.00     0.00   59957.68    3340.06 1101207.23
```
Signed-off-by: Alexander Indenbaum <aindenba@redhat.com>