### PR TITLE
Disable SPDK discovery controller on GW initialization

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -17,6 +17,7 @@ state_update_notify = True
 state_update_interval_sec = 5
 #min_controller_id = 1
 #max_controller_id = 65519
+enable_discovery_controller = false
 
 [ceph]
 pool = rbd

--- a/control/server.py
+++ b/control/server.py
@@ -113,6 +113,13 @@ class GatewayServer:
 
         # Start server
         self.server.start()
+        enable_discovery_controller = self.config.getboolean_with_default("gateway", "enable_discovery_controller", False)
+        if not enable_discovery_controller:
+            try:
+                rpc_nvmf.nvmf_delete_subsystem(self.spdk_rpc_ping_client, "nqn.2014-08.org.nvmexpress.discovery")
+            except Exception as ex:
+                self.logger.error(f"  Delete Discovery subsystem returned with error: \n {ex}")
+                raise
 
     def _add_server_listener(self):
         """Adds listener port to server."""


### PR DESCRIPTION
when Gateway is created it by default creates discovery subsystem
server.py when spdk is started, calls rpc nvmf_delete_subsystem.

Tests:

1.
The rpc was issued before applying the new GW configuration :
[root@rhel8-leo-dev ceph-nvmeof]# nvmeof-cli get_subsystems
INFO:__main__:Get subsystems:
[]                <= the discovery subsystem does not appear anymore

2.
]# nvme discover -t tcp -a 192.168.13.3 -s 4420
Failed to write to /dev/nvme-fabrics: Input/output error


The PR has no impact  on the current Gateway behavior. Checked also  IOs from the nvme-tcp initiator.