### PR TITLE
refactor(ci): Don't run build-container.yml on a schedule

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -2,8 +2,8 @@ name: "CI"
 on:
   push:
   pull_request:
-  schedule:
-    - cron: '0 0 * * *'
+#  schedule:
+#    - cron: '0 0 * * *'
   workflow_dispatch:
 env:
   WAIT_INTERVAL_SECS: 1


### PR DESCRIPTION
Commenting out `schedule` action to stop receiving run status reports. It looks like Github Actions designers decided that the committer that added the `schedule` line had to be [the one receiving the job run emails forever](https://github.com/orgs/community/discussions/25067), no matter they didn't make any further changes to that file.

Ideally, someone actively involved from the @ceph/nvmeof team should re-enable it (if deemed useful).