### PR TITLE
When deleting bdev also delete any namespace using it from OMAP.

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -175,10 +175,11 @@ class GatewayClient:
 
     @cli.cmd([
         argument("-b", "--bdev", help="Bdev name", required=True),
+        argument("-f", "--force", help="Delete any namespace using this bdev before deleting bdev", action='store_true', required=False),
     ])
     def delete_bdev(self, args):
         """Deletes a bdev."""
-        req = pb2.delete_bdev_req(bdev_name=args.bdev)
+        req = pb2.delete_bdev_req(bdev_name=args.bdev, force=args.force)
         ret = self.stub.delete_bdev(req)
         self.logger.info(f"Deleted bdev {args.bdev}: {ret.status}")
 

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -57,6 +57,7 @@ message create_bdev_req {
 
 message delete_bdev_req {
 	string bdev_name = 1;
+	bool force = 2;
 }
 
 message create_subsystem_req {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from control.cli import main as cli
 image = "mytestdevimage"
 pool = "rbd"
 bdev = "Ceph0"
+bdev1 = "Ceph1"
 subsystem = "nqn.2016-06.io.spdk:cnode1"
 serial = "SPDK00000000000001"
 host_list = ["nqn.2016-06.io.spdk:host1", "*"]
@@ -40,6 +41,8 @@ class TestCreate:
     def test_create_bdev(self, caplog, gateway):
         cli(["create_bdev", "-i", image, "-p", pool, "-b", bdev])
         assert "Failed to create" not in caplog.text
+        cli(["create_bdev", "-i", image, "-p", pool, "-b", bdev1])
+        assert "Failed to create" not in caplog.text
 
     def test_create_subsystem(self, caplog, gateway):
         cli(["create_subsystem", "-n", subsystem, "-s", serial])
@@ -47,6 +50,8 @@ class TestCreate:
 
     def test_add_namespace(self, caplog, gateway):
         cli(["add_namespace", "-n", subsystem, "-b", bdev])
+        assert "Failed to add" not in caplog.text
+        cli(["add_namespace", "-n", subsystem, "-b", bdev1])
         assert "Failed to add" not in caplog.text
 
     @pytest.mark.parametrize("host", host_list)
@@ -76,7 +81,9 @@ class TestDelete:
         assert "Failed to remove" not in caplog.text
 
     def test_delete_bdev(self, caplog, gateway):
-        cli(["delete_bdev", "-b", bdev])
+        cli(["delete_bdev", "-b", bdev, "-f"])
+        assert "Failed to delete" not in caplog.text
+        cli(["delete_bdev", "-b", bdev1, "--force"])
         assert "Failed to delete" not in caplog.text
 
     def test_delete_subsystem(self, caplog, gateway):


### PR DESCRIPTION
Fixes #145

The SPDK automatically delete any namespace using a bdev which is deleted. But there is no such mechanism for the OMAP file. So, we need the CLI to take care of that and whenever a bdev is deleted to also delete any namespace using it. The default behavior is to fail the delete_bdev command with EBUSY in case a namespace is still using it. The user should explicitly remove any such namespace. In case "--force" (or "-f") is used in the delete_bdev command line the namespaces would get deleted automatically.