### PR TITLE
Manage controller id ranges for gateways in the group in OMAP object

### DIFF
--- a/control/omap.py
+++ b/control/omap.py
@@ -9,17 +9,33 @@
 import logging
 import rados
 from typing import Dict
-from collections import defaultdict
 
 
 class OmapObject:
-    """Class representing versioned omap object"""
+    """Class representing a versioned OMAP object
+
+    Methods:
+        get(): Returns dict of all OMAP keys and values
+        delete(): Deletes OMAP object contents
+        add_key(): Adds key and value to the OMAP
+        remove_key(): Removes key from the OMAP
+        register_watch(): Sets a watch on the OMAP object for changes
+    """
     OMAP_VERSION_KEY = "omap_version"
 
+    """
+    Instance attributes:
+        name: OMAP object name
+        version: OMAP object version
+        cached_object: last read cache copy of the object
+        logger: Logger instance to track OMAP access events
+        ioctx: I/O context which allows OMAP access
+        watch: OMAP change notification
+    """
     def __init__(self, name, ioctx) -> None:
         self.version = 1
         self.watch = None
-        self.cached_object = defaultdict(dict)
+        self.cached = {}
         self.name = name
         self.logger = logging.getLogger(__name__)
         self.ioctx = ioctx
@@ -78,8 +94,8 @@ class OmapObject:
                 self.ioctx.operate_write_op(write_op, self.name)
             self.version = version_update
             self.logger.debug(f"omap_key generated: {key}")
-        except Exception as ex:
-            self.logger.error(f"Unable to add key to omap: {ex}. Exiting!")
+        except Exception:
+            self.logger.exception(f"Unable to add {key=} {val=} to omap:")
             raise
 
         self._notify()

--- a/control/omap.py
+++ b/control/omap.py
@@ -1,0 +1,134 @@
+#
+#  Copyright (c) 2021 International Business Machines
+#  All rights reserved.
+#
+#  SPDX-License-Identifier: LGPL-3.0-or-later
+#
+#  Authors: anita.shekar@ibm.com, sandy.kaur@ibm.com
+#
+import logging
+import rados
+from typing import Dict
+from collections import defaultdict
+
+
+class OmapObject:
+    """Class representing versioned omap object"""
+    OMAP_VERSION_KEY = "omap_version"
+
+    def __init__(self, name, ioctx) -> None:
+        self.version = 1
+        self.watch = None
+        self.cached_object = defaultdict(dict)
+        self.name = name
+        self.logger = logging.getLogger(__name__)
+        self.ioctx = ioctx
+        self.create()
+
+    def create(self) -> None:
+        """Create OMAP object if does not exist already"""
+        try:
+            # Create a new persistence OMAP object
+            with rados.WriteOpCtx() as write_op:
+                # Set exclusive parameter to fail write_op if object exists
+                write_op.new(rados.LIBRADOS_CREATE_EXCLUSIVE)
+                self.ioctx.set_omap(write_op, (self.OMAP_VERSION_KEY,),
+                                    (str(self.version),))
+                self.ioctx.operate_write_op(write_op, self.name)
+                self.logger.info(
+                    f"First gateway: created object {self.name}")
+        except rados.ObjectExists:
+            self.logger.info(f"{self.name} omap object already exists.")
+        except Exception:
+            self.logger.exception(f"Unable to create omap {self.name}:")
+            raise
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """Context destructor"""
+        if self.watch is not None:
+            self.watch.close()
+        self.ioctx.close()
+
+    def get(self) -> Dict[str, str]:
+        """Returns dict of all OMAP keys and values."""
+        with rados.ReadOpCtx() as read_op:
+            i, _ = self.ioctx.get_omap_vals(read_op, "", "", -1)
+            self.ioctx.operate_read_op(read_op, self.name)
+            omap_dict = dict(i)
+        return omap_dict
+
+    def _notify(self) -> None:
+        """ Notify other gateways within the group of change """
+        try:
+            self.ioctx.notify(self.name)
+        except Exception as ex:
+            self.logger.info(f"Failed to notify.")
+
+    def add_key(self, key: str, val: str) -> None:
+        """Adds key and value to the OMAP."""
+        try:
+            version_update = self.version + 1
+            with rados.WriteOpCtx() as write_op:
+                # Compare operation failure will cause write failure
+                write_op.omap_cmp(self.OMAP_VERSION_KEY, str(self.version),
+                                  rados.LIBRADOS_CMPXATTR_OP_EQ)
+                self.ioctx.set_omap(write_op, (key,), (val,))
+                self.ioctx.set_omap(write_op, (self.OMAP_VERSION_KEY,),
+                                    (str(version_update),))
+                self.ioctx.operate_write_op(write_op, self.name)
+            self.version = version_update
+            self.logger.debug(f"omap_key generated: {key}")
+        except Exception as ex:
+            self.logger.error(f"Unable to add key to omap: {ex}. Exiting!")
+            raise
+
+        self._notify()
+
+    def remove_key(self, key: str) -> None:
+        """Removes key from the OMAP."""
+        try:
+            version_update = self.version + 1
+            with rados.WriteOpCtx() as write_op:
+                # Compare operation failure will cause remove failure
+                write_op.omap_cmp(self.OMAP_VERSION_KEY, str(self.version),
+                                  rados.LIBRADOS_CMPXATTR_OP_EQ)
+                self.ioctx.remove_omap_keys(write_op, (key,))
+                self.ioctx.set_omap(write_op, (self.OMAP_VERSION_KEY,),
+                                    (str(version_update),))
+                self.ioctx.operate_write_op(write_op, self.name)
+            self.version = version_update
+            self.logger.debug(f"omap_key removed: {key}")
+        except Exception:
+            self.logger.exception(f"Unable to remove key from omap:")
+            raise
+
+        self._notify()
+
+    def delete(self) -> None:
+        """Deletes OMAP object contents."""
+        try:
+            with rados.WriteOpCtx() as write_op:
+                self.ioctx.clear_omap(write_op)
+                self.ioctx.operate_write_op(write_op, self.name)
+                self.ioctx.set_omap(write_op, (self.OMAP_VERSION_KEY,),
+                                    (str(1),))
+                self.ioctx.operate_write_op(write_op, self.name)
+                self.logger.info(f"Deleted OMAP {self.name} contents.")
+        except Exception:
+            self.logger.exception(f"Error deleting OMAP {self.name} contents:")
+            raise
+
+    def register_watch(self, notify_event) -> None:
+        """Sets a watch on the OMAP object for changes."""
+
+        def _watcher_callback(notify_id, notifier_id, watch_id, data):
+            notify_event.set()
+
+        if self.watch is None:
+            try:
+                self.watch = self.ioctx.watch(self.name, _watcher_callback)
+            except Exception:
+                self.logger.exception(f"Unable to initiate watch {self.name}:")
+                raise
+        else:
+            self.logger.info(f"Watch {self.name} already exists.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,8 @@ def gateway(config):
 
         # Stop gateway
         gateway.server.stop(grace=1)
-        gateway.gateway_rpc.gateway_state.omap.state.delete()
+        gateway.gateway_rpc.gateway_state.state.spdk.obj.delete()
+        gateway.gateway_rpc.gateway_state.state.ranges.obj.delete()
 
 class TestGet:
     def test_get_subsystems(self, caplog, gateway):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def gateway(config):
 
         # Stop gateway
         gateway.server.stop(grace=1)
-        gateway.gateway_rpc.gateway_state.delete_state()
+        gateway.gateway_rpc.gateway_state.omap.state.delete()
 
 class TestGet:
     def test_get_subsystems(self, caplog, gateway):

--- a/tests/test_multi_gateway.py
+++ b/tests/test_multi_gateway.py
@@ -40,7 +40,7 @@ def conn(config):
     ):
         gatewayA.serve()
         # Delete existing OMAP state
-        gatewayA.gateway_rpc.gateway_state.delete_state()
+        gatewayA.gateway_rpc.gateway_state.omap.state.delete()
         # Create new
         gatewayB.serve()
 
@@ -54,7 +54,7 @@ def conn(config):
         # Stop gateways
         gatewayA.server.stop(grace=1)
         gatewayB.server.stop(grace=1)
-        gatewayB.gateway_rpc.gateway_state.delete_state()
+        gatewayB.gateway_rpc.gateway_state.omap.state.delete()
 
 def test_multi_gateway_coordination(config, image, conn):
     """Tests state coordination in a gateway group.

--- a/tests/test_multi_gateway.py
+++ b/tests/test_multi_gateway.py
@@ -40,7 +40,7 @@ def conn(config):
     ):
         gatewayA.serve()
         # Delete existing OMAP state
-        gatewayA.gateway_rpc.gateway_state.omap.state.delete()
+        gatewayA.gateway_rpc.gateway_state.state.spdk.obj.delete()
         # Create new
         gatewayB.serve()
 
@@ -54,7 +54,7 @@ def conn(config):
         # Stop gateways
         gatewayA.server.stop(grace=1)
         gatewayB.server.stop(grace=1)
-        gatewayB.gateway_rpc.gateway_state.omap.state.delete()
+        gatewayB.gateway_rpc.gateway_state.state.spdk.obj.delete()
 
 def test_multi_gateway_coordination(config, image, conn):
     """Tests state coordination in a gateway group.

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -22,9 +22,9 @@ def ioctx(config: GatewayConfig):
 def omap_state(config: GatewayConfig):
     """Sets up and tears down OMAP state object."""
     omap = OmapGatewayState(config)
-    omap.state.delete()
+    omap.spdk.obj.delete()
     yield omap
-    omap.state.delete()
+    omap.spdk.obj.delete()
 
 
 def add_key(ioctx: rados.Ioctx, key: str, value: str, version: int, omap_name: str, omap_version_key: str):
@@ -80,7 +80,7 @@ def test_state_polling_update(config: GatewayConfig, ioctx: rados.Ioctx, omap_st
     state_handler.use_notify = False
     key = "bdev_test"
     state_handler.start_update()
-    omap_obj = omap_state.state
+    omap_obj = omap_state.spdk.obj
 
     # Add bdev key to OMAP and update version number
     version += 1
@@ -143,7 +143,7 @@ def test_state_notify_update(config: GatewayConfig, ioctx: rados.Ioctx, omap_sta
     state_handler.use_notify = True
     start = time.time()
     state_handler.start_update()
-    omap_obj = omap_state.state
+    omap_obj = omap_state.spdk.obj
 
     # Add bdev key to OMAP and update version number
     version += 1


### PR DESCRIPTION
## Manage controller id ranges for gateways in the group in OMAP object

Each controller ID within a gateway group must be unique. Currently, the responsibility for partitioning the ID space is delegated to orchestrators like `cephadm`, which then passes the assigned range to a gateway in the `ceph-nvmeof.conf` configuration. This proposed change introduces a cooperative algorithm for managing controller ID ranges among gateways through a shared OMAP object. This approach is designed to work seamlessly with any orchestrator when deploying multiple gateways. The length of the controller id range is specified in the gateways via the `ceph-nvmeof.conf` configuration file.

- Extract OmapObject, refactor state, remove localstate
- Controller id range in omap
- Gateways will fail when unable to store requests in the config state object.
   Resolve the issue of the gateway is not up to date with the latest changes in the config object,
   i.e. its local version is different from the config object version in Ceph
