### PR TITLE
Set default block size in create_bdev CLI to 512 instead of 4K.

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -160,7 +160,7 @@ class GatewayClient:
                  "--block-size",
                  help="Block size",
                  type=int,
-                 default=4096),
+                 default=512),
     ])
     def create_bdev(self, args):
         """Creates a bdev from an RBD image."""


### PR DESCRIPTION
Fixes #224