### PR TITLE
Add CLI that enables  NVMe ANA report per volumes and utilizes SPDK ANA-groupIds, ANA states for namespaces and listeners

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -187,12 +187,17 @@ class GatewayClient:
         argument("-n", "--subnqn", help="Subsystem NQN", required=True),
         argument("-s", "--serial", help="Serial number", required=False),
         argument("-m", "--max-namespaces", help="Maximum number of namespaces", type=int, default=0, required=False),
+        argument("-a", "--ana-reporting", help="Enable ANA reporting", type=bool, default=False, required=False),
+        argument("-t", "--enable-ha", help="Enable automatic HA"  , type=bool, default=False, required=False),
+
     ])
     def create_subsystem(self, args):
         """Creates a subsystem."""
         req = pb2.create_subsystem_req(subsystem_nqn=args.subnqn,
                                         serial_number=args.serial,
-                                        max_namespaces=args.max_namespaces)
+                                        max_namespaces=args.max_namespaces,
+                                        ana_reporting=args.ana_reporting,
+                                        enable_ha=args.enable_ha)
         ret = self.stub.create_subsystem(req)
         self.logger.info(f"Created subsystem {args.subnqn}: {ret.status}")
 
@@ -209,15 +214,20 @@ class GatewayClient:
         argument("-n", "--subnqn", help="Subsystem NQN", required=True),
         argument("-b", "--bdev", help="Bdev name", required=True),
         argument("-i", "--nsid", help="Namespace ID", type=int),
+        argument("-a", "--anagrpid", help="ANA group ID", type=int),
     ])
     def add_namespace(self, args):
         """Adds a namespace to a subsystem."""
+        if args.anagrpid == 0:
+	        args.anagrpid = 1
+
         req = pb2.add_namespace_req(subsystem_nqn=args.subnqn,
                                     bdev_name=args.bdev,
-                                    nsid=args.nsid)
+                                    nsid=args.nsid,
+                                    anagrpid=args.anagrpid)
         ret = self.stub.add_namespace(req)
         self.logger.info(
-            f"Added namespace {ret.nsid} to {args.subnqn}: {ret.status}")
+            f"Added namespace {ret.nsid} to {args.subnqn}, ANA group id {args.anagrpid} : {ret.status}")
 
     @cli.cmd([
         argument("-n", "--subnqn", help="Subsystem NQN", required=True),

--- a/control/discovery.py
+++ b/control/discovery.py
@@ -316,10 +316,10 @@ class DiscoveryService:
         self.lock = threading.Lock()
 
         self.logger = logging.getLogger(__name__)
-        log_level = self.config.get("discovery", "debug")
-        self.logger.setLevel(level=int(log_level))
+        log_level = self.config.getint_with_default("discovery", "debug", 20)
+        self.logger.setLevel(level=log_level)
 
-        gateway_group = self.config.get("gateway", "group")
+        gateway_group = self.config.get_with_default("gateway", "group", "")
         self.omap_name = f"nvmeof.{gateway_group}.state" \
             if gateway_group else "nvmeof.state"
         self.logger.info(f"log pages info from omap: {self.omap_name}")
@@ -330,9 +330,9 @@ class DiscoveryService:
         conn.connect()
         self.ioctx = conn.open_ioctx(ceph_pool)
 
-        self.discovery_addr = self.config.get("discovery", "addr")
-        self.discovery_port = self.config.get("discovery", "port")
-        if self.discovery_addr == '' or self.discovery_port == '':
+        self.discovery_addr = self.config.get_with_default("discovery", "addr", "0.0.0.0")
+        self.discovery_port = self.config.get_with_default("discovery", "port", "8009")
+        if not self.discovery_addr or not self.discovery_port:
             self.logger.error("discovery addr/port are empty.")
             assert 0
         self.logger.info(f"discovery addr: {self.discovery_addr} port: {self.discovery_port}")

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -64,6 +64,8 @@ message create_subsystem_req {
 	string subsystem_nqn = 1;
 	string serial_number = 2;
 	int32 max_namespaces = 3;
+	bool  ana_reporting  = 4;
+	bool  enable_ha      = 5;
 }
 
 message delete_subsystem_req {
@@ -74,6 +76,7 @@ message add_namespace_req {
 	string subsystem_nqn = 1;
 	string bdev_name = 2;
 	optional int32 nsid = 3;
+        optional int32 anagrpid = 4;
 }
 
 message remove_namespace_req {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ subsystem2 = "nqn.2016-06.io.spdk:cnode2"
 serial = "SPDK00000000000001"
 host_list = ["nqn.2016-06.io.spdk:host1", "*"]
 nsid = "1"
+anagrpid = "2"
 trtype = "TCP"
 gateway_name = socket.gethostname()
 addr = "127.0.0.1"
@@ -98,3 +99,46 @@ class TestDelete:
         assert "Failed to delete" not in caplog.text
         cli(["delete_subsystem", "-n", subsystem2])
         assert "Failed to delete" not in caplog.text
+
+
+class TestCreateWithAna:
+    def test_create_bdev_ana(self, caplog, gateway):
+        cli(["create_bdev", "-i", image, "-p", pool, "-b", bdev])
+        assert "Failed to create" not in caplog.text
+
+
+    def test_create_subsystem_ana(self, caplog, gateway):
+        cli(["create_subsystem", "-n", subsystem, "-a", "true", "-t", "true"])
+        assert "Failed to create" not in caplog.text
+        cli(["get_subsystems"])
+        assert serial not in caplog.text
+
+    def test_add_namespace_ana(self, caplog, gateway):
+        cli(["add_namespace", "-n", subsystem, "-b", bdev, "-a", anagrpid])
+        assert "Failed to add" not in caplog.text
+
+    @pytest.mark.parametrize("listener", listener_list)
+    def test_create_listener_ana(self, caplog, listener, gateway):
+        cli(["create_listener", "-n", subsystem] + listener)
+        assert "Failed to create" not in caplog.text
+
+
+class TestDeleteAna:
+
+    @pytest.mark.parametrize("listener", listener_list)
+    def test_delete_listener_ana(self, caplog, listener, gateway):
+        cli(["delete_listener", "-n", subsystem] + listener)
+        assert "Failed to delete" not in caplog.text
+
+    def test_remove_namespace_ana(self, caplog, gateway):
+        cli(["remove_namespace", "-n", subsystem, "-i", nsid])
+        assert "Failed to remove" not in caplog.text
+
+    def test_delete_bdev_ana(self, caplog, gateway):
+        cli(["delete_bdev", "-b", bdev, "-f"])
+        assert "Failed to delete" not in caplog.text
+
+    def test_delete_subsystem_ana(self, caplog, gateway):
+        cli(["delete_subsystem", "-n", subsystem])
+        assert "Failed to delete" not in caplog.text
+


### PR DESCRIPTION
Based on ceph-nvmeof issue 122 

As per explanation in the issue:
-added optional flag "ana_report" to create-subsystem cli
-added optional flag  "enable_ha" to create-subsystem cli 
-added optional "ana_grpid" to add-namespace cli
-limited  just 4 ANA groups per subsystem
-when added listener and "enable_ha" is configured - set ana_states to all supported ANA groups as "inaccessible"

pushed as 2 commits, they would be squashed 
