### PR TITLE
Make sure OMAP's get_state() reads the entire file, even if it has more than 1024 keys

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -87,6 +87,27 @@ jobs:
           docker load < nvmeof-devel.tar
           docker load < vstart-cluster.tar
 
+      - name: Clear space on disk
+        run: |
+          if [[ -d /usr/share/dotnet ]]; then
+            /usr/bin/du -sh /usr/share/dotnet
+            rm -rf /usr/share/dotnet
+          fi
+          if [[ -d /opt/ghc ]]; then
+            /usr/bin/du -sh /opt/ghc
+            rm -rf /opt/ghc
+          fi
+          if [[ -d /usr/local/share/boost ]]; then
+            /usr/bin/du -sh /usr/local/share/boost
+            rm -rf /usr/local/share/boost
+          fi
+          if [[ -n "$AGENT_TOOLSDIRECTORY" ]]; then
+            if [[ -d "$AGENT_TOOLSDIRECTORY" ]]; then
+              /usr/bin/du -sh "$AGENT_TOOLSDIRECTORY"
+              rm -rf "$AGENT_TOOLSDIRECTORY"
+            fi
+          fi
+
       - name: Start ceph cluster
         run: |
           make up SVC=ceph OPTS="--detach"

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -11,7 +11,7 @@ image = "mytestdevimage"
 pool = "rbd"
 bdev_prefix = "Ceph0"
 subsystem_prefix = "nqn.2016-06.io.spdk:cnode"
-created_resource_count = 150
+created_resource_count = 500
 get_subsys_count = 100
 
 def create_resource_by_index(i):


### PR DESCRIPTION
Fixes #263
Fixes #266

The OMAP get_state() function only reads 1024 values from the OMAP file. When I had an OMAP file which was 3000 lines long I got an exception the the omap_version key wasn't found. Adding some debug messages I found out that the dictionary created from the values we read from the OMAP file was 1024 big and not 3000. So, even though we pass -1 to get_omap_vals() we only read 1024 lines from the file. We need to enclose this code in a loop and keep on reading from the OMAP until we read the entire file.