### PR TITLE
Create the SPDK socket under /var/run/ceph/<fsid> and not /var/tmp

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -37,7 +37,8 @@ client_cert = ./client.crt
 
 [spdk]
 tgt_path = /usr/local/bin/nvmf_tgt
-rpc_socket = /var/tmp/spdk.sock
+#rpc_socket_dir = /var/tmp/
+#rpc_socket_name = spdk.sock
 #tgt_cmd_extra_args = --env-context="--no-huge -m1024" --iova-mode=va
 timeout = 60.0
 log_level = WARN

--- a/tests/test_multi_gateway.py
+++ b/tests/test_multi_gateway.py
@@ -21,6 +21,7 @@ def conn(config):
     configA.config["gateway"]["min_controller_id"] = "1"
     configA.config["gateway"]["max_controller_id"] = "20000"
     configA.config["gateway"]["enable_spdk_discovery_controller"] = "True"
+    configA.config["spdk"]["rpc_socket_name"] = "spdk_GatewayA.sock"
     configB = copy.deepcopy(configA)
     addr = configA.get("gateway", "addr")
     portA = configA.getint("gateway", "port")
@@ -31,7 +32,7 @@ def conn(config):
     configA.config["gateway"]["max_controller_id"] = "40000"
     configB.config["gateway"]["state_update_interval_sec"] = str(
         update_interval_sec)
-    configB.config["spdk"]["rpc_socket"] = "/var/tmp/spdk_GatewayB.sock"
+    configB.config["spdk"]["rpc_socket_name"] = "spdk_GatewayB.sock"
     configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x02"
 
     # Start servers

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,7 +55,7 @@ class TestServer(unittest.TestCase):
         configB = copy.deepcopy(configA)
         configB.config["gateway"]["name"] = "GatewayB"
         configB.config["gateway"]["port"] = str(configA.getint("gateway", "port") + 1)
-        configB.config["spdk"]["rpc_socket"] = "/var/tmp/spdk_GatewayB.sock"
+        configB.config["spdk"]["rpc_socket_name"] = "spdk_GatewayB.sock"
         # invalid arg, spdk would exit with code 1 at start up
         configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x343435545"
 


### PR DESCRIPTION
Fixes #216

Notice that this works for an SPDK run from within the gateway. If SPDK is run as a stand alone container (which we don't do), the socket file would still be created in /var/tmp/