### PR TITLE
Handle IPv6 parameters in NVMe CLI

### DIFF
--- a/.env
+++ b/.env
@@ -27,7 +27,8 @@ NVMEOF_DESCRIPTION="Service to provide block storage on top of Ceph for platform
 NVMEOF_URL="https://github.com/ceph/ceph-nvmeof"
 NVMEOF_TAGS="ceph,nvme-of,nvme-of gateway,rbd,block storage"
 NVMEOF_WANTS="ceph,rbd"
-NVMEOF_IP_ADDRESS="192.168.13.3"
+NVMEOF_IP_ADDRESS=192.168.13.3
+NVMEOF_IPV6_ADDRESS=2001:db8::3
 NVMEOF_IO_PORT=4420
 NVMEOF_GW_PORT=5500
 NVMEOF_DISC_PORT=8009
@@ -57,10 +58,10 @@ CEPH_CLUSTER_VERSION="${CEPH_VERSION}"
 CEPH_VSTART_ARGS="--without-dashboard --memstore"
 
 # Demo settings
-RBD_POOL="rbd"
-RBD_IMAGE_NAME="demo_image"
-RBD_IMAGE_SIZE="10M"
-BDEV_NAME="demo_bdev"
+RBD_POOL=rbd
+RBD_IMAGE_NAME=demo_image
+RBD_IMAGE_SIZE=10M
+BDEV_NAME=demo_bdev
 NQN="nqn.2016-06.io.spdk:cnode1"
 SERIAL="SPDK00000000000001"
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -226,6 +226,7 @@ jobs:
           shopt -s expand_aliases
           eval $(make alias)
           nvmeof-cli get_subsystems
+          nvmeof-cli-ipv6 get_subsystems
 
       - name: Run bdevperf
         run: |

--- a/control/cli.py
+++ b/control/cli.py
@@ -17,7 +17,7 @@ from functools import wraps
 
 from .proto import gateway_pb2_grpc as pb2_grpc
 from .proto import gateway_pb2 as pb2
-
+from .config import GatewayConfig
 
 def argument(*name_or_flags, **kwargs):
     """Helper function to format arguments for argparse command decorator."""
@@ -124,7 +124,9 @@ class GatewayClient:
 
     def connect(self, host, port, client_key, client_cert, server_cert):
         """Connects to server and sets stub."""
-        server = "{}:{}".format(host, port)
+        # We need to enclose IPv6 addresses in brackets before concatenating a colon and port number to it
+        host = GatewayConfig.escape_address_if_ipv6(host)
+        server = f"{host}:{port}"
 
         if client_key and client_cert:
             # Create credentials for mutual TLS and a secure channel

--- a/control/config.py
+++ b/control/config.py
@@ -64,3 +64,10 @@ class GatewayConfig:
                 self.conffile_logged = True
         except Exception:
             pass
+
+    # We need to enclose IPv6 addresses in brackets before concatenating a colon and port number to it
+    def escape_address_if_ipv6(addr) -> str:
+        ret_addr = addr
+        if ":" in addr and not addr.strip().startswith("["):
+            ret_addr = f"[{addr}]"
+        return ret_addr

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -23,6 +23,7 @@ import spdk.rpc.nvmf as rpc_nvmf
 from google.protobuf import json_format
 from .proto import gateway_pb2 as pb2
 from .proto import gateway_pb2_grpc as pb2_grpc
+from .config import GatewayConfig
 
 MAX_ANA_GROUPS = 4
 
@@ -535,9 +536,10 @@ class GatewayService(pb2_grpc.GatewayServicer):
     def create_listener_safe(self, request, context=None):
         """Creates a listener for a subsystem at a given IP/Port."""
         ret = True
+        traddr = GatewayConfig.escape_address_if_ipv6(request.traddr)
         self.logger.info(f"Received request to create {request.gateway_name}"
                          f" {request.trtype} listener for {request.nqn} at"
-                         f" {request.traddr}:{request.trsvcid}.")
+                         f" {traddr}:{request.trsvcid}.")
         try:
             if request.gateway_name == self.gateway_name:
                 listener_already_exist = self.matching_listener_exists(
@@ -627,9 +629,10 @@ class GatewayService(pb2_grpc.GatewayServicer):
         """Deletes a listener from a subsystem at a given IP/Port."""
 
         ret = True
+        traddr = GatewayConfig.escape_address_if_ipv6(request.traddr)
         self.logger.info(f"Received request to delete {request.gateway_name}"
                          f" {request.trtype} listener for {request.nqn} at"
-                         f" {request.traddr}:{request.trsvcid}.")
+                         f" {traddr}:{request.trsvcid}.")
         try:
             if request.gateway_name == self.gateway_name:
                 ret = rpc_nvmf.nvmf_subsystem_remove_listener(

--- a/control/server.py
+++ b/control/server.py
@@ -28,6 +28,7 @@ from .proto import gateway_pb2_grpc as pb2_grpc
 from .state import GatewayState, LocalGatewayState, OmapGatewayState, GatewayStateHandler
 from .grpc import GatewayService
 from .discovery import DiscoveryService
+from .config import GatewayConfig
 
 def sigchld_handler(signum, frame):
     """Handle SIGCHLD, runs when a spdk process terminates."""
@@ -158,6 +159,8 @@ class GatewayServer:
         enable_auth = self.config.getboolean("gateway", "enable_auth")
         gateway_addr = self.config.get("gateway", "addr")
         gateway_port = self.config.get("gateway", "port")
+        # We need to enclose IPv6 addresses in brackets before concatenating a colon and port number to it
+        gateway_addr = GatewayConfig.escape_address_if_ipv6(gateway_addr)
         if enable_auth:
             # Read in key and certificates for authentication
             server_key = self.config.get("mtls", "server_key")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
     networks:
       default:
         ipv4_address: 192.168.13.2
+        ipv6_address: 2001:db8::2
   nvmeof-base:
     build:
       context: .
@@ -213,6 +214,8 @@ volumes:
   ceph-conf:
 networks:
   default:
+    enable_ipv6: true
     ipam:
       config:
         - subnet: 192.168.13.0/24
+        - subnet: 2001:0DB8::/112

--- a/mk/demo.mk
+++ b/mk/demo.mk
@@ -10,9 +10,12 @@ rbd: CMD = bash -c "rbd -p $(RBD_POOL) info $(RBD_IMAGE_NAME) || rbd -p $(RBD_PO
 demo: export NVMEOF_HOSTNAME != docker ps -q -f name=$(NVMEOF_CONTAINER_NAME)
 demo: rbd ## Expose RBD_IMAGE_NAME as NVMe-oF target
 	$(NVMEOF_CLI) create_bdev --pool $(RBD_POOL) --image $(RBD_IMAGE_NAME) --bdev $(BDEV_NAME)
+	$(NVMEOF_CLI_IPV6) create_bdev --pool $(RBD_POOL) --image $(RBD_IMAGE_NAME) --bdev $(BDEV_NAME)_ipv6
 	$(NVMEOF_CLI) create_subsystem --subnqn $(NQN)
 	$(NVMEOF_CLI) add_namespace --subnqn $(NQN) --bdev $(BDEV_NAME)
+	$(NVMEOF_CLI) add_namespace --subnqn $(NQN) --bdev $(BDEV_NAME)_ipv6
 	$(NVMEOF_CLI) create_listener --subnqn $(NQN) --gateway-name $(NVMEOF_HOSTNAME) --traddr $(NVMEOF_IP_ADDRESS) --trsvcid $(NVMEOF_IO_PORT)
+	$(NVMEOF_CLI_IPV6) create_listener --subnqn $(NQN) --gateway-name $(NVMEOF_HOSTNAME) --traddr '$(NVMEOF_IPV6_ADDRESS)' --trsvcid $(NVMEOF_IO_PORT) --adrfam IPV6
 	$(NVMEOF_CLI) add_host --subnqn $(NQN) --host "*"
 
 .PHONY: demo rbd

--- a/mk/misc.mk
+++ b/mk/misc.mk
@@ -2,8 +2,9 @@
 
 # nvmeof_cli
 NVMEOF_CLI = $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE) run --rm nvmeof-cli --server-address $(NVMEOF_IP_ADDRESS) --server-port $(NVMEOF_GW_PORT)
+NVMEOF_CLI_IPV6 = $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE) run --rm nvmeof-cli --server-address $(NVMEOF_IPV6_ADDRESS) --server-port $(NVMEOF_GW_PORT)
 
 alias: ## Print bash alias command for the nvmeof-cli. Usage: "eval $(make alias)"
-	@echo alias nvmeof-cli=\"$(NVMEOF_CLI)\"
+	@echo alias nvmeof-cli=\"$(NVMEOF_CLI)\" \; alias nvmeof-cli-ipv6=\'$(NVMEOF_CLI_IPV6)\'
 
 .PHONY: alias


### PR DESCRIPTION
We got several issues with IPv6. first we need to allow the gateway to listen and accept connections using IPv6. Then we need to allow using IPv6 in different CLI parameters, like in the create_listener command.

Fixes #245
Fixes #247

Also fixes: [bugzilla bug 2240580](https://bugzilla.redhat.com/show_bug.cgi?id=2240580)