### PR TITLE
Make port parameter not required for create and delete listener CLI commands

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -298,7 +298,7 @@ class GatewayClient:
         argument("-t", "--trtype", help="Transport type", default="TCP"),
         argument("-f", "--adrfam", help="Address family", default="ipv4"),
         argument("-a", "--traddr", help="NVMe host IP", required=True),
-        argument("-s", "--trsvcid", help="Port number", required=True),
+        argument("-s", "--trsvcid", help="Port number", default="4420", required=False),
     ])
     def create_listener(self, args):
         """Creates a listener for a subsystem at a given IP/Port."""
@@ -320,7 +320,7 @@ class GatewayClient:
         argument("-t", "--trtype", help="Transport type", default="TCP"),
         argument("-f", "--adrfam", help="Address family", default="ipv4"),
         argument("-a", "--traddr", help="NVMe host IP", required=True),
-        argument("-s", "--trsvcid", help="Port number", required=True),
+        argument("-s", "--trsvcid", help="Port number", default="4420", required=False),
     ])
     def delete_listener(self, args):
         """Deletes a listener from a subsystem at a given IP/Port."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ addr = "127.0.0.1"
 addr_ipv6 = "::1"
 server_addr_ipv6 = "2001:db8::3"
 listener_list = [["-g", gateway_name, "-a", addr, "-s", "5001"], ["-g", gateway_name, "-a", addr,"-s", "5002"]]
+listener_list_no_port = [["-g", gateway_name, "-a", addr]]
 listener_list_ipv6 = [["-g", gateway_name, "-a", addr_ipv6, "-s", "5003"], ["-g", gateway_name, "-a", addr_ipv6, "-s", "5004"]]
 config = "ceph-nvmeof.conf"
 
@@ -201,6 +202,14 @@ class TestCreate:
         assert "IPV6" in caplog.text
         assert f"Created {subsystem} listener at [{listener_ipv6[3]}]:{listener_ipv6[5]}: True" in caplog.text
 
+    @pytest.mark.parametrize("listener", listener_list_no_port)
+    def test_create_listener_no_port(self, caplog, listener, gateway):
+        caplog.clear()
+        cli(["create_listener", "-n", subsystem] + listener)
+        assert "enable_ha: False" in caplog.text
+        assert "ipv4" in caplog.text
+        assert f"Created {subsystem} listener at {listener[3]}:4420: True" in caplog.text
+
 class TestDelete:
     @pytest.mark.parametrize("host", host_list)
     def test_remove_host(self, caplog, host, gateway):
@@ -222,6 +231,12 @@ class TestDelete:
         caplog.clear()
         cli(["--server-address", server_addr_ipv6, "delete_listener", "-n", subsystem, "--adrfam", "IPV6"] + listener_ipv6)
         assert f"Deleted [{listener_ipv6[3]}]:{listener_ipv6[5]} from {subsystem}: True" in caplog.text
+
+    @pytest.mark.parametrize("listener", listener_list_no_port)
+    def test_delete_listener_no_port(self, caplog, listener, gateway):
+        caplog.clear()
+        cli(["delete_listener", "-n", subsystem] + listener)
+        assert f"Deleted {listener[3]}:4420 from {subsystem}: True" in caplog.text
 
     def test_remove_namespace(self, caplog, gateway):
         caplog.clear()


### PR DESCRIPTION
When the port parameter (`--trsvcid`) is not passed a default of 4420 will be used.

Fixes #335