### PR TITLE
docker,ci,make: add Ceph-Dashboard support and other improvements

### DIFF
--- a/.env
+++ b/.env
@@ -59,7 +59,7 @@ SPDK_CENTOS_REPO_VER="9.0-21.el9"
 # Ceph Cluster
 CEPH_CLUSTER_VERSION="${CEPH_VERSION}"
 CEPH_VSTART_ARGS="--memstore"
-CEPH_DEVEL_MGR_PATH=/home/epuertat/git/ceph
+CEPH_DEVEL_MGR_PATH=../ceph
 
 # Demo settings
 RBD_POOL=rbd

--- a/.env
+++ b/.env
@@ -58,6 +58,7 @@ SPDK_CENTOS_REPO_VER="9.0-21.el9"
 
 # Ceph Cluster
 CEPH_CLUSTER_VERSION="${CEPH_VERSION}"
+# CEPH_CLUSTER_CEPH_REPO_BASEURL= # Uncomment for specifying a custom Ceph YUM repo
 CEPH_VSTART_ARGS="--memstore"
 CEPH_DEVEL_MGR_PATH=../ceph
 

--- a/.env
+++ b/.env
@@ -49,16 +49,16 @@ SPDK_DESCRIPTION="The Storage Performance Development Kit (SPDK) provides a set 
 SPDK_URL="https://spdk.io"
 
 SPDK_PKGDEP_ARGS="--rbd"
+# check spdk/configure --help
 SPDK_CONFIGURE_ARGS="--with-rbd --disable-tests --disable-unit-tests --disable-examples --enable-debug"
+SPDK_TARGET_ARCH="x86-64-v2"
 SPDK_MAKEFLAGS=
-SPDK_DISABLE_VPCLMULQDQ=
-SPDK_DISABLE_AVX512=
 SPDK_CENTOS_BASE="https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/"
 SPDK_CENTOS_REPO_VER="9.0-21.el9"
 
 # Ceph Cluster
 CEPH_CLUSTER_VERSION="${CEPH_VERSION}"
-# CEPH_CLUSTER_CEPH_REPO_BASEURL= # Uncomment for specifying a custom Ceph YUM repo
+# CEPH_CLUSTER_CEPH_REPO_BASEURL=
 CEPH_VSTART_ARGS="--memstore"
 CEPH_DEVEL_MGR_PATH=../ceph
 

--- a/.env
+++ b/.env
@@ -58,7 +58,8 @@ SPDK_CENTOS_REPO_VER="9.0-21.el9"
 
 # Ceph Cluster
 CEPH_CLUSTER_VERSION="${CEPH_VERSION}"
-CEPH_VSTART_ARGS="--without-dashboard --memstore"
+CEPH_VSTART_ARGS="--memstore"
+CEPH_DEVEL_MGR_PATH=/home/epuertat/git/ceph
 
 # Demo settings
 RBD_POOL=rbd

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -21,13 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          # git submodule update --init --recursive
           submodules: recursive
-
-      - name: Build container images - ceph
-        run: make build SVC=ceph SPDK_TARGET_ARCH=x86-64-v2
 
       - name: Build container images - spdk
         run: make build SVC="spdk" SPDK_TARGET_ARCH=x86-64-v2
@@ -49,21 +45,40 @@ jobs:
           . .env
           docker save $QUAY_NVMEOF:$NVMEOF_VERSION > nvmeof.tar
           docker save $QUAY_NVMEOFCLI:$NVMEOF_VERSION > nvmeof-cli.tar
-          docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
           docker save bdevperf > bdevperf.tar
 
       - name: Upload container images
         uses: actions/upload-artifact@v4
         with:
-          name: ceph_nvmeof_container_images-${{ github.run_number }}
+          name: container_images
           path: |
             nvmeof.tar
             nvmeof-cli.tar
-            ceph.tar
             bdevperf.tar
 
+  build-ceph:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build container images - ceph
+        run: make build SVC=ceph
+
+      - name: Save container images
+        run: |
+          . .env
+          docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
+
+      - name: Upload container images
+        uses: actions/upload-artifact@v4
+        with:
+          name: container_images_ceph
+          path: |
+            ceph.tar
+
   pytest:
-    needs: build
+    needs: [build, build-ceph]
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +88,7 @@ jobs:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup huge pages
         run: |
@@ -82,7 +97,8 @@ jobs:
       - name: Download container images
         uses: actions/download-artifact@v4
         with:
-          name: ceph_nvmeof_container_images-${{ github.run_number }}
+          pattern: container_images*
+          merge-multiple: true
 
       - name: Load container images
         run: |
@@ -157,11 +173,10 @@ jobs:
 
       - name: Upload ${{ matrix.test }} test core dumps
         if: steps.check_coredumps.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ceph_nvmeof_pytest_${{ matrix.test }}_cores-${{ github.run_number }}
-          path: |
-            /tmp/coredump/core.*
+          name: core_pytest_${{ matrix.test }}
+          path: /tmp/coredump/core.*
 
       - name: Display logs
         if: success() || failure()
@@ -175,13 +190,13 @@ jobs:
           make clean
 
   demo:
-    needs: build
+    needs: [build, build-ceph]
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 512
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES
@@ -189,7 +204,8 @@ jobs:
       - name: Download container images
         uses: actions/download-artifact@v4
         with:
-          name: ceph_nvmeof_container_images-${{ github.run_number }}
+          pattern: container_images*
+          merge-multiple: true
 
       - name: Load container images
         run: |
@@ -280,11 +296,10 @@ jobs:
 
       - name: Upload demo core dumps
         if: steps.check_coredumps.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ceph_nvmeof_demo_cores-${{ github.run_number }}
-          path: |
-            /tmp/coredump/core.*
+          name: core_demo
+          path: /tmp/coredump/core.*
 
       # For debugging purposes (provides an SSH connection to the runner)
       # - name: Setup tmate session
@@ -303,7 +318,7 @@ jobs:
           make clean
 
   discovery:
-    needs: build
+    needs: [build, build-ceph]
     strategy:
       fail-fast: false
       matrix:
@@ -314,7 +329,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES
@@ -322,7 +337,8 @@ jobs:
       - name: Download container images
         uses: actions/download-artifact@v4
         with:
-          name: ceph_nvmeof_container_images-${{ github.run_number }}
+          pattern: container_images*
+          merge-multiple: true
 
       - name: Load container images
         run: |
@@ -471,9 +487,9 @@ jobs:
 
       - name: Upload demo core dumps
         if: steps.check_coredumps.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
-          name: ceph_nvmeof_demo_cores-${{ github.run_number }}
+          name: core_demo
           path: /tmp/coredump/core.*
 
       - name: Display logs
@@ -493,12 +509,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download container images
         uses: actions/download-artifact@v4
         with:
-          name: ceph_nvmeof_container_images-${{ github.run_number }}
+          name: container_images
 
       - name: Load container images
         run: |

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -14,6 +14,10 @@ on:  # yamllint disable rule:truthy
   release:
     types:
       - created
+# Credit: https://stackoverflow.com/a/72408109
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   WAIT_INTERVAL_SECS: 1
 jobs:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -53,7 +53,7 @@ jobs:
           docker save bdevperf > bdevperf.tar
 
       - name: Upload container images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ceph_nvmeof_container_images-${{ github.run_number }}
           path: |
@@ -80,7 +80,7 @@ jobs:
           make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ceph_nvmeof_container_images-${{ github.run_number }}
 
@@ -187,7 +187,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ceph_nvmeof_container_images-${{ github.run_number }}
 
@@ -320,7 +320,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ceph_nvmeof_container_images-${{ github.run_number }}
 
@@ -496,7 +496,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download container images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ceph_nvmeof_container_images-${{ github.run_number }}
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,11 +1,13 @@
 name: "CI"
 on:
   push:
-    branches:
-      - '*'
     tags:
       - 'v*'
   pull_request:
+    branches:
+      - devel
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
   release:
     types:
@@ -22,8 +24,26 @@ jobs:
           # git submodule update --init --recursive
           submodules: recursive
 
-      - name: Build container images
-        run: make build SPDK_DISABLE_VPCLMULQDQ="yes" SPDK_DISABLE_AVX512="yes"
+      - name: Build container images - ceph
+        run: make build SVC=ceph SPDK_TARGET_ARCH=x86-64-v2
+
+      - name: Build container images - spdk
+        run: make build SVC="spdk" SPDK_TARGET_ARCH=x86-64-v2
+
+      - name: Build container images - bdevperf
+        run: make build SVC="bdevperf" SPDK_TARGET_ARCH=x86-64-v2
+
+      - name: Build container images - nvmeof
+        run: make build SVC="nvmeof" SPDK_TARGET_ARCH=x86-64-v2
+
+      - name: Build container images - nvmeof-devel
+        run: make build SVC="nvmeof-devel" SPDK_TARGET_ARCH=x86-64-v2
+
+      - name: Build container images - nvmeof-cli
+        run: make build SVC="nvmeof-cli" SPDK_TARGET_ARCH=x86-64-v2
+
+      - name: Build container images - discovery
+        run: make build SVC="discovery" SPDK_TARGET_ARCH=x86-64-v2
 
       - name: Save container images
         run: |

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Build container images - nvmeof
         run: make build SVC="nvmeof" SPDK_TARGET_ARCH=x86-64-v2
 
-      - name: Build container images - nvmeof-devel
-        run: make build SVC="nvmeof-devel" SPDK_TARGET_ARCH=x86-64-v2
-
       - name: Build container images - nvmeof-cli
         run: make build SVC="nvmeof-cli" SPDK_TARGET_ARCH=x86-64-v2
 
@@ -52,7 +49,6 @@ jobs:
           docker save $QUAY_NVMEOFCLI:$NVMEOF_VERSION > nvmeof-cli.tar
           docker save $QUAY_CEPH:$CEPH_VERSION  > vstart-cluster.tar
           docker save bdevperf > bdevperf.tar
-          docker save nvmeof-devel > nvmeof-devel.tar
 
       - name: Upload container images
         uses: actions/upload-artifact@v3
@@ -61,7 +57,6 @@ jobs:
           path: |
             nvmeof.tar
             nvmeof-cli.tar
-            nvmeof-devel.tar
             vstart-cluster.tar
             bdevperf.tar
 
@@ -89,7 +84,7 @@ jobs:
 
       - name: Load container images
         run: |
-          docker load < nvmeof-devel.tar
+          docker load < nvmeof.tar
           docker load < vstart-cluster.tar
 
       - name: Clear space on disk
@@ -149,7 +144,7 @@ jobs:
         run: |
           # Run tests code in current dir
           # Managing pytest’s output: https://docs.pytest.org/en/7.1.x/how-to/output.html
-          make run SVC="nvmeof-devel" OPTS="--volume=$(pwd)/tests:/src/tests --entrypoint=python3" CMD="-m pytest --show-capture=all -s --full-trace -vv -rA tests/test_${{ matrix.test }}.py"
+          make run SVC="nvmeof" OPTS="--volume=$(pwd)/tests:/src/tests --entrypoint=python3" CMD="-m pytest --show-capture=all -s --full-trace -vv -rA tests/test_${{ matrix.test }}.py"
 
       - name: Check coredump existence
         if: success() || failure()

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,5 +1,7 @@
+---
+# yamllint disable rule:line-length
 name: "CI"
-on:
+on:  # yamllint disable rule:truthy
   push:
     tags:
       - 'v*'
@@ -47,7 +49,7 @@ jobs:
           . .env
           docker save $QUAY_NVMEOF:$NVMEOF_VERSION > nvmeof.tar
           docker save $QUAY_NVMEOFCLI:$NVMEOF_VERSION > nvmeof-cli.tar
-          docker save $QUAY_CEPH:$CEPH_VERSION  > vstart-cluster.tar
+          docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
           docker save bdevperf > bdevperf.tar
 
       - name: Upload container images
@@ -57,7 +59,7 @@ jobs:
           path: |
             nvmeof.tar
             nvmeof-cli.tar
-            vstart-cluster.tar
+            ceph.tar
             bdevperf.tar
 
   pytest:
@@ -65,10 +67,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          test: ["cli", "state", "multi_gateway", "server", "grpc", "omap_lock", "old_omap", "log_files"]
+        test: ["cli", "state", "multi_gateway", "server", "grpc", "omap_lock", "old_omap", "log_files"]
     runs-on: ubuntu-latest
     env:
-      HUGEPAGES: 512 # for multi gateway test, approx 256 per gateway instance
+      HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -85,7 +87,7 @@ jobs:
       - name: Load container images
         run: |
           docker load < nvmeof.tar
-          docker load < vstart-cluster.tar
+          docker load < ceph.tar
 
       - name: Clear space on disk
         run: |
@@ -149,7 +151,7 @@ jobs:
       - name: Check coredump existence
         if: success() || failure()
         id: check_coredumps
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2, pinned to SHA for security reasons
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b  # v2, pinned to SHA for security reasons
         with:
           files: "/tmp/coredump/core.*"
 
@@ -193,7 +195,7 @@ jobs:
         run: |
           docker load < nvmeof.tar
           docker load < nvmeof-cli.tar
-          docker load < vstart-cluster.tar
+          docker load < ceph.tar
           docker load < bdevperf.tar
 
       - name: Start containers
@@ -272,9 +274,9 @@ jobs:
       - name: Check coredump existence
         if: success() || failure()
         id: check_coredumps
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2, pinned to SHA for security reasons
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b  # v2, pinned to SHA for security reasons
         with:
-            files: "/tmp/coredump/core.*"
+          files: "/tmp/coredump/core.*"
 
       - name: Upload demo core dumps
         if: steps.check_coredumps.outputs.files_exists == 'true'
@@ -285,10 +287,10 @@ jobs:
             /tmp/coredump/core.*
 
       # For debugging purposes (provides an SSH connection to the runner)
-      #- name: Setup tmate session
-      #  uses: mxschmitt/action-tmate@v3
-      #  with:
-      #    limit-access-to-actor: true
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+      #   with:
+      #     limit-access-to-actor: true
 
       - name: Display logs
         if: success() || failure()
@@ -305,10 +307,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          integration: ["container", "embedded"]
+        integration: ["container", "embedded"]
     runs-on: ubuntu-latest
     env:
-      HUGEPAGES: 768 # 3 spdk instances
+      HUGEPAGES: 768  # 3 spdk instances
 
     steps:
       - name: Checkout code
@@ -326,7 +328,7 @@ jobs:
         run: |
           docker load < nvmeof.tar
           docker load < nvmeof-cli.tar
-          docker load < vstart-cluster.tar
+          docker load < ceph.tar
           docker load < bdevperf.tar
 
       - name: Start discovery controller
@@ -463,9 +465,9 @@ jobs:
       - name: Check coredump existence
         if: success() || failure()
         id: check_coredumps
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2, pinned to SHA for security reasons
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b  # v2, pinned to SHA for security reasons
         with:
-            files: "/tmp/coredump/core.*"
+          files: "/tmp/coredump/core.*"
 
       - name: Upload demo core dumps
         if: steps.check_coredumps.outputs.files_exists == 'true'

--- a/Dockerfile.ceph
+++ b/Dockerfile.ceph
@@ -2,25 +2,34 @@
 # vim: syntax=dockerfile
 FROM quay.io/centos/centos:stream9-minimal AS build
 
-ARG CEPH_CLUSTER_VERSION
+ARG CEPH_CLUSTER_VERSION \
+    CEPH_CLUSTER_CEPH_REPO_BASEURL="https://download.ceph.com/rpm-$CEPH_CLUSTER_VERSION/el\$releasever" \
+    CEPH_CLUSTER_EPEL_REPO_URL="https://copr.fedorainfracloud.org/coprs/ceph/el9/repo/epel-9/ceph-el9-epel-9.repo"
 
 COPY <<EOF /etc/yum.repos.d/ceph.repo
 [Ceph]
 name=Ceph packages for \$basearch
-baseurl=https://download.ceph.com/rpm-$CEPH_CLUSTER_VERSION/el\$releasever/\$basearch
+baseurl=${CEPH_CLUSTER_CEPH_REPO_BASEURL:?}/\$basearch
 enabled=1
 priority=2
-gpgcheck=1
-gpgkey=https://download.ceph.com/keys/release.asc
+gpgcheck=0
 
 [Ceph-noarch]
 name=Ceph noarch packages
-baseurl=https://download.ceph.com/rpm-$CEPH_CLUSTER_VERSION/el\$releasever/noarch
+baseurl=${CEPH_CLUSTER_CEPH_REPO_BASEURL:?}/noarch
 enabled=1
 priority=2
-gpgcheck=1
-gpgkey=https://download.ceph.com/keys/release.asc
+gpgcheck=0
 EOF
+
+ARG MICRODNF_OPTS="\
+    --enablerepo crb \
+    --nobest \
+    --nodocs \
+    --setopt=install_weak_deps=0 \
+    --setopt=keepcache=1 \
+    --setopt=cachedir=/var/cache/microdnf \
+  "
 
 ARG CEPH_PACKAGES="\
     ceph-common \
@@ -46,24 +55,19 @@ ARG DEBUG_PACKAGES="\
     strace \
     perf \
     ltrace \
+    lsof \
     "
 
 RUN rpm -vih https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
-RUN cd /etc/yum.repos.d/ && curl -O https://copr.fedorainfracloud.org/coprs/ceph/el9/repo/epel-9/ceph-el9-epel-9.repo
+RUN curl -O --output-dir /etc/yum.repos.d/ $CEPH_CLUSTER_EPEL_REPO_URL
 
-RUN \
-    --mount=type=cache,target=/var/cache/microdnf \
-    microdnf install -y \
-        --enablerepo crb \
-        --nobest \
-        --nodocs \
-        --setopt=install_weak_deps=0 \
-        --setopt=keepcache=1 \
-        --setopt=cachedir=/var/cache/microdnf \
-        $CEPH_PACKAGES \
-        $EXTRA_PACKAGES \
-        $DEBUG_PACKAGES
+RUN --mount=type=cache,target=/var/cache/microdnf \
+    microdnf install -y $MICRODNF_OPTS \
+      $CEPH_PACKAGES \
+      $EXTRA_PACKAGES \
+      $DEBUG_PACKAGES
+
 
 #------------------------------------------------------------------------------
 FROM build

--- a/Dockerfile.ceph
+++ b/Dockerfile.ceph
@@ -2,25 +2,10 @@
 # vim: syntax=dockerfile
 FROM quay.io/centos/centos:stream9-minimal AS build
 
-ARG CEPH_CLUSTER_VERSION \
-    CEPH_CLUSTER_CEPH_REPO_BASEURL="https://download.ceph.com/rpm-$CEPH_CLUSTER_VERSION/el\$releasever" \
-    CEPH_CLUSTER_EPEL_REPO_URL="https://copr.fedorainfracloud.org/coprs/ceph/el9/repo/epel-9/ceph-el9-epel-9.repo"
 
-COPY <<EOF /etc/yum.repos.d/ceph.repo
-[Ceph]
-name=Ceph packages for \$basearch
-baseurl=${CEPH_CLUSTER_CEPH_REPO_BASEURL:?}/\$basearch
-enabled=1
-priority=2
-gpgcheck=0
-
-[Ceph-noarch]
-name=Ceph noarch packages
-baseurl=${CEPH_CLUSTER_CEPH_REPO_BASEURL:?}/noarch
-enabled=1
-priority=2
-gpgcheck=0
-EOF
+ARG CEPH_CLUSTER_VERSION
+ARG CEPH_CLUSTER_CEPH_REPO_BASEURL
+ARG CEPH_CLUSTER_EPEL_REPO_URL="https://copr.fedorainfracloud.org/coprs/ceph/el9/repo/epel-9/ceph-el9-epel-9.repo"
 
 ARG MICRODNF_OPTS="\
     --enablerepo crb \
@@ -58,9 +43,35 @@ ARG DEBUG_PACKAGES="\
     lsof \
     "
 
+RUN <<EOF
+    echo Log variables
+    echo ======================================================================
+    echo CEPH_CLUSTER_CEPH_REPO_BASEURL=$CEPH_CLUSTER_CEPH_REPO_BASEURL
+    echo CEPH_CLUSTER_VERSION=$CEPH_CLUSTER_VERSION
+    echo ======================================================================
+EOF
+
+COPY <<EOF /etc/yum.repos.d/ceph.repo
+[Ceph]
+name=Ceph packages for \$basearch
+baseurl=${CEPH_CLUSTER_CEPH_REPO_BASEURL:-https://download.ceph.com/rpm-${CEPH_CLUSTER_VERSION}/el\$releasever}/\$basearch
+enabled=1
+priority=2
+gpgcheck=0
+
+[Ceph-noarch]
+name=Ceph noarch packages
+baseurl=${CEPH_CLUSTER_CEPH_REPO_BASEURL:-https://download.ceph.com/rpm-${CEPH_CLUSTER_VERSION}/el\$releasever}/noarch
+enabled=1
+priority=2
+gpgcheck=0
+EOF
+
+RUN cat /etc/yum.repos.d/ceph.repo
+
 RUN rpm -vih https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
-RUN curl -O --output-dir /etc/yum.repos.d/ $CEPH_CLUSTER_EPEL_REPO_URL
+RUN curl -O --output-dir /etc/yum.repos.d/ ${CEPH_CLUSTER_EPEL_REPO_URL:?}
 
 RUN --mount=type=cache,target=/var/cache/microdnf \
     microdnf install -y $MICRODNF_OPTS \
@@ -106,7 +117,8 @@ RUN ln -sf $EC_PATH/* $CEPH_LIB && \
 
 USER ceph
 WORKDIR /ceph
-ADD --chown=ceph:ceph --chmod=755 https://raw.githubusercontent.com/ceph/ceph/v$CEPH_CLUSTER_VERSION/src/vstart.sh .
+ADD --chown=ceph:ceph --chmod=755 \
+    https://raw.githubusercontent.com/ceph/ceph/v${CEPH_CLUSTER_VERSION:?}/src/vstart.sh .
 
 COPY <<EOF ./CMakeCache.txt
 ceph_SOURCE_DIR:STATIC=/ceph

--- a/Dockerfile.ceph
+++ b/Dockerfile.ceph
@@ -1,4 +1,5 @@
 # syntax = docker/dockerfile:1.4
+# vim: syntax=dockerfile
 FROM quay.io/centos/centos:stream9-minimal AS build
 
 ARG CEPH_CLUSTER_VERSION
@@ -27,11 +28,24 @@ ARG CEPH_PACKAGES="\
     ceph-osd \
     ceph-mds \
     ceph-mgr \
+    ceph-mgr-dashboard \
     ceph-radosgw \
     ceph-exporter \
     hostname \
     jq \
     net-tools \
+    iproute \
+    "
+# TODO: To remove when ceph-mgr-dashboard defines these as deps
+ARG EXTRA_PACKAGES="\
+    python3-grpcio\ 
+    python3-grpcio-tools \
+    "
+ARG DEBUG_PACKAGES="\
+    procps-ng \
+    strace \
+    perf \
+    ltrace \
     "
 
 RUN rpm -vih https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
@@ -47,7 +61,9 @@ RUN \
         --setopt=install_weak_deps=0 \
         --setopt=keepcache=1 \
         --setopt=cachedir=/var/cache/microdnf \
-        $CEPH_PACKAGES
+        $CEPH_PACKAGES \
+        $EXTRA_PACKAGES \
+        $DEBUG_PACKAGES
 
 #------------------------------------------------------------------------------
 FROM build
@@ -67,7 +83,7 @@ ENV MON=1 \
     RGW=0 \
     NFS=0 \
     CEPH_PORT=10000 \
-    CEPH_VSTART_ARGS="--without-dashboard"
+    CEPH_VSTART_ARGS="--memstore"
 
 ENV CEPH_BIN=/usr/bin \
     CEPH_LIB=/usr/lib64/ceph \
@@ -87,6 +103,12 @@ RUN ln -sf $EC_PATH/* $CEPH_LIB && \
 USER ceph
 WORKDIR /ceph
 ADD --chown=ceph:ceph --chmod=755 https://raw.githubusercontent.com/ceph/ceph/v$CEPH_CLUSTER_VERSION/src/vstart.sh .
+
+COPY <<EOF ./CMakeCache.txt
+ceph_SOURCE_DIR:STATIC=/ceph
+WITH_MGR_DASHBOARD_FRONTEND:BOOL=ON
+WITH_RBD:BOOL=ON
+EOF
 
 ENTRYPOINT \
     ./vstart.sh --new $CEPH_VSTART_ARGS && \

--- a/Dockerfile.spdk
+++ b/Dockerfile.spdk
@@ -134,6 +134,7 @@ LABEL io.spdk.version="$SPDK_VERSION" \
       io.spdk.build.pkgdep-args="$SPDK_PKGDEP_ARGS" \
       io.spdk.build.configure-args="$SPDK_CONFIGURE_ARGS" \
       io.spdk.build.makeflags="$SPDK_MAKEFLAGS" \
+      io.spdk.build.target-arch="$SPDK_TARGET_ARCH" \
       io.spdk.build.ceph-release="$SPDK_CEPH_VERSION" \
       io.spdk.git.repo="$SPDK_GIT_REPO" \
       io.spdk.git.branch="$SPDK_GIT_BRANCH" \

--- a/Dockerfile.spdk
+++ b/Dockerfile.spdk
@@ -1,4 +1,5 @@
 # syntax = docker/dockerfile:1.4
+# vim: syntax=dockerfile
 FROM quay.io/centos/centos:stream9 AS build
 
 ARG SPDK_CEPH_VERSION \

--- a/Dockerfile.spdk
+++ b/Dockerfile.spdk
@@ -1,14 +1,55 @@
 # syntax = docker/dockerfile:1.4
 # vim: syntax=dockerfile
+
+ARG DNF_OPTS="\
+  --enablerepo crb \
+  --nobest \
+  --nodocs \
+  --setopt=install_weak_deps=0 \
+  --setopt=keepcache=1 \
+  --setopt=cachedir=/var/cache/dnf \
+  "
+
 FROM quay.io/centos/centos:stream9 AS build
 
 ARG SPDK_CEPH_VERSION \
-    SPDK_VERSION
+    SPDK_VERSION \
+    DNF_OPTS \
+    SPDK_PKGDEP_ARGS \
+    SPDK_CONFIGURE_ARGS \
+    SPDK_TARGET_ARCH \
+    SPDK_MAKEFLAGS
+
+RUN <<EOF
+    echo Log variables
+    echo ======================================================================
+    echo SPDK_PKGDEP_ARGS=$SPDK_PKGDEP_ARGS
+    echo SPDK_CONFIGURE_ARGS=$SPDK_CONFIGURE_ARGS
+    echo SPDK_TARGET_ARCH=$SPDK_TARGET_ARCH
+    echo SPDK_MAKEFLAGS=$SPDK_MAKEFLAGS
+    echo ======================================================================
+EOF
+
+WORKDIR /src
+COPY . .
+
+COPY <<EOF /etc/yum.conf
+[main]
+gpgcheck=1
+installonly_limit=3
+clean_requirements_on_remove=True
+best=False
+skip_if_unavailable=False
+cachedir=/var/cache/dnf
+install_weak_deps=0
+keepcache=True
+tsflags=nodocs
+EOF
 
 COPY <<EOF /etc/yum.repos.d/ceph.repo
 [Ceph]
 name=Ceph packages for \$basearch
-baseurl=https://download.ceph.com/rpm-${SPDK_CEPH_VERSION?}/el\$releasever/\$basearch
+baseurl=https://download.ceph.com/rpm-${SPDK_CEPH_VERSION:?}/el\$releasever/\$basearch
 enabled=1
 priority=2
 gpgcheck=1
@@ -23,47 +64,27 @@ gpgcheck=1
 gpgkey=https://download.ceph.com/keys/release.asc
 EOF
 
-ARG SPDK_PKGDEP_ARGS \
-    SPDK_CONFIGURE_ARGS \
-    SPDK_MAKEFLAGS \
-    SPDK_DISABLE_VPCLMULQDQ \
-    SPDK_DISABLE_AVX512
-
-WORKDIR /src
-COPY . .
-
 RUN \
     --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
     --mount=type=cache,target=/root/.cache/pip \
-    dnf install -y 'dnf-command(config-manager)' \
+    dnf install $DNF_OPTS -y 'dnf-command(config-manager)' \
     && dnf config-manager --set-enabled crb \
-    && dnf install -y \
+    && dnf install $DNF_OPTS -y \
         rpm-build \
         git-core \
     && rpm -vih https://buildlogs.centos.org/centos/9-stream/storage/x86_64/ceph-reef/Packages/t/thrift-0.15.0-3.el9s.x86_64.rpm \
     && scripts/pkgdep.sh $SPDK_PKGDEP_ARGS \
-    && dnf update -y
-
-# Disable RDSEED, see https://github.com/ceph/ceph-nvmeof/issues/259
-RUN \
-    sed -i "s/^\( \+'RDSEED'\)/#\1/" dpdk/config/x86/meson.build
-# If we run from github disable also VPCLMULQDQ as some of github's runners don't have it
-RUN \
-    if [[ -n "$SPDK_DISABLE_VPCLMULQDQ" ]]; then sed -i "s/^\( \+'VPCLMULQDQ'\)/#\1/" dpdk/config/x86/meson.build ; fi
-RUN \
-    if [[ -n "$SPDK_DISABLE_AVX512" ]]; then sed -i "s/^\( \+'AVX512\)/#\1/" dpdk/config/x86/meson.build ; fi
-RUN \
-    cat dpdk/config/x86/meson.build
+    && dnf $DNF_OPTS update -y
 
 RUN \
     --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
     DEPS="no" \
-    SPDK_VERSION=${SPDK_VERSION?} \
+    SPDK_VERSION=${SPDK_VERSION:?} \
     RPM_RELEASE=0 \
     MAKEFLAGS=$SPDK_MAKEFLAGS \
-    rpmbuild/rpm.sh $SPDK_CONFIGURE_ARGS
+    rpmbuild/rpm.sh $SPDK_CONFIGURE_ARGS --target-arch="${SPDK_TARGET_ARCH:?}"
 
 # build bdevperf example, will not be a part of generated rpm
 RUN make -C ./examples/bdev/bdevperf
@@ -76,7 +97,8 @@ COPY --from=build /root/rpmbuild/rpm /rpm
 FROM registry.access.redhat.com/ubi9/ubi as spdk
 
 ARG SPDK_CEPH_VERSION \
-    SPDK_VERSION
+    SPDK_VERSION \
+    DNF_OPTS
 
 ARG SPDK_CENTOS_BASE="https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/"
 # This would become obsolete as the release rolls out new packages
@@ -121,6 +143,7 @@ LABEL io.spdk.version="$SPDK_VERSION" \
 LABEL org.centos.url="$SPDK_CENTOS_BASE" \
       org.centos.version="$SPDK_CENTOS_REPO_VER"
 
+COPY --from=build /etc/yum.conf /etc/yum.conf
 COPY --from=build /etc/yum.repos.d/ceph.repo /etc/yum.repos.d/ceph.repo
 
 RUN \
@@ -129,9 +152,9 @@ RUN \
     --mount=type=cache,target=/var/lib/dnf \
     rpm -vih $SPDK_CENTOS_BASE/centos-stream-repos-$SPDK_CENTOS_REPO_VER.noarch.rpm \
              $SPDK_CENTOS_BASE/centos-gpg-keys-$SPDK_CENTOS_REPO_VER.noarch.rpm \
-             https://buildlogs.centos.org/centos/9-stream/storage/x86_64/ceph-reef/Packages/t/thrift-0.15.0-3.el9s.x86_64.rpm \
-    && dnf install -y /rpm/$(uname -m)/*.rpm \
-    && dnf update -y
+    && rpm -vih https://buildlogs.centos.org/centos/9-stream/storage/x86_64/ceph-reef/Packages/t/thrift-0.15.0-3.el9s.x86_64.rpm \
+    && dnf $DNF_OPTS install -y /rpm/$(uname -m)/*.rpm \
+    && dnf $DNF_OPTS update -y
 
 ENTRYPOINT [ "/usr/local/bin/nvmf_tgt" ]
 CMD [ "-u", "-r", "/var/tmp/spdk.sock" ]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ setup: ## Configure huge-pages (requires sudo/root password)
 	@echo Actual Hugepages allocation: $$(cat $(HUGEPAGES_DIR))
 	@[ $$(cat $(HUGEPAGES_DIR)) -eq $(HUGEPAGES) ]
 
-build pull logs: SVC ?= spdk bdevperf nvmeof nvmeof-devel nvmeof-cli discovery ceph
+build pull logs: SVC ?= ceph spdk bdevperf nvmeof nvmeof-devel nvmeof-cli discovery
 
 build: export NVMEOF_GIT_REPO != git remote get-url origin
 build: export NVMEOF_GIT_BRANCH != git name-rev --name-only HEAD

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,9 +53,7 @@ services:
     ulimits:
       nofile: $NVMEOF_NOFILE
       memlock: -1
-  ceph:
-    image: $QUAY_CEPH:$CEPH_CLUSTER_VERSION
-    container_name: ceph
+  ceph-base:
     build:
       context: .
       dockerfile: Dockerfile.ceph
@@ -68,20 +66,27 @@ services:
     entrypoint: >-
       sh -c './vstart.sh --new $$CEPH_VSTART_ARGS &&
       ceph osd pool create rbd &&
+      ceph dashboard nvmeof-gateway-add -i <(echo nvmeof-devel:5500) nvmeof.1 &&
       sleep infinity'
     healthcheck:
       test: ceph osd pool stats rbd
       start_period: 6s
       interval: 3s
+      retries: 10
     volumes:
       - ceph-conf:/etc/ceph
     networks:
       default:
         ipv4_address: 192.168.13.2
         ipv6_address: 2001:db8::2
+  ceph:
+    extends:
+      service: ceph-base
+    image: $QUAY_CEPH:$CEPH_CLUSTER_VERSION
+    container_name: ceph
   ceph-devel:
     extends:
-      service: ceph
+      service: ceph-base
     image: $QUAY_CEPH-devel:$CEPH_CLUSTER_VERSION
     container_name: ceph-devel
     volumes:
@@ -192,7 +197,7 @@ services:
       args:
         NVMEOF_TARGET: cli
   nvmeof-devel:
-    image: nvmeof-devel
+    image: nvmeof-devel:$NVMEOF_VERSION
     # Runs from source code in current dir
     extends:
       service: nvmeof-base
@@ -201,6 +206,9 @@ services:
       args:
         # https://daobook.github.io/pdm/usage/dependency/#add-development-only-dependencies
         PDM_INSTALL_DEV: "-d"
+    depends_on:
+      ceph-devel:
+        condition: service_healthy
     volumes:
       - ./control:/src/control
   nvmeof-cli:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,11 +64,9 @@ services:
       labels:
         io.ceph.nvmeof:
     environment:
-      CEPH_VSTART_ARGS:
-      VSTART_ARGS: --without-dashboard --memstore
       TOUCHFILE: /tmp/ceph.touch
     entrypoint: >-
-      sh -c './vstart.sh --new $$VSTART_ARGS &&
+      sh -c './vstart.sh --new $$CEPH_VSTART_ARGS &&
       ceph osd pool create rbd &&
       sleep infinity'
     healthcheck:
@@ -81,6 +79,13 @@ services:
       default:
         ipv4_address: 192.168.13.2
         ipv6_address: 2001:db8::2
+  ceph-devel:
+    extends:
+      service: ceph
+    image: $QUAY_CEPH-devel:$CEPH_CLUSTER_VERSION
+    container_name: ceph-devel
+    volumes:
+      - ${CEPH_DEVEL_MGR_PATH?Define the path of your local Ceph repo}/src/pybind/mgr:/usr/share/ceph/mgr
   nvmeof-base:
     build:
       context: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,6 +59,7 @@ services:
       dockerfile: Dockerfile.ceph
       args:
         CEPH_CLUSTER_VERSION:
+        CEPH_CLUSTER_CEPH_REPO_BASEURL:
       labels:
         io.ceph.nvmeof:
     environment:
@@ -75,6 +76,8 @@ services:
       retries: 10
     volumes:
       - ceph-conf:/etc/ceph
+    ulimits:
+      nofile: 1024
     networks:
       default:
         ipv4_address: 192.168.13.2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,14 +13,13 @@ services:
         SPDK_CEPH_VERSION:
         SPDK_PKGDEP_ARGS:
         SPDK_CONFIGURE_ARGS:
+        SPDK_TARGET_ARCH:
         SPDK_MAKEFLAGS:
         SPDK_NAME:
         SPDK_SUMMARY:
         SPDK_DESCRIPTION:
         SPDK_URL:
         SPDK_MAINTAINER: $MAINTAINER
-        SPDK_DISABLE_VPCLMULQDQ:
-        SPDK_DISABLE_AVX512:
         BUILD_DATE:
         SPDK_GIT_REPO:
         SPDK_GIT_BRANCH:
@@ -67,7 +66,7 @@ services:
     entrypoint: >-
       sh -c './vstart.sh --new $$CEPH_VSTART_ARGS &&
       ceph osd pool create rbd &&
-      ceph dashboard nvmeof-gateway-add -i <(echo nvmeof-devel:5500) nvmeof.1 &&
+      echo ceph dashboard nvmeof-gateway-add -i <(echo nvmeof-devel:5500) nvmeof.1 &&
       sleep infinity'
     healthcheck:
       test: ceph osd pool stats rbd

--- a/mk/containerized.mk
+++ b/mk/containerized.mk
@@ -65,8 +65,13 @@ down: override OPTS += --volumes --remove-orphans
 
 events: ## Receive real-time events from containers
 
+.PHONY:
 docker_compose_clean: down
 	$(DOCKER) system prune --all --force --volumes --filter label="io.ceph.nvmeof"
+
+.PHONY:
+clean_cache: ## Clean the Docker build cache
+	$(DOCKER) builder prune --force --all
 
 CLEAN += docker_compose_clean
 ALL += pull up ps

--- a/mk/containerized.mk
+++ b/mk/containerized.mk
@@ -66,6 +66,10 @@ down: override OPTS += --volumes --remove-orphans
 events: ## Receive real-time events from containers
 
 .PHONY:
+image_name:
+	@$(DOCKER_COMPOSE) config --format=json | jq '.services."$(SVC)".image'
+
+.PHONY:
 docker_compose_clean: down
 	$(DOCKER) system prune --all --force --volumes --filter label="io.ceph.nvmeof"
 

--- a/mk/containerized.mk
+++ b/mk/containerized.mk
@@ -19,7 +19,7 @@ pull: ## Download SVC images
 build:  ## Build SVC images
 build: DOCKER_COMPOSE_ENV = DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1
 
-GIT_LATEST_TAG != git describe --tags --abbrev=0
+GIT_LATEST_TAG != git describe --tags --abbrev=0 2>/dev/null
 push: ## Push nvmeof and nvmeof-cli containers images to quay.io registries
 	docker tag $(QUAY_NVMEOF):$(VERSION) $(QUAY_NVMEOF):$(GIT_LATEST_TAG)
 	docker tag $(QUAY_NVMEOFCLI):$(VERSION) $(QUAY_NVMEOFCLI):$(GIT_LATEST_TAG)

--- a/mk/misc.mk
+++ b/mk/misc.mk
@@ -5,6 +5,7 @@ NVMEOF_CLI = $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE) run --rm nvmeof-cli --serve
 NVMEOF_CLI_IPV6 = $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE) run --rm nvmeof-cli --server-address $(NVMEOF_IPV6_ADDRESS) --server-port $(NVMEOF_GW_PORT)
 
 alias: ## Print bash alias command for the nvmeof-cli. Usage: "eval $(make alias)"
-	@echo alias cephnvmf=\"$(NVMEOF_CLI)\" \; alias cephnvmf-ipv6=\'$(NVMEOF_CLI_IPV6)\'
+	@echo alias cephnvmf=\"$(strip $(NVMEOF_CLI))\"
+	@echo alias cephnvmf-ipv6=\"$(strip $(NVMEOF_CLI_IPV6))\"
 
 .PHONY: alias

--- a/mk/misc.mk
+++ b/mk/misc.mk
@@ -5,7 +5,7 @@ NVMEOF_CLI = $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE) run --rm nvmeof-cli --serve
 NVMEOF_CLI_IPV6 = $(DOCKER_COMPOSE_ENV) $(DOCKER_COMPOSE) run --rm nvmeof-cli --server-address $(NVMEOF_IPV6_ADDRESS) --server-port $(NVMEOF_GW_PORT)
 
 alias: ## Print bash alias command for the nvmeof-cli. Usage: "eval $(make alias)"
-	@echo alias cephnvmf=\"$(strip $(NVMEOF_CLI))\"
+	@echo alias cephnvmf=\"$(strip $(NVMEOF_CLI))\"\;
 	@echo alias cephnvmf-ipv6=\"$(strip $(NVMEOF_CLI_IPV6))\"
 
 .PHONY: alias


### PR DESCRIPTION
This PR is to make it easier for developers to test Ceph-Dashboard when doing integration testing.
Fixes: #357
Fixes: #382

## docker: add Ceph-Dashboard support

Include `ceph-mgr-dashboard` package and deps (grpcio).

Create new ceph-devel service to mount local ceph repo inside the container (for dev purposes).

## docker: add ceph-devel container  
Also:
* Extend healthcheck retries to prevent random failures
* Configure nvmeof gateway in Ceph
* Fix nvmeof-cli aliases (the leading space prevented the shell from
  adding these to the history)
 * Add syntax highlight tag to the Dockerfile.spdk

## docker: add custom Ceph repo
    
* A custom Ceph YUM repo (usually a ceph-ci generated/Chacra one, like
  https://3.chacra.ceph.com/r/ceph/ceph-nvmeof-mon/c1ced49d133c2bcd1fa9311a35688bf641b93c76/centos/9/flavors/default/)
* New make targer `clean_cache` to prune builder cache (required when
  changing the Ceph YUM Repo.
* Repo/RPM GPG check disabled. Not ideal, but ceph-ci builds don't sign
  RPMs.
* Specify ulimits (nofile 1024) for the Ceph container. In Docker CE,
  ceph-mon's ms_dispatch thread iterated through all available file
  descriptors and tried to close them. By setting nofile to 1024, this
  is heavily constrained. This behaviour is not exhibited with
  Fedora's Moby-engine.
 
## docker: support target-arch in SPDK

* Remove exising handling for AVX512*, VPCLMULQDQ and RDSEED
  instructions.
* Replace it with spdk/configure --target-arc=<arch>
 * Tune SPDK's yum/dnf cache and settings.
    
## ci: remove nvmeof-devel dependency

nvmeof-devel is not required for pytests, since they're mounted via `run` CLI command.
    
## make: fix alias issue

Alias was not properly working for `cephnvmf*` as it was erased from the shell history.

## docker: save SPDK target arch as label

SPDK/DPDK relies on pretty modern CPU instruction sets, which renders that incompatible with certain servers (Ivy Bridge and older). This new `SPDK_TARGET_ARCH` setting allows setting that. The new default (`x86-64-v2`) could result in a less performant SPDK.

## ci: update upload-download artifact actions
    
The v4 of these actions provide 90% speed-ups by compressing artifacts.
Migration to this new action means zero cost.

 Additional core clean-up performed.
    
## ci: split ceph job and update checkout

There's no need for `ceph` to be built together with the rest of the nvmeof services. In fact this container could/should be pulled off to a separate repo/CI.    

## ci: cancel CI run when another starts
    
When a user pushes a change to a PR, if there was an ongoing CI run,
this will cancel any previous runs. This will save some CO2.