### PR TITLE
Make the "host" parameter mandatory in "host add" and "host del" CLI commands

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -935,6 +935,8 @@ class GatewayClient:
         """Add a host to a subsystem."""
 
         out_func, err_func = self.get_output_functions(args)
+        if not args.host:
+            self.cli.parser.error("--host argument is mandatory for add command")
         req = pb2.add_host_req(subsystem_nqn=args.subsystem, host_nqn=args.host)
         try:
             ret = self.stub.add_host(req)
@@ -975,6 +977,8 @@ class GatewayClient:
         """Delete a host from a subsystem."""
 
         out_func, err_func = self.get_output_functions(args)
+        if not args.host:
+            self.cli.parser.error("--host argument is mandatory for del command")
         req = pb2.remove_host_req(subsystem_nqn=args.subsystem, host_nqn=args.host)
 
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -389,6 +389,15 @@ class TestCreate:
     @pytest.mark.parametrize("host", host_list)
     def test_add_host(self, caplog, host):
         caplog.clear()
+        rc = 0
+        try:
+            cli(["host", "add", "--subsystem", subsystem])
+        except SystemExit as sysex:
+            rc = int(str(sysex))
+            pass
+        assert "error: --host argument is mandatory for add command" in caplog.text
+        assert rc == 2
+        caplog.clear()
         cli(["host", "add", "--subsystem", subsystem, "--host", host])
         if host == "*":
             assert f"Allowing open host access to {subsystem}: Successful" in caplog.text
@@ -499,6 +508,15 @@ class TestCreate:
 class TestDelete:
     @pytest.mark.parametrize("host", host_list)
     def test_remove_host(self, caplog, host, gateway):
+        caplog.clear()
+        rc = 0
+        try:
+            cli(["host", "del", "--subsystem", subsystem])
+        except SystemExit as sysex:
+            rc = int(str(sysex))
+            pass
+        assert "error: --host argument is mandatory for del command" in caplog.text
+        assert rc == 2
         caplog.clear()
         cli(["host", "del", "--subsystem", subsystem, "--host", host])
         if host == "*":


### PR DESCRIPTION
Fixes #361