### PR TITLE
🧹ANA interface cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The following command executes all the steps required to set up the NVMe-oF envi
 $ make demo
 docker-compose  exec  ceph bash -c "rbd -p rbd info demo_image || rbd -p rbd create demo_image --size 10M"
 rbd: error opening image demo_image: (2) No such file or directory
-docker-compose  run --rm nvmeof-cli --server-address 192.168.13.3 --server-port 5500 subsystem add --subsystem "nqn.2016-06.io.spdk:cnode1" --ana-reporting --enable-ha
+docker-compose  run --rm nvmeof-cli --server-address 192.168.13.3 --server-port 5500 subsystem add --subsystem "nqn.2016-06.io.spdk:cnode1" --enable-ha
 Adding subsystem nqn.2016-06.io.spdk:cnode1: Successful
 docker-compose  run --rm nvmeof-cli --server-address 192.168.13.3 --server-port 5500 namespace add --subsystem "nqn.2016-06.io.spdk:cnode1" --rbd-pool rbd --rbd-image demo_image
 Adding namespace 1 to nqn.2016-06.io.spdk:cnode1, load balancing group 1: Successful

--- a/control/cli.py
+++ b/control/cli.py
@@ -555,15 +555,12 @@ class GatewayClient:
             self.cli.parser.error("--subsystem argument is mandatory for add command")
         if args.force:
             self.cli.parser.error("--force argument is not allowed for add command")
-        if args.enable_ha and not args.ana_reporting:
-            self.cli.parser.error("ANA reporting must be enabled when HA is active")
         if args.subsystem == GatewayUtils.DISCOVERY_NQN:
             self.cli.parser.error("Can't add a discovery subsystem")
 
         req = pb2.create_subsystem_req(subsystem_nqn=args.subsystem,
                                         serial_number=args.serial_number,
                                         max_namespaces=args.max_namespaces,
-                                        ana_reporting=args.ana_reporting,
                                         enable_ha=args.enable_ha)
         try:
             ret = self.stub.create_subsystem(req)
@@ -603,8 +600,6 @@ class GatewayClient:
             self.cli.parser.error("--serial-number argument is not allowed for del command")
         if args.max_namespaces != None:
             self.cli.parser.error("--max-namespaces argument is not allowed for del command")
-        if args.ana_reporting:
-            self.cli.parser.error("--ana-reporting argument is not allowed for del command")
         if args.enable_ha:
             self.cli.parser.error("--enable-ha argument is not allowed for del command")
         if args.subsystem == GatewayUtils.DISCOVERY_NQN:
@@ -645,8 +640,6 @@ class GatewayClient:
         out_func, err_func = self.get_output_functions(args)
         if args.max_namespaces != None:
             self.cli.parser.error("--max-namespaces argument is not allowed for list command")
-        if args.ana_reporting:
-            self.cli.parser.error("--ana-reporting argument is not allowed for list command")
         if args.enable_ha:
             self.cli.parser.error("--enable-ha argument is not allowed for list command")
         if args.force:
@@ -719,7 +712,6 @@ class GatewayClient:
         argument("--subsystem", "-n", help="Subsystem NQN", required=False),
         argument("--serial-number", "-s", help="Serial number", required=False),
         argument("--max-namespaces", "-m", help="Maximum number of namespaces", type=int, required=False),
-        argument("--ana-reporting", "-a", help="Enable ANA reporting", action='store_true', required=False),
         argument("--enable-ha", "-t", help="Enable automatic HA", action='store_true', required=False),
         argument("--force", help="Delete subsytem's namespaces if any, then delete subsystem. If not set a subsystem deletion would fail in case it contains namespaces", action='store_true', required=False),
     ])
@@ -762,7 +754,6 @@ class GatewayClient:
             adrfam=adrfam,
             traddr=traddr,
             trsvcid=args.trsvcid,
-            auto_ha_state="AUTO_HA_UNSET",
         )
 
         try:

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -23,12 +23,6 @@ enum LogLevel {
     DEBUG = 4;
 }
 
-enum AutoHAState {
-    AUTO_HA_UNSET = 0;
-    AUTO_HA_OFF = 1;
-    AUTO_HA_ON = 2;
-}
-
 service Gateway {
 	// Creates a namespace from an RBD image
 	rpc namespace_add(namespace_add_req) returns (nsid_status) {}
@@ -148,8 +142,7 @@ message create_subsystem_req {
 	string subsystem_nqn = 1;
 	string serial_number = 2;
 	optional uint32 max_namespaces = 3;
-	bool ana_reporting = 4;
-	bool enable_ha = 5;
+	bool enable_ha = 4;
 }
 
 message delete_subsystem_req {
@@ -187,7 +180,6 @@ message create_listener_req {
 	string traddr = 3;
 	optional AddressFamily adrfam = 5;
 	optional uint32 trsvcid = 6;
-	optional AutoHAState auto_ha_state = 7;
 }
 
 message delete_listener_req {

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -13,7 +13,7 @@ subsys_list_count = 50
 
 def create_resource_by_index(i):
     subsystem = f"{subsystem_prefix}{i}"
-    cli(["subsystem", "add", "--subsystem", subsystem, "--ana-reporting", "--enable-ha" ])
+    cli(["subsystem", "add", "--subsystem", subsystem, "--enable-ha" ])
     cli(["namespace", "add", "--subsystem", subsystem, "--rbd-pool", pool, "--rbd-image", image, "--size", "16MiB", "--rbd-create-image"])
 
 def check_resource_by_index(i, caplog):
@@ -44,7 +44,6 @@ def test_create_get_subsys(caplog, config):
         # add a listener
         cli(["listener", "add", "--subsystem", f"{subsystem_prefix}0", "--gateway-name",
              gateway.name, "--traddr", "127.0.0.1", "--trsvcid", "5001"])
-        assert f"auto HA state: AUTO_HA_UNSET" in caplog.text
         assert f"Adding {subsystem_prefix}0 listener at 127.0.0.1:5001: Successful" in caplog.text
 
         # Change ANA group id for the first namesapce
@@ -76,7 +75,6 @@ def test_create_get_subsys(caplog, config):
             time.sleep(0.1)
 
         time.sleep(20)     # Make sure update() is over
-        assert f"auto HA state: AUTO_HA_ON" in caplog.text
         assert f"{subsystem_prefix}0 with ANA group id 4" in caplog.text
         assert f"Received request to set QOS limits for namespace using NSID 1 on {subsystem_prefix}0, R/W IOs per second: 2000 Read megabytes per second: 5" in caplog.text
         caplog.clear()

--- a/tests/test_omap_lock.py
+++ b/tests/test_omap_lock.py
@@ -273,8 +273,7 @@ def test_multi_gateway_concurrent_changes(config, image, conn_concurrent, caplog
                                            gateway_name="GatewayAAA",
                                            adrfam="ipv4",
                                            traddr="127.0.0.1",
-                                           trsvcid=5001,
-                                           auto_ha_state="AUTO_HA_UNSET")
+                                           trsvcid=5001)
     listener_ret = stubA.create_listener(listener_req)
     assert listener_ret.status == 0
     assert f"Received request to create GatewayAAA TCP ipv4 listener for {subsystem_prefix}0 at 127.0.0.1:5001" in caplog.text
@@ -320,8 +319,7 @@ def test_multi_gateway_listener_update(config, image, conn_concurrent, caplog):
                                            gateway_name="GatewayAAA",
                                            adrfam="ipv4",
                                            traddr="127.0.0.1",
-                                           trsvcid=5101,
-                                           auto_ha_state="AUTO_HA_UNSET")
+                                           trsvcid=5101)
     listener_ret = stubA.create_listener(listenerA_req)
     assert listener_ret.status == 0
     assert f"Received request to create GatewayAAA TCP ipv4 listener for {subsystem} at 127.0.0.1:5101" in caplog.text
@@ -331,8 +329,7 @@ def test_multi_gateway_listener_update(config, image, conn_concurrent, caplog):
                                            gateway_name="GatewayBBB",
                                            adrfam="ipv4",
                                            traddr="127.0.0.1",
-                                           trsvcid=5102,
-                                           auto_ha_state="AUTO_HA_UNSET")
+                                           trsvcid=5102)
     listener_ret = stubB.create_listener(listenerB_req)
     assert listener_ret.status == 0
     assert f"Received request to create GatewayBBB TCP ipv4 listener for {subsystem} at 127.0.0.1:5102" in caplog.text


### PR DESCRIPTION
## ANA interface cleanup
Fixes: #397, sub-issue 3
Remove `ana_reporting` & `auto_ha_state`. Use exclusively the subsystem [enable HA flag](https://github.com/baum/ceph-nvmeof/blob/b27c2f777be1e201ef7f1a553ef9b57f67cc317a/control/proto/gateway.proto#L145)

- pass the enable HA  subsystem flag to spdk as `ana_reporting`
- listeners checks the subsystem enable HA flag