### PR TITLE
Fix 'make up'

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Start ceph cluster
         run: |
-          make up SVC=ceph OPTS="--detach"
+          docker-compose up -d ceph
 
       - name: Wait for the ceph cluster container to become healthy
         timeout-minutes: 3
@@ -223,30 +223,9 @@ jobs:
           docker load < bdevperf.tar
 
       - name: Start containers
-        run: |
-          make up OPTS=--detach
-
-      - name: Wait for the ceph cluster container to become healthy
         timeout-minutes: 3
         run: |
-          while true; do
-            container_status=$(docker inspect --format='{{.State.Health.Status}}' ceph)
-            if [[ $container_status == "healthy" ]]; then
-              # success
-              exit 0
-            else
-              # Wait for a specific time before checking again
-              sleep ${{ env.WAIT_INTERVAL_SECS }}
-              echo -n .
-            fi
-          done
-
-      - name: Inform the Ceph monitor regarding the new Gateway
-        timeout-minutes: 3
-        run: |
-          set -x
-          GW_NAME=$(docker ps --format '{{.ID}}\t{{.Names}}' | awk '$2 ~ /nvmeof/ {print $1}')
-          docker-compose exec -T ceph ceph nvme-gw create $GW_NAME rbd ''
+          make up
 
       - name: Wait for the Gateway to be listening
         timeout-minutes: 3
@@ -303,7 +282,7 @@ jobs:
           . .env
           set -x
           echo -n "ℹ️  Starting bdevperf container"
-          make up  SVC=bdevperf OPTS="--detach"
+          docker-compose up -d bdevperf
           sleep 10
           echo "ℹ️  bdevperf start up logs"
           make logs SVC=bdevperf
@@ -495,7 +474,7 @@ jobs:
           }
 
           echo -n "ℹ️  Starting bdevperf container"
-          make up  SVC=bdevperf OPTS="--detach"
+          docker-compose up -d bdevperf
           sleep 10
           echo "ℹ️  bdevperf start up logs"
           make logs SVC=bdevperf

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,9 @@ build: export NVMEOF_GIT_MODIFIED_FILES != git status -s | grep -e "^ *M" | sed 
 build: export CEPH_CLUSTER_CEPH_REPO_BASEURL != curl -s https://shaman.ceph.com/api/repos/ceph/$(CEPH_BRANCH)/$(CEPH_SHA)/centos/9/ | jq -r '.[0].url'
 
 up: ## Launch services
-up: SVC ?= ceph nvmeof ## Services
-up: OPTS ?= --abort-on-container-exit --exit-code-from $(SVC) --remove-orphans
-#up: override OPTS += --scale nvmeof=$(SCALE)
+up: SCALE?= 1 ## Number of gateways
+up:
+	@$(CURDIR)/tests/ha/start_up.sh $(SCALE)
 
 clean: $(CLEAN) setup  ## Clean-up environment
 clean: override HUGEPAGES = 0

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Python wheel exported to:
 To avoid having to re-build container on every code change, developer friendly containers are provided:
 
 ```bash
-make up SVC="nvmeof-devel"
+docker-compose up nvmeof-devel
 ```
 
 Devel containers provide the same base layer as the production containers but with the source code mounted at run-time.

--- a/mk/containerized.mk
+++ b/mk/containerized.mk
@@ -7,12 +7,11 @@ DOCKER_COMPOSE != command -v docker-compose || (DOCKER=$$(command -v docker) && 
 ifndef DOCKER_COMPOSE
 $(error DOCKER_COMPOSE command not found. Please install from: https://docs.docker.com/engine/install/))
 endif
-DOCKER_COMPOSE_COMMANDS = pull build up run exec ps top images logs port \
+DOCKER_COMPOSE_COMMANDS = pull build run exec ps top images logs port \
 	pause unpause stop restart down events
 
 OPTS ?= ## Docker-compose subcommand options
-SCALE ?= 1 ## Number of instances
-CMD ?= ## Command to run with run/exec targets
+CMD ?=  ## Command to run with run/exec targets
 
 .PHONY: $(DOCKER_COMPOSE_COMMANDS) shell
 $(DOCKER_COMPOSE_COMMANDS):

--- a/tests/ha/sanity.sh
+++ b/tests/ha/sanity.sh
@@ -8,7 +8,7 @@ container_ip() {
 }
 
 echo -n "ℹ️  Starting bdevperf container"
-make up  SVC=bdevperf OPTS="--detach"
+docker-compose up -d bdevperf
 sleep 10
 echo "ℹ️  bdevperf start up logs"
 make logs SVC=bdevperf

--- a/tests/ha/start_up.sh
+++ b/tests/ha/start_up.sh
@@ -1,22 +1,39 @@
-set -ex
-docker-compose up -d --scale nvmeof=2 nvmeof
+set -e
+SCALE=2
+POOL="${RBD_POOL:-rbd}"
+# Check if argument is provided
+if [ $# -ge 1 ]; then
+    # Check if argument is an integer larger or equal than 1
+    if [ "$1" -eq "$1" ] 2>/dev/null && [ "$1" -ge 1 ]; then
+        # Set variable to the provided argument
+        SCALE="$1"
+    else
+        echo "Error: Argument must be an integer larger than 1." >&2
+        exit 1
+    fi
+fi
+echo ℹ️  Starting $SCALE nvmeof gateways
+docker-compose up -d --remove-orphans --scale nvmeof=$SCALE nvmeof
 
-echo "Wait for ceph container to become healthy"
+# Waiting for the ceph container to become healthy
 while true; do
   container_status=$(docker inspect --format='{{.State.Health.Status}}' ceph)
-  if [[ $container_status == "healthy" ]]; then
+  if [ "$container_status" = "healthy" ]; then
     # success
     break
   else
     # Wait for a specific time before checking again
     sleep 1
-    echo -n .
+    printf .
   fi
 done
-docker ps
+echo ✅ ceph is healthy
+echo ℹ️  Running processes of services
+docker-compose top
 
-# Send nvme-gw create for both gateways
-for i in $(seq 2); do
+echo ℹ️  Send nvme-gw create for all gateways
+for i in $(seq $SCALE); do
   GW_NAME=$(docker ps --format '{{.ID}}\t{{.Names}}' | grep -v discovery | awk '$2 ~ /nvmeof/ && $2 ~ /'$i'/ {print $1}')
-  docker-compose exec -T ceph ceph nvme-gw create $GW_NAME rbd ''
+  echo  📫 nvme-gw create gateway: \'$GW_NAME\' pool: \'$POOL\', group: \'\' \(empty string\)
+  docker-compose exec -T ceph ceph nvme-gw create $GW_NAME $POOL ''
 done


### PR DESCRIPTION
# Send nvme-gw create for all gateways

## Fixes: #482 

## Usage
```shelll
$ make up SCALE=3
ℹ️ Starting 3 nvmeof gateways
[+] Running 6/6
 ✔ Network ceph-nvmeof_default     Created                                                                     0.1s
 ✔ Volume "ceph-nvmeof_ceph-conf"  Created                                                                     0.0s
 ✔ Container ceph                  Healthy                                                                     0.0s
 ✔ Container ceph-nvmeof-nvmeof-3  Started                                                                     0.0s
 ✔ Container ceph-nvmeof-nvmeof-1  Started                                                                     0.0s
 ✔ Container ceph-nvmeof-nvmeof-2  Started                                                                     0.0s
✅ ceph is healthy
ℹ️ Running processes of services
ceph
UID   PID       PPID      C    STIME   TTY   TIME       CMD
167   2049966   2049944   0    12:51   ?     00:00:00   /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep infinity
167   2050078   2049966   2    12:51   ?     00:00:00   /usr/bin/ceph-mon -i a -c /etc/ceph/ceph.conf
167   2050247   2049966   33   12:51   ?     00:00:04   /usr/bin/ceph-mgr -i x -c /etc/ceph/ceph.conf
167   2050651   2049966   0    12:51   ?     00:00:00   /usr/bin/ceph-osd -i 0 -c /etc/ceph/ceph.conf
167   2050764   2049966   0    12:51   ?     00:00:00   /usr/bin/ceph-osd -i 1 -c /etc/ceph/ceph.conf
167   2050877   2049966   0    12:51   ?     00:00:00   /usr/bin/ceph-osd -i 2 -c /etc/ceph/ceph.conf

ceph-nvmeof-nvmeof-1
UID    PID       PPID      C    STIME   TTY   TIME       CMD
root   2051532   2051510   0    12:51   ?     00:00:00   python3 -m control -c /src/ceph-nvmeof.conf

ceph-nvmeof-nvmeof-2
UID    PID       PPID      C    STIME   TTY   TIME       CMD
root   2051189   2051168   36   12:51   ?     00:00:00   python3 -m control -c /src/ceph-nvmeof.conf
root   2051406   2051189   0    12:51   ?     00:00:00   /usr/bin/ceph-nvmeof-monitor-client --gateway-name 387de52051bd --gateway-address 0.0.0.0:5500 --gateway-pool rbd --gateway-group --monitor-address 0.0.0.0:5499 -c /etc/ceph/ceph.conf -n client.admin -k /etc/ceph/keyring

ceph-nvmeof-nvmeof-3
UID    PID       PPID      C    STIME   TTY   TIME       CMD
root   2051335   2051314   36   12:51   ?     00:00:00   python3 -m control -c /src/ceph-nvmeof.conf
root   2051592   2051335   0    12:51   ?     00:00:00   /usr/bin/ceph-nvmeof-monitor-client --gateway-name c9759b405872 --gateway-address 0.0.0.0:5500 --gateway-pool rbd --gateway-group --monitor-address 0.0.0.0:5499 -c /etc/ceph/ceph.conf -n client.admin -k /etc/ceph/keyring

ℹ️ Send nvme-gw create for all gateways
📫 nvme-gw create gateway: '826d3daaf3d1' pool: 'rbd', group: '' (empty string) 2024-03-12T12:51:41.121+0000 7fc516097640 -1 WARNING: all dangerous and experimental features are enabled. 2024-03-12T12:51:41.133+0000 7fc516097640 -1 WARNING: all dangerous and experimental features are enabled. 
📫 nvme-gw create gateway: '387de52051bd' pool: 'rbd', group: '' (empty string) 2024-03-12T12:51:41.621+0000 7fa1d56ac640 -1 WARNING: all dangerous and experimental features are enabled. 2024-03-12T12:51:41.634+0000 7fa1d56ac640 -1 WARNING: all dangerous and experimental features are enabled. 
📫 nvme-gw create gateway: 'c9759b405872' pool: 'rbd', group: '' (empty string) 2024-03-12T12:51:42.998+0000 7f84b3479640 -1 WARNING: all dangerous and experimental features are enabled. 2024-03-12T12:51:43.012+0000 7f84b3479640 -1 WARNING: all dangerous and experimental features are enabled.
```