### PR TITLE
server: fix missing group_id

### DIFF
--- a/control/server.py
+++ b/control/server.py
@@ -80,6 +80,7 @@ class GatewayServer:
         self.monitor_client_process = None
         self.ceph_utils = None
         self.rpc_lock = threading.Lock()
+        self.group_id = 0
 
         self.name = self.config.get("gateway", "name")
         if not self.name:


### PR DESCRIPTION
Fixes: #558

When mon client is disabled, the following stack trace appears:

```
nvmeof-1  | [08-Apr-2024 15:18:46] INFO server.py:244: Starting ceph nvmeof discovery service
nvmeof-1  | [08-Apr-2024 15:18:46] ERROR server.py:107: GatewayServer exception occurred:
nvmeof-1  | Traceback (most recent call last):
nvmeof-1  |   File "/src/control/__main__.py", line 43, in <module>
nvmeof-1  |     gateway.serve()
nvmeof-1  |   File "/src/control/server.py", line 177, in serve
nvmeof-1  |     self.gateway_rpc = GatewayService(self.config, gateway_state, self.rpc_lock, omap_lock, self.group_id, self.spdk_rpc_client, self.ceph_utils)
nvmeof-1  | AttributeError: 'GatewayServer' object has no attribute 'group_id'
nvmeof-1  | [08-Apr-2024 15:18:46] INFO server.py:391: Aborting (999a3cf6a97a) pid 37...
nvmeof-1  | [08-Apr-2024 15:18:46] INFO state.py:354: nvmeof.state omap object already exists.
nvmeof-1  | [08-Apr-2024 15:18:46] INFO discovery.py:322: log pages info from omap: nvmeof.state
nvmeof-1  | [08-Apr-2024 15:18:47] INFO discovery.py:330: discovery addr: 0.0.0.0 port: 8009
nvmeof-1  | [08-Apr-2024 15:18:47] DEBUG discovery.py:1052: waiting for connection...
nvmeof-1  | [08-Apr-2024 15:18:47] INFO server.py:423: Terminating discovery service...
nvmeof-1  | [08-Apr-2024 15:18:47] DEBUG discovery.py:1072: received a ctrl+C interrupt. exiting...
nvmeof-1  | [08-Apr-2024 15:18:47] INFO server.py:430: Discovery service terminated
nvmeof-1  | [08-Apr-2024 15:18:47] INFO server.py:128: Exiting the gateway process.
nvmeof-1  | [08-Apr-2024 15:18:47] INFO utils.py:391: Will compress log file /var/log/ceph/nvmeof-999a3cf6a97a/nvmeof-log to /var/log/ceph/nvmeof-999a3cf6a97a/nvmeof-log.gz
nvmeof-1  | Traceback (most recent call last):
nvmeof-1  |   File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
nvmeof-1  |     return _run_code(code, main_globals, None,
nvmeof-1  |   File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
nvmeof-1  |     exec(code, run_globals)
nvmeof-1  |   File "/src/control/__main__.py", line 43, in <module>
nvmeof-1  |     gateway.serve()
nvmeof-1  |   File "/src/control/server.py", line 177, in serve
nvmeof-1  |     self.gateway_rpc = GatewayService(self.config, gateway_state, self.rpc_lock, omap_lock, self.group_id, self.spdk_rpc_client, self.ceph_utils)
nvmeof-1  | AttributeError: 'GatewayServer' object has no attribute 'group_id'
```