### PR TITLE
4gws fixes

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -869,12 +869,11 @@ class GatewayService(pb2_grpc.GatewayServicer):
                             context.set_details(f"{ex}")
                         return pb2.req_status()
         for ana_key in inaccessible_ana_groups :
-            with self.omap_lock(context=context):
-                ret_recycle = self.namespace_recycle_safe(ana_key, peer_msg)
-                if ret_recycle != 0:
-                    errmsg = f"Failure recycle namespaces of ana group {ana_key} "
-                    self.logger.error(errmsg)
-                    return pb2.req_status(status=ret_recycle , error_message=errmsg)
+            ret_recycle = self.namespace_recycle_safe(ana_key, peer_msg)
+            if ret_recycle != 0:
+                errmsg = f"Failure recycle namespaces of ana group {ana_key} "
+                self.logger.error(errmsg)
+                return pb2.req_status(status=ret_recycle , error_message=errmsg)
         return pb2.req_status(status=True)
 
     def choose_anagrpid_for_namespace(self, nsid) ->int:

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -651,6 +651,8 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 )
                 self.subsys_ha.pop(request.subsystem_nqn)
                 self.subsys_max_ns.pop(request.subsystem_nqn)
+                if request.subsystem_nqn in self.subsystem_listeners:
+                    self.subsystem_listeners.pop(request.subsystem_nqn)
                 self.logger.debug(f"delete_subsystem {request.subsystem_nqn}: {ret}")
             except Exception as ex:
                 self.logger.exception(delete_subsystem_error_prefix)

--- a/tests/ha/setup_4gws.sh
+++ b/tests/ha/setup_4gws.sh
@@ -42,8 +42,9 @@ for i in $(seq $NUM_SUBSYSTEMS); do
     for g in $(seq $NUM_GATEWAYS); do
         GW_NAME=$(gw_name $g)
         GW_IP=$(gw_ip $g)
+        ADDR=0.0.0.0
         PORT=4420
-        docker-compose  run --rm nvmeof-cli --server-address $GW_IP --server-port 5500 listener add  --subsystem $NQN --host-name $GW_NAME --traddr $GW_IP --trsvcid $PORT
+        docker-compose  run --rm nvmeof-cli --server-address $GW_IP --server-port 5500 listener add  --subsystem $NQN --host-name $GW_NAME --traddr $ADDR --trsvcid $PORT
     done
 done
 
@@ -53,7 +54,6 @@ for g in $(seq $NUM_GATEWAYS); do
     echo "Verify $i $GW_NAME $GW_IP"
     GW_NAME=$(gw_name $g)
     GW_IP=$(gw_ip $g)
-    PORT=4420
     subs=$(docker-compose  run --rm nvmeof-cli --server-address $GW_IP --server-port 5500 get_subsystems 2>&1 | sed 's/Get subsystems://')
 
     # verify all resources found in get subsystems


### PR DESCRIPTION
# several fixes

- tweak the 4gws test,to allow gateway IP change by using '0.0.0.0' as listener address
- control/grpc.py
   - tweak listener matching logic, to disallow the creation of the same address/port listener on the same gateway only.
   - revert the OMAP lock from recycle
   - fix subsystem listeners state  clean-up