### PR TITLE
push images to private registry on merge

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -645,7 +645,37 @@ jobs:
           make down
           make clean
 
-  push-to-registry:
+  push-images-to-private-registry:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+    needs: [pytest, demo, discovery, ha]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download container images
+        uses: actions/download-artifact@v4
+        with:
+          name: container_images
+
+      - name: Load container images
+        run: |
+          docker load < nvmeof.tar
+          docker load < nvmeof-cli.tar
+
+      - name: Login to quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.CONTAINER_REGISTRY }}
+          username: '${{ vars.CONTAINER_PRIVATE_REGISTRY_USERNAME }}'
+          password: '${{ secrets.CONTAINER_PRIVATE_REGISTRY_PASSWORD }}'
+
+      - name: Publish nvmeof containers when release/tag is created
+        run: |
+          make push
+
+  push-images-to-ceph-registry:
     if: github.event_name == 'release'
     needs: [pytest, demo, discovery, ha]
     runs-on: ubuntu-latest


### PR DESCRIPTION
The nvmeof images will be pushed to private registry on every merge to devel.
Those images will be used by CI.