### PR TITLE
control/server.py: Enable DSA to offload and accelerate CRC calculation

### DIFF
--- a/.env
+++ b/.env
@@ -57,7 +57,7 @@ SPDK_URL="https://spdk.io"
 
 SPDK_PKGDEP_ARGS="--rbd"
 # check spdk/configure --help
-SPDK_CONFIGURE_ARGS="--with-rbd --disable-tests --disable-unit-tests --disable-examples --enable-debug"
+SPDK_CONFIGURE_ARGS="--with-rbd --with-idxd --disable-tests --disable-unit-tests --disable-examples --enable-debug"
 SPDK_TARGET_ARCH="x86-64-v2"
 SPDK_MAKEFLAGS=
 SPDK_CENTOS_BASE="https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/"

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -66,6 +66,9 @@ tgt_path = /usr/local/bin/nvmf_tgt
 timeout = 60.0
 #log_level = WARNING
 
+# True / False to enable dsa
+# enable_dsa = False
+
 # Example value: -m 0x3 -L all
 # tgt_cmd_extra_args =
 


### PR DESCRIPTION
Intel® DSA can generate and test CRC checksum. This feature has already been implemented in SPDK. Enabling this feature allows for offloading and accelerating CRC calculations in NVMe-oF.
﻿