### PR TITLE
tests/test_grpc.py: fix error

### DIFF
--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -68,13 +68,14 @@ def test_create_get_subsys(caplog, config):
         ceph_utils.execute_ceph_monitor_command("{" + f'"prefix":"nvme-gw create", "id": "{gateway.name}", "pool": "{pool}", "group": ""' + "}")
         gateway.serve()
 
+        time.sleep(20)     # Make sure update() is over
+
         for i in range(subsys_list_count):
             cli(["--format", "plain", "subsystem", "list"])
             assert "Exception" not in caplog.text
             assert "No subsystems" not in caplog.text
             time.sleep(0.1)
 
-        time.sleep(20)     # Make sure update() is over
         assert f"{subsystem_prefix}0 with ANA group id 1" in caplog.text
         assert f"Received request to set QOS limits for namespace using NSID 1 on {subsystem_prefix}0, R/W IOs per second: 2000 Read megabytes per second: 5" in caplog.text
         caplog.clear()


### PR DESCRIPTION
# tests/test_grpc.py: fix error

2024-06-27 07:13:45 [    INFO] Received request to list all subsystems, context: <grpc._server._Context object at 0x7f074c1ccac0>, client address: IPv6 [::1]:48924 (grpc.py:2379)
2024-06-27 07:13:45 [    INFO] Received request to create subsystem nqn.2016-06.io.spdk:cnode14, enable_ha: True, max_namespaces: 256, context: None (grpc.py:509)
2024-06-27 07:13:45 [    INFO] No subsystems (cli.py:782)
2024-06-27 07:13:45 [   ERROR] GatewayServer exception occurred: (server.py:111)
Traceback (most recent call last):
  File "/src/tests/test_grpc.py", line 74, in test_create_get_subsys
    assert "No subsystems" not in caplog.text