### PR TITLE
ceph: avoid becoming healthy before certs/keys are generated

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,12 +66,12 @@ services:
       TOUCHFILE: /tmp/ceph.touch
     entrypoint: >-
       sh -c './vstart.sh --new $$CEPH_VSTART_ARGS &&
-      ceph osd pool create rbd &&
       echo ceph dashboard nvmeof-gateway-add -i <(echo nvmeof-devel:5500) nvmeof.1 &&
       pushd /etc/ceph &&
       openssl req -x509 -newkey rsa:4096 -nodes -keyout server.key -out server.crt -days 3650 -subj /CN=my.server  -addext "subjectAltName = IP:192.168.13.3, IP:0.0.0.0" &&
       openssl req -x509 -newkey rsa:4096 -nodes -keyout client.key -out client.crt -days 3650 -subj /CN=client1 &&
       popd &&
+      ceph osd pool create rbd &&
       sleep infinity'
     healthcheck:
       test: ceph osd pool stats rbd


### PR DESCRIPTION
# ceph: avoid becoming healthy before certs/keys are generated

example of error: https://github.com/ceph/ceph-nvmeof/actions/runs/9760366985/job/26941165767