### PR TITLE
github ci: ensure that each artifact has a unique name

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload container images
         uses: actions/upload-artifact@v4
         with:
-          name: container_images
+          name: container_images-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: |
             nvmeof.tar
             nvmeof-cli.tar
@@ -76,7 +76,7 @@ jobs:
       - name: Upload container images
         uses: actions/upload-artifact@v4
         with:
-          name: container_images_ceph
+          name: container_images_ceph-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: |
             ceph.tar
 
@@ -188,7 +188,7 @@ jobs:
         if: steps.check_coredumps.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: core_pytest_${{ matrix.test }}
+          name: core_pytest_${{ matrix.test }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: /tmp/coredump/core.*
 
       - name: Display logs
@@ -325,7 +325,7 @@ jobs:
         if: steps.check_coredumps.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: core_demo
+          name: core_demo-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: /tmp/coredump/core.*
 
       # For debugging purposes (provides an SSH connection to the runner)
@@ -517,7 +517,7 @@ jobs:
         if: steps.check_coredumps.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: core_demo
+          name: core_demo-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: /tmp/coredump/core.*
 
       - name: Display logs
@@ -621,7 +621,7 @@ jobs:
         if: steps.check_coredumps.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: core_demo
+          name: core_demo-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: /tmp/coredump/core.*
 
       - name: Copy ceph logs
@@ -632,7 +632,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ceph_out_${{ matrix.test }}
+          name: ceph_out_${{ matrix.test }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: /tmp/out/*
 
       - name: Display logs


### PR DESCRIPTION
# github ci: ensure that each artifact has a unique name

Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
See: https://github.com/ceph/ceph-nvmeof/actions/runs/9828494951/job/27133077089?pr=745