### PR TITLE
Create "ceph-nvmeof" CLI command to use nvmeof-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+# Publishes official python package at https://pypi.org/project/ceph-nvmeof/
+# This is official release, and will be pushed to pypi when a new tag is pushed in repo.
+# Usage: pip install ceph-nvmeof==1.2.15
+
+# Also publishes dev python package at https://test.pypi.org/p/ceph-nvmeof
+# This is for dev releases, and will be pushed to test pypi on all merges to "devel" branch.
+# Usage: `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ceph-nvmeof==1.2.15`
+
+name: Publish release to PyPI
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - 'devel'
+  release:
+    types:
+      - published 
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: 'Python Version'
+        required: false
+        type: string
+      pdm_version:
+        description: 'PDM Version'
+        required: false
+        type: string
+      pypi_env:
+        description: 'Push to test.pypi (dev) or pypi (prod). And `dev-debug-version` pushes to test.pypi with a test package version.'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev 
+          - prod
+          - dev-debug-version
+      ref:
+        description: 'Build using this branch, tag or SHA'
+        required: false
+        type: string
+
+env:
+  DEFAULT_PYTHON: ${{ inputs.python_version || '3.9' }}
+  DEFAULT_PDM: ${{ inputs.pdm_version || '2.7.4' }}
+  REF: ${{ inputs.ref || 'devel' }} 
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{env.REF}} 
+      - uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: ${{env.DEFAULT_PYTHON}}
+          version: ${{env.DEFAULT_PDM}}
+      
+      - name: Sync Dependencies 
+        run: pdm sync -v --no-isolation --no-self --no-editable
+      - name: Compile Protocol Buffers
+        run: pdm run protoc
+      
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+      - name: (DEBUG) Set dev version number
+        # For debug-release, set version "<current_release>dev<timestamp>" (eg 1.2.15.dev20240710183756)
+        # (to avoid messing current releases versions like 1.2.15).
+        run: |
+          NEW_VERSION="$(pdm show --version).dev$NOW"
+          sed -i "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" pyproject.toml
+        if: (inputs.pypi_env && inputs.pypi_env == 'dev-debug-version')
+      - name: Build package
+        run: pdm build --config-setting="--build-number=$NOW" --no-sdist
+
+      - name: Publish package distributions to PyPI
+        run: pdm publish --no-build
+        if: ( github.event_name == 'release' && github.event.action == 'published' ) || (github.event_name == 'workflow_dispatch' && inputs.pypi_env == 'prod') 
+
+      - name: Publish package distributions to Test PyPI
+        run: pdm publish --no-build -r testpypi
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.pypi_env == 'dev' || inputs.pypi_env == 'dev-debug-version'))

--- a/README.md
+++ b/README.md
@@ -357,6 +357,15 @@ Python wheel exported to:
 /tmp/ceph_nvmeof-0.0.1-py3-none-any.whl
 ```
 
+To install nvmeof-cli as a CLI tool from the above Python wheel package, (or alternatively only build the cli package):
+```
+make export-python
+pip install /tmp/ceph_nvmeof-0.0.1-py3-none-any.whl
+ceph-nvmeof // use nvmeof-cli tool!
+```
+
+This can also be installed from https://pypi.org/project/ceph-nvmeof/, by running `pip3 install ceph-nvmeof`.
+
 ### Development containers
 
 To avoid having to re-build container on every code change, developer friendly containers are provided:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ The same configuration can also be manually run:
     cephnvmf host add --subsystem nqn.2016-06.io.spdk:cnode1 --host "*"
     ```
 
+These can also be run by setting environment variables `CEPH_NVMEOF_SERVER_ADDRESS` and `CEPH_NVMEOF_SERVER_PORT` before running nvmeof-cli commands, example:
+```
+export CEPH_NVMEOF_SERVER_ADDRESS=x.x.x.x 
+export CEPH_NVMEOF_SERVER_PORT=5500
+
+// using containers
+docker-compose run --it <container_image> subsystem add --subsystem nqn.2016-06.io.spdk:cnode1 
+// using pypi package
+ceph-nvmeof subsystem add --subsystem nqn.2016-06.io.spdk:cnode1 
+```
 
 ### Mounting the NVMe-oF volume
 

--- a/control/cli.py
+++ b/control/cli.py
@@ -108,13 +108,13 @@ class Parser:
             required=False)
         self.parser.add_argument(
             "--server-address",
-            default="localhost",
+            default=(os.getenv('CEPH_NVMEOF_SERVER_ADDRESS') or "localhost"),
             type=str,
             help="Server address",
         )
         self.parser.add_argument(
             "--server-port",
-            default=5500,
+            default=int(os.getenv('CEPH_NVMEOF_SERVER_PORT') or "5500"),
             type=int,
             help="Server port",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,6 @@ test = [
 # documentation = ""
 repository = "https://github.com/ceph/ceph-nvmeof.git"
 # changelog = ""
+
+[project.scripts]
+ceph-nvmeof = "control.cli:main"


### PR DESCRIPTION
Add "ceph-nvmeof" cli command to package this as python cli tool instead of using via containers.

How to build it:
```
git clone https://github.com/ceph/ceph-nvmeof.git
cd ceph-nvmeof/
dnf install -y python3-pip
python3 -m venv venv
source venv/bin/activate
pip install -U pip setuptools
pip install pdm==2.7.4
pdm "sync" -v --no-isolation --no-self --no-editable
pdm run protoc
pdm build

pip install dist/ceph_nvmeof-1.2.15-py3-none-any.whl
ceph-nvmeof
```

Usage:
```
[root@singleESXiS1in ~]# pip3 install ceph-nvmeof
[root@singleESXiS1in ~]# ceph-nvmeof --server-address $NVMEOF_DEFAULT_GATEWAY_IP_ADDRESS --server-port $NVMEOF_SRPORT --format json subsystem list
{
    "error_message": "Success",
    "status": 0,
    "subsystems": []
}
[root@singleESXiS1in ~]# ceph-nvmeof  --server-address $NVMEOF_DEFAULT_GATEWAY_IP_ADDRESS --server-port $NVMEOF_SRPORT subsystem add --subsystem nqn.2016-06.io.spdk:cnode1
Adding subsystem nqn.2016-06.io.spdk:cnode1: Successful
[root@singleESXiS1in ~]# ceph-nvmeof --server-address $NVMEOF_DEFAULT_GATEWAY_IP_ADDRESS --server-port $NVMEOF_SRPORT --format json subsystem list
{
    "error_message": "Success",
    "subsystems": [
        {
            "nqn": "nqn.2016-06.io.spdk:cnode1",
            "enable_ha": true,
            "serial_number": "Ceph36100720827891",
            "model_number": "Ceph bdev Controller",
            "min_cntlid": 1,
            "max_cntlid": 2040,
            "subtype": "NVMe",
            "max_namespaces": 256,
            "namespace_count": 0
        }
    ],
    "status": 0
}
```
Package: https://pypi.org/project/ceph-nvmeof/
