### PR TITLE
Python package: Disable pypi workflow for forks and improve help message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ env:
 jobs:
   pypi-publish:
     name: Upload release to PyPI
+    if: github.repository == 'ceph/ceph-nvmeof'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/README.md
+++ b/README.md
@@ -148,12 +148,16 @@ The same configuration can also be manually run:
 
 These can also be run by setting environment variables `CEPH_NVMEOF_SERVER_ADDRESS` and `CEPH_NVMEOF_SERVER_PORT` before running nvmeof-cli commands, example:
 ```
-export CEPH_NVMEOF_SERVER_ADDRESS=x.x.x.x 
-export CEPH_NVMEOF_SERVER_PORT=5500
+cat <<EOF > /etc/ceph/nvmeof-cli.env
+CEPH_NVMEOF_SERVER_ADDRESS=x.x.x.x 
+CEPH_NVMEOF_SERVER_PORT=5500
+EOF
+
 
 // using containers
-docker-compose run --it <container_image> subsystem add --subsystem nqn.2016-06.io.spdk:cnode1 
+docker-compose run --env-file /etc/ceph/nvmeof-cli.env -it <container_image> subsystem add --subsystem nqn.2016-06.io.spdk:cnode1 
 // using pypi package
+source /etc/ceph/nvmeof-cli.env
 ceph-nvmeof subsystem add --subsystem nqn.2016-06.io.spdk:cnode1 
 ```
 

--- a/control/cli.py
+++ b/control/cli.py
@@ -110,13 +110,13 @@ class Parser:
             "--server-address",
             default=(os.getenv('CEPH_NVMEOF_SERVER_ADDRESS') or "localhost"),
             type=str,
-            help="Server address",
+            help="Server address (default: CEPH_NVMEOF_SERVER_ADDRESS env variable or 'localhost')",
         )
         self.parser.add_argument(
             "--server-port",
             default=int(os.getenv('CEPH_NVMEOF_SERVER_PORT') or "5500"),
             type=int,
-            help="Server port",
+            help="Server port (default: CEPH_NVMEOF_SERVER_PORT env variable or '5500')",
         )
         self.parser.add_argument(
             "--client-key",


### PR DESCRIPTION
1. Disable workflow "Publish to PyPi" for forked repos.
2. Add about "CEPH_NVMEOF_SERVER_ADDRESS"
and "CEPH_NVMEOF_SERVER_PORT" env variables in "ceph-nvmeof --help" message.
