### PR TITLE
Use OBSOLETE_ prefix instead of actually deleting obsolete uuid field

### DIFF
--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -127,20 +127,20 @@ message namespace_add_req {
 message namespace_resize_req {
 	string subsystem_nqn = 1;
 	uint32 nsid = 2;
-	//optional string uuid = 3;
+	optional string OBSOLETE_uuid = 3;
 	uint64 new_size = 4;
 }
 
 message namespace_get_io_stats_req {
 	string subsystem_nqn = 1;
 	uint32 nsid = 2;
-	//optional string uuid = 3;
+	optional string OBSOLETE_uuid = 3;
 }
 
 message namespace_set_qos_req {
 	string subsystem_nqn = 1;
 	uint32 nsid = 2;
-	//optional string uuid = 3;
+	optional string OBSOLETE_uuid = 3;
 	optional uint64 rw_ios_per_second = 4;
 	optional uint64 rw_mbytes_per_second = 5;
 	optional uint64 r_mbytes_per_second = 6;
@@ -150,14 +150,14 @@ message namespace_set_qos_req {
 message namespace_change_load_balancing_group_req {
 	string subsystem_nqn = 1;
 	uint32 nsid = 2;
-	//optional string uuid = 3;
+	optional string OBSOLETE_uuid = 3;
 	int32 anagrpid = 4;
 }
 
 message namespace_delete_req {
 	string subsystem_nqn = 1;
 	uint32 nsid = 2;
-	//optional string uuid = 3;
+	optional string OBSOLETE_uuid = 3;
 }
 
 message create_subsystem_req {


### PR DESCRIPTION
Fixes #775