### PR TITLE
minor ping/keepalive tweaks

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -633,7 +633,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ceph_out_${{ matrix.test }}
-          path: /tmp/out/*
+          path: /tmp/out/*.log
 
       - name: Display logs
         if: success() || failure()

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -29,7 +29,6 @@ enable_spdk_discovery_controller = False
 #verify_nqns = True
 #allowed_consecutive_spdk_ping_failures = 1
 #spdk_ping_interval_in_seconds = 2.0
-#ping_spdk_under_lock = False
 
 [gateway-logs]
 log_level=debug

--- a/tests/ceph-nvmeof.tls.conf
+++ b/tests/ceph-nvmeof.tls.conf
@@ -28,7 +28,6 @@ enable_spdk_discovery_controller = False
 #verify_nqns = True
 #allowed_consecutive_spdk_ping_failures = 1
 #spdk_ping_interval_in_seconds = 2.0
-#ping_spdk_under_lock = False
 
 [gateway-logs]
 log_level=debug


### PR DESCRIPTION
# minor ping/keepalive tweaks

1. we do no use lock for the ping spdk client since this client is used by a single thread (keap_alive). no need to support configurable lock ping mode
2. clean up usage of ping spdk client during initialization
3. mv keap alive variables initialization from __init__ to keep_alive.