### PR TITLE
build: remove install thrift explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ CMD []
 #------------------------------------------------------------------------------
 # Base image for NVMEOF_TARGET=gateway (nvmeof-gateway)
 FROM quay.io/ceph/spdk:${NVMEOF_SPDK_VERSION:-NULL} AS base-gateway
-RUN rpm -vih https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN \
     --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \

--- a/Dockerfile.spdk
+++ b/Dockerfile.spdk
@@ -73,7 +73,8 @@ RUN \
     && dnf install $DNF_OPTS -y \
         rpm-build \
         git-core \
-    && rpm -vih https://buildlogs.centos.org/centos/9-stream/storage/x86_64/ceph-reef/Packages/t/thrift-0.15.0-3.el9s.x86_64.rpm \
+	epel-release \
+	epel-next-release \
     && scripts/pkgdep.sh $SPDK_PKGDEP_ARGS \
     && dnf $DNF_OPTS update -y
 
@@ -153,7 +154,7 @@ RUN \
     --mount=type=cache,target=/var/lib/dnf \
     rpm -vih $SPDK_CENTOS_BASE/centos-stream-repos-$SPDK_CENTOS_REPO_VER.noarch.rpm \
              $SPDK_CENTOS_BASE/centos-gpg-keys-$SPDK_CENTOS_REPO_VER.noarch.rpm \
-    && rpm -vih https://buildlogs.centos.org/centos/9-stream/storage/x86_64/ceph-reef/Packages/t/thrift-0.15.0-3.el9s.x86_64.rpm \
+    && rpm -vih https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
     && dnf $DNF_OPTS install -y /rpm/$(uname -m)/*.rpm \
     && dnf $DNF_OPTS update -y
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Make config
 MAKEFLAGS += --no-builtin-rules --no-builtin-variables
+TARGET_ARCH := $(shell uname -m | sed -e 's/aarch64/arm64/')
 .SUFFIXES:
 
 # Includes
@@ -33,7 +34,7 @@ build: export SPDK_GIT_BRANCH != git -C spdk name-rev --name-only HEAD
 build: export SPDK_GIT_COMMIT != git rev-parse HEAD:spdk
 build: export BUILD_DATE != date -u +"%Y-%m-%d %H:%M:%S %Z"
 build: export NVMEOF_GIT_MODIFIED_FILES != git status -s | grep -e "^ *M" | sed 's/^ *M //' | xargs
-build: export CEPH_CLUSTER_CEPH_REPO_BASEURL != curl -s https://shaman.ceph.com/api/repos/ceph/$(CEPH_BRANCH)/$(CEPH_SHA)/centos/9/ | jq -r '.[] | select(.status == "ready" and .sha1 == "$(CEPH_SHA)" and .archs[] == "x86_64") | .url'
+build: export CEPH_CLUSTER_CEPH_REPO_BASEURL != curl -s https://shaman.ceph.com/api/repos/ceph/$(CEPH_BRANCH)/$(CEPH_SHA)/centos/9/ | jq -r '.[] | select(.status == "ready" and .sha1 == "$(CEPH_SHA)" and .archs[] == "$(TARGET_ARCH)") | .url'
 up: ## Launch services
 up: SCALE?= 1 ## Number of gateways
 up:

--- a/README.md
+++ b/README.md
@@ -335,6 +335,20 @@ To build the container images from the local sources:
 make build
 ```
 
+To build the container images for Arm64, you need to override the default values of `SPDK_TARGET_ARCH` and `SPDK_MAKEFLAGS`. For how to set the values for all the supported Arm64 SoCs see [the socs and implementer_xxx parts](https://github.com/DPDK/dpdk/blob/main/config/arm/meson.build#L674).
+And override the values of [ceph-ci git repo](https://github.com/ceph/ceph-ci) `CEPH_BRANCH` and `CEPH_SHA` or `CEPH_CLUSTER_CEPH_REPO_BASEURL` if the default Ceph rpm repo doesn't contain Arm64 rpm.
+
+E.g.
+```bash
+make build SPDK_TARGET_ARCH="armv8-a+crypto" \
+    SPDK_MAKEFLAGS="DPDKBUILD_FLAGS=-Dplatform=generic" \
+    CEPH_BRANCH=ceph-nvmeof-mon-arm64-testin \
+    CEPH_SHA=0adaeecf622b3867ee27e9fabeb939831c4967dc
+make build SPDK_TARGET_ARCH="armv8.2-a+crypto" \
+    SPDK_MAKEFLAGS="DPDKBUILD_FLAGS=-Dplatform=kunpeng920" \
+    CEPH_CLUSTER_CEPH_REPO_BASEURL="https://uk.linaro.cloud/repo/ceph/9-stream"
+```
+
 The resulting images should be like these:
 
 ```bash


### PR DESCRIPTION
The thrift installation is introduced from commit
f789b3dbca78 ("build: force install thrift 0.14")
as a workaround for issue https://tracker.ceph.com/issues/61882. 
This issue has been fixed already, we can install thrift from
 the epel repo automatically like Dockerfile.ceph do now.

This change also enables building the spdk image for arm64 and
the testing building cmds are:
make build SVC="spdk" SPDK_TARGET_ARCH="armv8-a+crypto" \
  SPDK_MAKEFLAGS="DPDKBUILD_FLAGS=-Dplatform=generic" \
  CEPH_BRANCH=ceph-nvmeof-mon-arm64-testin \
  CEPH_SHA=0adaeecf622b3867ee27e9fabeb939831c4967dc
 make build SVC="spdk" SPDK_TARGET_ARCH="armv8.2-a+crypto" \
  SPDK_MAKEFLAGS="DPDKBUILD_FLAGS=-Dplatform=kunpeng920" \
  CEPH_CLUSTER_CEPH_REPO_BASEURL="https://uk.linaro.cloud/repo/ceph/9-stream"
To know the values of `SPDK_TARGET_ARCH` and `platform` for other
Arm64 SoCs, see https://github.com/DPDK/dpdk/blob/main/config/arm/meson.build


resolve #781
Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>