### PR TITLE
Show nvmeof gateways in "ceph status"

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -737,7 +737,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["sanity", "state_transitions", "state_transitions_both_gws", "state_transitions_loop", "state_transitions_rand_loop", "late_registration", "late_registration_loop", "4gws", "4gws_loop", "4gws_create_delete", "4gws_create_delete_loop", "namespaces", "namespaces_loop", "mtls", "notify"]
+        test: ["sanity", "state_transitions", "state_transitions_both_gws", "state_transitions_loop", "state_transitions_rand_loop", "late_registration", "late_registration_loop", "4gws", "4gws_loop", "4gws_create_delete", "4gws_create_delete_loop", "namespaces", "namespaces_loop", "mtls", "notify", "ceph_status"]
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 1024  # 4 spdk instances

--- a/control/cephutils.py
+++ b/control/cephutils.py
@@ -96,6 +96,22 @@ class CephUtils:
 
         return False
 
+    def service_daemon_register(self, cluster, metadata):
+        try:
+            if cluster: # rados client 
+                daemon_name = metadata['id']
+                cluster.service_daemon_register("nvmeof", daemon_name, metadata)
+                self.logger.info(f"Registered {daemon_name} to service_map!")
+        except Exception:
+            self.logger.exception(f"Can't register daemon to service_map!")
+
+    def service_daemon_update(self, cluster, status_buffer):
+        try:
+            if cluster and status_buffer:
+                cluster.service_daemon_update(status_buffer)
+        except Exception:
+            self.logger.exception(f"Can't update daemon status to service_map!") 
+
     def create_image(self, pool_name, image_name, size) -> bool:
         # Check for pool existence in advance as we don't create it if it's not there
         if not self.pool_exists(pool_name):

--- a/control/server.py
+++ b/control/server.py
@@ -203,6 +203,19 @@ class GatewayServer:
             log_level = log_level.strip().upper()
             log_req = pb2.set_spdk_nvmf_logs_req(log_level=log_level, print_level=log_level)
             self.gateway_rpc.set_spdk_nvmf_logs(log_req)
+        
+        self._register_service_map()
+
+    def _register_service_map(self):
+        # show gateway in "ceph status" output
+        conn = self.omap_state.conn
+        metadata = {
+            "id": self.name.removeprefix("client.nvmeof."),
+            "pool_name": self.config.get("ceph", "pool"),
+            "daemon_type": "gateway", # "nvmeof: 3 <daemon_type> active (3 hosts)"
+            "group": self.config.get_with_default("gateway", "group", ""),
+        } 
+        self.ceph_utils.service_daemon_register(conn, metadata) 
 
     def _monitor_client_version(self) -> str:
         """Return monitor client version string."""

--- a/control/state.py
+++ b/control/state.py
@@ -573,6 +573,9 @@ class OmapGatewayState(GatewayState):
                 self.ioctx = None
             except Exception:
                 pass
+        if self.conn:
+            self.conn.shutdown()
+            self.conn = None
 
 class GatewayStateHandler:
     """Maintains consistency in NVMeoF target state store instances.

--- a/tests/ha/ceph_status.sh
+++ b/tests/ha/ceph_status.sh
@@ -1,0 +1,22 @@
+set -xe
+
+POOL="${RBD_POOL:-rbd}"
+CEPH_NAME=$(docker ps --format '{{.ID}}\t{{.Names}}' | grep -v nvme | grep ceph | awk '{print $1}')
+GW1_NAME=$(docker ps --format '{{.ID}}\t{{.Names}}' | awk '$2 ~ /nvmeof/ && $2 ~ /1/ {print $1}')
+
+docker compose exec -T ceph ceph service dump
+docker compose exec -T ceph ceph status
+
+echo "ℹ️  Step 1: verify 2 gateways"
+
+docker compose exec -T ceph ceph status | grep "nvmeof: 2 gateways active"
+
+echo "ℹ️  Step 2: stop a gateway"
+
+docker stop $GW1_NAME
+wait
+sleep 5
+
+echo "ℹ️  Step 3: verify 1 gateway"
+
+docker compose exec -T ceph ceph status | grep "nvmeof: 1 gateway active"


### PR DESCRIPTION
Register nvmeof gw service to service_map.
This brings up nvmeof in "ceph status" output.

After gateway deployment, It shows all 4 gateways in "ceph -s" output):
```
2024-08-20T11:51:41.617 INFO:tasks.workunit.client.2.smithi067.stdout:  cluster:
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:    id:     de9bdec8-5ee8-11ef-bccf-c7b262605968
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:    health: HEALTH_WARN
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:            Degraded data redundancy: 484/1452 objects degraded (33.333%), 32 pgs degraded, 32 pgs undersized
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:  services:
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:    mon:    3 daemons, quorum a,c,b (age 9m)
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:    mgr:    x(active, since 10m)
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:    osd:    2 osds: 2 up (since 8m), 2 in (since 8m)
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:    nvmeof: 4 gateways active (4 hosts)
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:  data:
2024-08-20T11:51:41.618 INFO:tasks.workunit.client.2.smithi067.stdout:    pools:   1 pools, 32 pgs
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:    objects: 484 objects, 1020 MiB
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:    usage:   1.5 GiB used, 177 GiB / 179 GiB avail
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:    pgs:     484/1452 objects degraded (33.333%)
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:             32 active+undersized+degraded
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:  io:
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:    client:   32 KiB/s rd, 2 op/s rd, 0 op/s wr
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:  progress:
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:    Global Recovery Event (0s)
2024-08-20T11:51:41.619 INFO:tasks.workunit.client.2.smithi067.stdout:      [............................]
```
After nvmeof service is removed, nvmeof disappears from "ceph status" too:
```
2024-08-20T11:52:02.450 INFO:tasks.workunit.client.2.smithi067.stderr:+ ceph -s
2024-08-20T11:52:02.987 INFO:tasks.workunit.client.2.smithi067.stdout:  cluster:
2024-08-20T11:52:02.987 INFO:tasks.workunit.client.2.smithi067.stdout:    id:     de9bdec8-5ee8-11ef-bccf-c7b262605968
2024-08-20T11:52:02.987 INFO:tasks.workunit.client.2.smithi067.stdout:    health: HEALTH_WARN
2024-08-20T11:52:02.987 INFO:tasks.workunit.client.2.smithi067.stdout:            Degraded data redundancy: 484/1452 objects degraded (33.333%), 32 pgs degraded, 32 pgs undersized
2024-08-20T11:52:02.987 INFO:tasks.workunit.client.2.smithi067.stdout:
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:  services:
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:    mon: 3 daemons, quorum a,c,b (age 9m)
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:    mgr: x(active, since 10m)
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:    osd: 2 osds: 2 up (since 8m), 2 in (since 8m)
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:  data:
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:    pools:   1 pools, 32 pgs
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:    objects: 484 objects, 1020 MiB
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:    usage:   1.4 GiB used, 177 GiB / 179 GiB avail
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:    pgs:     484/1452 objects degraded (33.333%)
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:             32 active+undersized+degraded
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:
2024-08-20T11:52:02.988 INFO:tasks.workunit.client.2.smithi067.stdout:  io:
2024-08-20T11:52:02.989 INFO:tasks.workunit.client.2.smithi067.stdout:    client:   87 KiB/s rd, 0 B/s wr, 97 op/s rd, 55 op/s wr
2024-08-20T11:52:02.989 INFO:tasks.workunit.client.2.smithi067.stdout:
2024-08-20T11:52:02.989 INFO:tasks.workunit.client.2.smithi067.stdout:  progress:
2024-08-20T11:52:02.989 INFO:tasks.workunit.client.2.smithi067.stdout:    Global Recovery Event (0s)
2024-08-20T11:52:02.989 INFO:tasks.workunit.client.2.smithi067.stdout:      [............................]
```

https://pulpito.ceph.com/vallariag-2024-08-20_11:27:49-nvmeof-main-distro-default-smithi/ 



- [x] Fix problem "4 stray daemon(s) not managed by cephadm" 
- [x] Ensure it shows 4 gateways in "ceph -s"
- [ ] Run it again with good build - this build gives `[WRN] Health check failed: Degraded data redundancy: 2/6 objects degraded (33.333%), 2 pgs degraded (PG_DEGRADED)`