### PR TITLE
Revert SPDK sokcet path to /var/tmp/spdk.sock

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -60,8 +60,7 @@ client_cert = ./client.crt
 [spdk]
 bdevs_per_cluster = 32
 tgt_path = /usr/local/bin/nvmf_tgt
-#rpc_socket_dir = /var/tmp/
-#rpc_socket_name = spdk.sock
+#rpc_socket = /var/tmp/spdk.sock
 #tgt_cmd_extra_args = --env-context="--no-huge -m1024" --iova-mode=va
 timeout = 60.0
 log_level =

--- a/control/server.py
+++ b/control/server.py
@@ -332,18 +332,6 @@ class GatewayServer:
 
         return server
 
-    def _get_spdk_rpc_socket_path(self, omap_state) -> str:
-        # For backward compatibility, try first to get the old attribute
-        spdk_rpc_socket = self.config.get_with_default("spdk", "rpc_socket", "")
-        if spdk_rpc_socket:
-            return spdk_rpc_socket
-
-        (spdk_rpc_socket_dir, create_status) = GatewayUtils.get_directory_with_fsid(
-                                         self.logger, self.config, self.ceph_utils, "spdk", "rpc_socket_dir",
-                                         GatewayConfig.CEPH_RUN_DIRECTORY, "", True)
-        spdk_rpc_socket = spdk_rpc_socket_dir + self.config.get_with_default("spdk", "rpc_socket_name", "spdk.sock")
-        return spdk_rpc_socket
-
     def _start_spdk(self, omap_state):
         """Starts SPDK process."""
 
@@ -351,7 +339,7 @@ class GatewayServer:
         self.logger.debug(f"Configuring server {self.name}")
         spdk_tgt_path = self.config.get("spdk", "tgt_path")
         self.logger.info(f"SPDK Target Path: {spdk_tgt_path}")
-        self.spdk_rpc_socket_path = self._get_spdk_rpc_socket_path(omap_state)
+        self.spdk_rpc_socket_path = self.config.get_with_default("spdk", "rpc_socket", "/var/tmp/spdk.sock")
         self.logger.info(f"SPDK Socket: {self.spdk_rpc_socket_path}")
         spdk_tgt_cmd_extra_args = self.config.get_with_default(
             "spdk", "tgt_cmd_extra_args", "")

--- a/control/utils.py
+++ b/control/utils.py
@@ -176,43 +176,6 @@ class GatewayUtils:
 
         return (0, os.strerror(0))
 
-    def get_directory_with_fsid(logger, config, ceph_utils, conf_section, conf_field, def_value, suffix, should_create):
-        status = errno.ENOENT
-        dir_name = config.get_with_default(conf_section, conf_field, "")
-        if dir_name:
-            # If there is an explicit dir name in configuration file, do not change it
-            suffix = ""
-        else:
-            dir_name = def_value
-            if ceph_utils:
-                fsid = ceph_utils.fetch_ceph_fsid()
-                if fsid:
-                    dir_name += fsid + "/"
-        if not dir_name.endswith("/"):
-            dir_name += "/"
-        if suffix:
-            dir_name += suffix
-        if not dir_name.endswith("/"):
-            dir_name += "/"
-        if should_create:
-            try:
-                os.makedirs(dir_name, 0o777, True)
-                status = 0
-            except OSError as err:
-                logger.exception(f"makedirs({dir_name}, 0o777, True) failed")
-                status = err.errno
-            except Exception:
-                logger.exception(f"makedirs({dir_name}, 0o777, True) failed")
-                status = errno.ENOENT
-        else:
-            if os.path.isdir(dir_name):
-                status = 0
-            else:
-                logger.error(f"Directory {dir_name} does not exist")
-                status = errno.ENOENT
-
-        return (dir_name, status)
-
 class GatewayLogger:
     CEPH_LOG_DIRECTORY = "/var/log/ceph/"
     MAX_LOG_FILE_SIZE_DEFAULT = 10

--- a/tests/ceph-nvmeof.tls.conf
+++ b/tests/ceph-nvmeof.tls.conf
@@ -59,8 +59,7 @@ client_cert = /etc/ceph/client.crt
 [spdk]
 bdevs_per_cluster = 32
 tgt_path = /usr/local/bin/nvmf_tgt
-#rpc_socket_dir = /var/tmp/
-#rpc_socket_name = spdk.sock
+#rpc_socket = /var/tmp/spdk.sock
 #tgt_cmd_extra_args = --env-context="--no-huge -m1024" --iova-mode=va
 timeout = 60.0
 log_level = WARNING

--- a/tests/ha/4gws.sh
+++ b/tests/ha/4gws.sh
@@ -10,7 +10,7 @@ expect_optimized() {
   socket_retries=0
   socket=""
   while [ $socket_retries -lt 10 ] ; do
-      socket=$(docker exec "$GW_NAME" find /var/run/ceph -name spdk.sock)
+      socket=$(docker exec "$GW_NAME" find /var/tmp -name spdk.sock)
       if [ -n "$socket" ]; then
           break
       fi

--- a/tests/ha/4gws_create_delete.sh
+++ b/tests/ha/4gws_create_delete.sh
@@ -11,7 +11,7 @@ expect_optimized() {
   socket_retries=0
   socket=""
   while [ $socket_retries -lt 10 ] ; do
-      socket=$(docker exec "$GW_NAME" find /var/run/ceph -name spdk.sock)
+      socket=$(docker exec "$GW_NAME" find /var/tmp -name spdk.sock)
       if [ -n "$socket" ]; then
           break
       fi

--- a/tests/ha/late_registration.sh
+++ b/tests/ha/late_registration.sh
@@ -7,7 +7,7 @@ expect_optimized() {
   GW_NAME=$1
   EXPECTED_OPTIMIZED=$2
 
-  socket=$(docker exec "$GW_NAME" find /var/run/ceph -name spdk.sock)
+  socket=$(docker exec "$GW_NAME" find /var/tmp -name spdk.sock)
   # Verify expected number of "optimized"
   while true; do
     response=$(docker exec "$GW_NAME" "$rpc" "-s" "$socket" "$cmd" "$nqn")

--- a/tests/ha/state_transitions.sh
+++ b/tests/ha/state_transitions.sh
@@ -7,7 +7,7 @@ expect_optimized() {
   GW_NAME=$1
   EXPECTED_OPTIMIZED=$2
 
-  socket=$(docker exec "$GW_NAME" find /var/run/ceph -name spdk.sock)
+  socket=$(docker exec "$GW_NAME" find /var/tmp -name spdk.sock)
   # Verify expected number of "optimized"
   while true; do
     response=$(docker exec "$GW_NAME" "$rpc" "-s" "$socket" "$cmd" "$nqn")

--- a/tests/ha/state_transitions_both_gws.sh
+++ b/tests/ha/state_transitions_both_gws.sh
@@ -7,7 +7,7 @@ expect_optimized() {
   GW_NAME=$1
   EXPECTED_OPTIMIZED=$2
 
-  socket=$(docker exec "$GW_NAME" find /var/run/ceph -name spdk.sock)
+  socket=$(docker exec "$GW_NAME" find /var/tmp -name spdk.sock)
   # Verify expected number of "optimized"
   while true; do
     response=$(docker exec "$GW_NAME" "$rpc" "-s" "$socket" "$cmd" "$nqn")

--- a/tests/test_cli_change_lb.py
+++ b/tests/test_cli_change_lb.py
@@ -33,14 +33,14 @@ def two_gateways(config):
     configB = copy.deepcopy(config)
     configA.config["gateway"]["name"] = nameA
     configA.config["gateway"]["override_hostname"] = nameA
-    configA.config["spdk"]["rpc_socket_name"] = sockA
+    configA.config["spdk"]["rpc_socket"] = f"/var/tmp/{sockA}"
     portA = configA.getint("gateway", "port") + 1
     configA.config["gateway"]["port"] = str(portA)
     discPortA = configA.getint("discovery", "port") + 1
     configA.config["discovery"]["port"] = str(discPortA)
     configB.config["gateway"]["name"] = nameB
     configB.config["gateway"]["override_hostname"] = nameB
-    configB.config["spdk"]["rpc_socket_name"] = sockB
+    configB.config["spdk"]["rpc_socket"] = f"/var/tmp/{sockB}"
     portB = portA + 1
     discPortB = discPortA + 1
     configB.config["gateway"]["port"] = str(portB)

--- a/tests/test_multi_gateway.py
+++ b/tests/test_multi_gateway.py
@@ -22,7 +22,7 @@ def conn(config):
     configA.config["gateway"]["group"] = "Group1"
     configA.config["gateway"]["state_update_notify"] = str(update_notify)
     configA.config["gateway"]["enable_spdk_discovery_controller"] = "True"
-    configA.config["spdk"]["rpc_socket_name"] = "spdk_GatewayA.sock"
+    configA.config["spdk"]["rpc_socket"] = "/var/tmp/spdk_GatewayA.sock"
     configB = copy.deepcopy(configA)
     addr = configA.get("gateway", "addr")
     portA = configA.getint("gateway", "port")
@@ -30,7 +30,7 @@ def conn(config):
     configB.config["gateway"]["name"] = "GatewayB"
     configB.config["gateway"]["port"] = str(portB)
     configB.config["gateway"]["state_update_interval_sec"] = str(update_interval_sec)
-    configB.config["spdk"]["rpc_socket_name"] = "spdk_GatewayB.sock"
+    configB.config["spdk"]["rpc_socket"] = "/var/tmp/spdk_GatewayB.sock"
     configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x02"
     ceph_utils = CephUtils(config)
 

--- a/tests/test_nsid.py
+++ b/tests/test_nsid.py
@@ -27,14 +27,14 @@ def setup_config(config, gw1_name, gw2_name, gw_group, update_notify, update_int
     configA.config["gateway"]["omap_file_disable_unlock"] = str(disable_unlock)
     configA.config["gateway"]["omap_file_lock_duration"] = str(lock_duration)
     configA.config["gateway"]["enable_spdk_discovery_controller"] = "True"
-    configA.config["spdk"]["rpc_socket_name"] = sock1_name
+    configA.config["spdk"]["rpc_socket"] = f"/var/tmp/{sock1_name}"
     configB = copy.deepcopy(configA)
     portA = configA.getint("gateway", "port")
     configA.config["gateway"]["port"] = str(portA)
     portB = portA + 2
     configB.config["gateway"]["name"] = gw2_name
     configB.config["gateway"]["port"] = str(portB)
-    configB.config["spdk"]["rpc_socket_name"] = sock2_name
+    configB.config["spdk"]["rpc_socket"] = f"/var/tmp/{sock2_name}"
     configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x02"
 
     return configA, configB

--- a/tests/test_omap_lock.py
+++ b/tests/test_omap_lock.py
@@ -29,7 +29,7 @@ def setup_config(config, gw1_name, gw2_name, gw_group, update_notify ,update_int
     configA.config["gateway"]["omap_file_disable_unlock"] = str(disable_unlock)
     configA.config["gateway"]["omap_file_lock_duration"] = str(lock_duration)
     configA.config["gateway"]["enable_spdk_discovery_controller"] = "True"
-    configA.config["spdk"]["rpc_socket_name"] = sock1_name
+    configA.config["spdk"]["rpc_socket"] = f"/var/tmp/{sock1_name}"
     configB = copy.deepcopy(configA)
     portA = configA.getint("gateway", "port") + port_inc
     configA.config["gateway"]["port"] = str(portA)
@@ -37,7 +37,7 @@ def setup_config(config, gw1_name, gw2_name, gw_group, update_notify ,update_int
     configB.config["gateway"]["name"] = gw2_name
     configB.config["gateway"]["override_hostname"] = gw2_name
     configB.config["gateway"]["port"] = str(portB)
-    configB.config["spdk"]["rpc_socket_name"] = sock2_name
+    configB.config["spdk"]["rpc_socket"] = f"/var/tmp/{sock2_name}"
     configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x02"
 
     return configA, configB

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,7 +57,7 @@ class TestServer(unittest.TestCase):
         configB = copy.deepcopy(configA)
         configB.config["gateway"]["name"] = "GatewayB"
         configB.config["gateway"]["port"] = str(configA.getint("gateway", "port") + 1)
-        configB.config["spdk"]["rpc_socket_name"] = "spdk_GatewayB.sock"
+        configB.config["spdk"]["rpc_socket"] = "/var/tmp/spdk_GatewayB.sock"
         # invalid arg, spdk would exit with code 1 at start up
         configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x343435545"
 


### PR DESCRIPTION
Fixes #794

It turned out that we didn't really need to use the /var/run/ceph/<fsid> for the SPDK socket path. So, to make things simpler and avoid the need to create a directory, I reverted the path back to /var/tmp/