### PR TITLE
Gerrit 24172 + CongMinYin:wip-dsa

### DIFF
--- a/.env
+++ b/.env
@@ -57,7 +57,7 @@ SPDK_URL="https://spdk.io"
 
 SPDK_PKGDEP_ARGS="--rbd"
 # check spdk/configure --help
-SPDK_CONFIGURE_ARGS="--with-rbd --disable-tests --disable-unit-tests --disable-examples --enable-debug"
+SPDK_CONFIGURE_ARGS="--with-rbd --with-idxd --disable-tests --disable-unit-tests --disable-examples --enable-debug"
 SPDK_TARGET_ARCH="x86-64-v2"
 SPDK_MAKEFLAGS=
 SPDK_CENTOS_BASE="https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/"

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -66,6 +66,9 @@ tgt_path = /usr/local/bin/nvmf_tgt
 timeout = 60.0
 #log_level = WARNING
 
+# True / False to enable dsa
+# enable_dsa = False
+
 # Example value: -m 0x3 -L all
 # tgt_cmd_extra_args =
 

--- a/control/server.py
+++ b/control/server.py
@@ -378,6 +378,11 @@ class GatewayServer:
             "spdk", "tgt_cmd_extra_args", "")
         cmd = [spdk_tgt_path, "-u", "-r", self.spdk_rpc_socket_path]
 
+        spdk_tgt_dsa = self.config.getboolean_with_default("spdk", "enable_dsa", False)
+        if spdk_tgt_dsa:
+            self.logger.info(f"Start SPDK, but wait for DSA detection before initialization")
+            cmd = [spdk_tgt_path, "-r", self.spdk_rpc_socket_path, "--wait-for-rpc"]
+
         # Add extra args from the conf file
         if spdk_tgt_cmd_extra_args:
             cmd += shlex.split(spdk_tgt_cmd_extra_args)
@@ -434,6 +439,11 @@ class GatewayServer:
                 log_level=protocol_log_level,
                 conn_retries=conn_retries,
             )
+            if spdk_tgt_dsa:
+                # init dsa
+                spdk.rpc.dsa.dsa_scan_accel_module(self.spdk_rpc_client)
+                spdk.rpc.framework_start_init(self.spdk_rpc_client)
+                self.logger.info(f"SPDK with DSA started")
         except Exception:
             self.logger.exception(f"Unable to initialize SPDK")
             raise


### PR DESCRIPTION
# Integration branch for CongMinYin:wip-dsa

- **spdk**: https://review.spdk.io/gerrit/c/spdk/spdk/+/24172 on top of ceph-nvmeof https://github.com/ceph/spdk/tree/ceph-nvmeof-v24.01
- **ceph-nvmeof**: [CongMinYin:wip-dsa](https://github.com/CongMinYin/ceph-nvmeof/tree/wip-dsa) - control/server.py: Enable DSA to offload and accelerate CRC calculation