### PR TITLE
control/server.py: support --cpumask=0xF

### DIFF
--- a/control/server.py
+++ b/control/server.py
@@ -58,6 +58,20 @@ def int_to_bitmask(n):
     """Converts an integer n to a bitmask string"""
     return f"0x{hex((1 << n) - 1)[2:].upper()}"
 
+def cpumask_set(args):
+    """Check if reactor cpu mask is set in command line args"""
+
+    # Check if "-m" or "--cpumask" is in the arguments
+    if "-m" in args or "--cpumask" in args:
+        return True
+
+    # Check for the presence of "--cpumask="
+    for arg in args:
+        if arg.startswith('--cpumask='):
+            return True
+
+    return False
+
 class GatewayServer:
     """Runs SPDK and receives client requests for the gateway service.
 
@@ -384,7 +398,7 @@ class GatewayServer:
 
         # If not provided in configuration,
         # calculate cpu mask available for spdk reactors
-        if '-m' not in cmd and '--cpumask' not in cmd:
+        if not cpumask_set(cmd):
             cpu_mask = f"-m {int_to_bitmask(min(4, os.cpu_count()))}"
             self.logger.info(f"SPDK autodetecting cpu_mask: {cpu_mask}")
             cmd += shlex.split(cpu_mask)


### PR DESCRIPTION
# control/server.py: support --cpumask=0xF
- https://github.com/ceph/ceph-nvmeof/issues/866

The spdk argument defined here - https://github.com/ceph/spdk/blob/0d9430fab9b368761b13dc73a65b0ed13d6c6bc6/lib/event/app.c#L97-L98

The `getopt_long` option expects a required argument (indicated by required_argument).
The option can be passed in two forms:
- Long option: --cpumask 0xF or --cpumask=0xF
- Short option: -m 0xF

# A sample test code to test valid/parsable command line variants for -m//--cpumask:

```c
#include <stdio.h>
#include <stdlib.h>
#include <getopt.h>

#define CPUMASK_OPT_IDX 'm'

int main(int argc, char *argv[]) {
    int option;
    char *cpumask_value = NULL;

    // Define the long options
    static struct option long_options[] = {
        {"cpumask", required_argument, NULL, CPUMASK_OPT_IDX},
        {0, 0, 0, 0}
    };

    // Parse the command-line options
    while ((option = getopt_long(argc, argv, "m:", long_options, NULL)) != -1) {
        switch (option) {
            case CPUMASK_OPT_IDX:
                cpumask_value = optarg;  // Get the cpumask argument value
                printf("cpumask option value: %s\n", cpumask_value);
                break;
            case '?':  // Invalid option
                printf("Unknown option!\n");
                return 1;
            default:
                printf("Usage: %s -m <value> or --cpumask=<value>\n", argv[0]);
                return 1;
        }
    }

    if (cpumask_value) {
        printf("Successfully parsed cpumask: %s\n", cpumask_value);
    } else {
        printf("cpumask argument was not provided.\n");
    }

    return 0;
}
```