### PR TITLE
ceph image from other registry for atom run

### DIFF
--- a/tests/atom/clusterBuildTestsRun.sh
+++ b/tests/atom/clusterBuildTestsRun.sh
@@ -28,7 +28,7 @@ sudo docker run \
     -v /root/.ssh:/root/.ssh \
     nvmeof_atom:"$ATOM_SHA" \
     python3 cephnvme_atom.py \
-    quay.ceph.io/ceph-ci/ceph:"$CEPH_SHA" \
+    quay.io/barakda1/ceph:d7c144c0d7e490bfda9715a0c8462bb67cffc764 \
     quay.io/ceph/nvmeof:"$VERSION" \
     quay.io/ceph/nvmeof-cli:"$VERSION" \
     None None None None None None 4 1 1 2 4 1024 2 2 200M 0 1 20 20 1 \


### PR DESCRIPTION
due to an issue pulling ceph image from ceph quay, changing the path to private quay temporary  