### PR TITLE
Revert "revert to latest ceph sha for atom"

### DIFF
--- a/tests/atom/clusterBuildTestsRun.sh
+++ b/tests/atom/clusterBuildTestsRun.sh
@@ -28,7 +28,7 @@ sudo docker run \
     -v /root/.ssh:/root/.ssh \
     nvmeof_atom:"$ATOM_SHA" \
     python3 cephnvme_atom.py \
-    quay.ceph.io/ceph-ci/ceph:"$CEPH_SHA" \
+    quay.io/barakda1/ceph:d7c144c0d7e490bfda9715a0c8462bb67cffc764 \
     quay.io/ceph/nvmeof:"$VERSION" \
     quay.io/ceph/nvmeof-cli:"$VERSION" \
     None None None None None None 4 1 1 2 4 1024 2 2 200M 0 1 20 20 1 \


### PR DESCRIPTION
Shaman ceph images are back online

Tested with 
```
/usr/bin/podman pull quay.ceph.io/ceph-ci/ceph:900fb5083740b52fc19cb09ed0110b216ca59a78
```


This reverts commit 05e7b26c14017d7998897031bbbaf1de5e77f529.