### PR TITLE
control/cli.py: handle connection refused

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -58,15 +58,6 @@ class ErrorCatchingArgumentParser(argparse.ArgumentParser):
         self.logger = logging.getLogger(__name__)
         super(ErrorCatchingArgumentParser, self).__init__(*args, **kwargs)
 
-    def exit(self, status = 0, message = None):
-        if status != 0:
-            if message:
-                self.logger.error(message)
-        else:
-            if message:
-                self.logger.info(message)
-        exit(status)
-
     def error(self, message):
         self.print_usage()
         if message:

--- a/control/server.py
+++ b/control/server.py
@@ -146,6 +146,7 @@ class GatewayServer:
         if logger:
             logger.info("Exiting the gateway process.")
         gw_logger.compress_final_log_file(gw_name)
+        self.logger.exception("Check if GatewayServer exception occurred:")
 
     def set_group_id(self, id: int):
         self.logger.info(f"Gateway {self.name} group {id=}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ host_name = socket.gethostname()
 addr = "127.0.0.1"
 addr_ipv6 = "::1"
 server_addr_ipv6 = "2001:db8::3"
+server_refused_port = 5517
 listener_list = [["-a", addr, "-s", "5001", "-f", "ipv4"], ["-a", addr, "-s", "5002"]]
 listener_list_no_port = [["-a", addr]]
 listener_list_invalid_adrfam = [["-a", addr, "-s", "5013", "--adrfam", "JUNK"]]
@@ -84,6 +85,11 @@ class TestGet:
         caplog.clear()
         cli(["--server-address", server_addr_ipv6, "subsystem", "list"])
         assert "No subsystems" in caplog.text
+
+    def test_get_subsystems_connection_refused(self, caplog, gateway):
+        with pytest.raises(SystemExit) as exc_info:
+            cli(["--server-port", str(server_refused_port), "get_subsystems"])
+        assert exc_info.value.code == 2  # Verify SystemExit was raised with code 2
 
     def test_get_gateway_info(self, caplog, gateway):
         gw, stub = gateway


### PR DESCRIPTION
# control/cli.py: handle connection refused

Example mtls test: https://github.com/ceph/ceph-nvmeof/actions/runs/11421827968/job/31779220634

```shell
CLI_TLS_ARGS --server-cert /etc/ceph/server.crt --client-key /etc/ceph/client.key --client-cert /etc/ceph/client.crt Container 1 87745defee53 is now running.
Container 1 87745defee53 192.168.13.3 subsystems:
Enable server auth since both --client-key and --client-cert are provided error: get_subsystems failed: code=StatusCode.UNAVAILABLE message=failed to connect to all addresses; last error: UNKNOWN: ipv4:192.168.13.3:5500: Failed to connect to remote host: Connection refused usage: python3 -m control.cli [-h] [--format {text,json,yaml,plain,python}]
                              [--output {log,stdio}]
                              [--log-level {debug,DEBUG,info,INFO,warning,WARNING,error,ERROR,critical,CRITICAL}]
                              [--server-address SERVER_ADDRESS]
                              [--server-port SERVER_PORT]
                              [--client-key CLIENT_KEY]
                              [--client-cert CLIENT_CERT]
                              [--server-cert SERVER_CERT] [--verbose]
                              {version,gw,spdk_log_level,subsystem,listener,host,connection,namespace,ns,get_subsystems}
                              ...
```


```shell
++ docker compose run --rm nvmeof-cli --server-address 192.168.13.3 --server-port 5500 --server-cert /etc/ceph/server.crt --client-key /etc/ceph/client.key --client-cert /etc/ceph/client.crt subsystem add --subsystem nqn.2016-06.io.spdk:cnode1 --no-group-append Enable server auth since both --client-key and --client-cert are provided Failure adding subsystem nqn.2016-06.io.spdk:cnode1: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAVAILABLE
	details = "failed to connect to all addresses; last error: UNKNOWN: ipv4:192.168.13.3:5500: Failed to connect to remote host: Connection refused"
	debug_error_string = "UNKNOWN:failed to connect to all addresses; last error: UNKNOWN: ipv4:192.168.13.3:5500: Failed to connect to remote host: Connection refused {created_time:"2024-10-20T00:27:59.51879366+00:00", grpc_status:14}"
```