### PR TITLE
control/prometheus.py: yield subsystem_namespace_count

### DIFF
--- a/control/prometheus.py
+++ b/control/prometheus.py
@@ -421,6 +421,7 @@ class NVMeOFCollector:
         yield subsystem_metadata
         yield subsystem_listeners
         yield subsystem_host_count
+        yield subsystem_namespace_count 
         yield subsystem_namespace_limit
         yield subsystem_namespace_metadata
         yield host_connection_state


### PR DESCRIPTION
The metric is defined but not exposed. This commit fixes that so the metric `ceph_nvmeof_subsystem_namespace_count` can be used for alerts.