### PR TITLE
CI: add 'push-devel-image-to-ceph-registry' to GA CI

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -716,3 +716,38 @@ jobs:
           make push
           make push TAG_SUFFIX="-arm64"
           make push-manifest-list
+
+  push-devel-image-to-ceph-registry:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+    needs: [pytest, demo, discovery, ha, atom]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download container images
+        uses: actions/download-artifact@v4
+        with:
+          pattern: container_images_nvmeof*
+          merge-multiple: true
+
+      - name: Load container images
+        run: |
+          docker load < nvmeof.tar
+          docker load < nvmeof-cli.tar
+
+      - name: Login to quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.CONTAINER_REGISTRY }}
+          username: '${{ vars.CONTAINER_REGISTRY_USERNAME }}'
+          password: '${{ secrets.CONTAINER_REGISTRY_PASSWORD }}'
+
+      - name: Publish nvmeof containers when merged to devel
+        run: |
+          . .env
+          for image in nvmeof nvmeof-cli; do
+            docker tag $CONTAINER_REGISTRY/$image:$NVMEOF_VERSION $CONTAINER_REGISTRY/$image:devel
+            docker push $CONTAINER_REGISTRY/$image:devel
+          done


### PR DESCRIPTION
Push to quay.io/ceph/nvmeof:devel and
quay.io/ceph/nvmeof-cli:devel on pushes to 'devel' branch.