### PR TITLE
idxd/dsa

### DIFF
--- a/.env
+++ b/.env
@@ -57,7 +57,7 @@ SPDK_URL="https://spdk.io"
 
 SPDK_PKGDEP_ARGS="--rbd"
 # check spdk/configure --help
-SPDK_CONFIGURE_ARGS="--with-rbd --disable-tests --disable-unit-tests --disable-examples --enable-debug"
+SPDK_CONFIGURE_ARGS="--with-idxd --with-rbd --disable-tests --disable-unit-tests --disable-examples --enable-debug"
 SPDK_TARGET_ARCH="x86-64-v2"
 SPDK_MAKEFLAGS=
 SPDK_CENTOS_BASE="https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/"

--- a/Dockerfile.spdk
+++ b/Dockerfile.spdk
@@ -9,6 +9,7 @@ ARG DNF_OPTS="\
   --setopt=keepcache=1 \
   --setopt=cachedir=/var/cache/dnf \
   "
+ARG ACCEL_CONFIG_SRC="/accel-config"
 
 FROM quay.io/centos/centos:stream9 AS build
 
@@ -19,7 +20,8 @@ ARG SPDK_CEPH_VERSION \
     SPDK_PKGDEP_ARGS \
     SPDK_CONFIGURE_ARGS \
     SPDK_TARGET_ARCH \
-    SPDK_MAKEFLAGS
+    SPDK_MAKEFLAGS \
+    ACCEL_CONFIG_SRC
 
 RUN <<EOF
     echo Log variables
@@ -29,6 +31,7 @@ RUN <<EOF
     echo SPDK_TARGET_ARCH=$SPDK_TARGET_ARCH
     echo SPDK_MAKEFLAGS=$SPDK_MAKEFLAGS
     echo CEPH_CLUSTER_CEPH_REPO_BASEURL=$CEPH_CLUSTER_CEPH_REPO_BASEURL
+    echo ACCEL_CONFIG_SRC=$ACCEL_CONFIG_SRC
     echo ======================================================================
 EOF
 
@@ -84,6 +87,27 @@ RUN \
 RUN \
     --mount=type=cache,target=/var/cache/dnf \
     --mount=type=cache,target=/var/lib/dnf \
+    --mount=type=cache,target=/root/.cache/pip \
+    dnf groupinstall -y "Development Tools" \
+    && dnf install -y autoconf automake libtool pkgconf rpm-build rpmdevtools \
+    && dnf install -y which asciidoc xmlto libuuid-devel json-c-devel zlib-devel openssl-devel \
+    && mkdir -p $ACCEL_CONFIG_SRC \
+    && git clone https://github.com/intel/idxd-config.git $ACCEL_CONFIG_SRC \
+    && pushd $ACCEL_CONFIG_SRC \
+    && ./autogen.sh \
+    && ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc \
+                   --libdir=/usr/lib64 --enable-test=yes \
+                   --disable-docs \
+    && mkdir -p /root/rpmbuild/SOURCES \
+    && make rhel/accfg.spec \
+    && ./rpmbuild.sh \
+    && ls -l /root/rpmbuild/RPMS/$(uname -m) \
+    && rpm -ivh /root/rpmbuild/RPMS/$(uname -m)/accel-config-"*".rpm \
+    && ls -l /usr/include/accel-config/libaccel_config.h
+
+RUN \
+    --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,target=/var/lib/dnf \
     DEPS="no" \
     SPDK_VERSION=${SPDK_VERSION:?} \
     RPM_RELEASE=0 \
@@ -96,6 +120,7 @@ RUN make -C ./examples/bdev/bdevperf
 #------------------------------------------------------------------------------
 FROM registry.access.redhat.com/ubi9/ubi@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072 AS rpm-export
 COPY --from=build /root/rpmbuild/rpm /rpm
+COPY --from=build /root/rpmbuild/RPMS /rpm
 
 #------------------------------------------------------------------------------
 FROM registry.access.redhat.com/ubi9/ubi@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072 as spdk

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -91,6 +91,8 @@ timeout = 60.0
 #log_level =
 #protocol_log_level = WARNING
 #log_file_dir =
+# DSA CRC32 acceleration, enabled by default
+#enable_dsa_acceleration = False
 
 # Example value: -m 0x3 -L all
 # tgt_cmd_extra_args =

--- a/control/server.py
+++ b/control/server.py
@@ -23,6 +23,7 @@ import spdk.rpc
 import spdk.rpc.client as rpc_client
 import spdk.rpc.nvmf as rpc_nvmf
 import spdk.rpc.iobuf as rpc_iobuf
+import spdk.rpc.dsa as rpc_dsa
 
 from .proto import gateway_pb2 as pb2
 from .proto import gateway_pb2_grpc as pb2_grpc
@@ -34,6 +35,7 @@ from .config import GatewayConfig
 from .utils import GatewayLogger
 from .utils import GatewayUtils
 from .utils import GatewayUtilsCrypto
+from .utils import DsaUtils
 from .cephutils import CephUtils
 from .prometheus import start_exporter
 
@@ -277,6 +279,9 @@ class GatewayServer:
                                       f"gateway-{self.name}")
         self.omap_state = omap_state
         local_state = LocalGatewayState()
+
+        # Accel config
+        self._accel_config()
 
         # install SIGCHLD handler
         signal.signal(signal.SIGCHLD, sigchld_handler)
@@ -543,7 +548,6 @@ class GatewayServer:
 
         # Start target
         self.logger.debug(f"Configuring server {self.name}")
-        waiting_for_rpc = False
         spdk_tgt_path = self.config.get("spdk", "tgt_path")
         self.logger.info(f"SPDK Target Path: {spdk_tgt_path}")
         sockdir = self.config.get_with_default("spdk", "rpc_socket_dir", "/var/tmp/")
@@ -565,16 +569,12 @@ class GatewayServer:
         self.logger.info(f"SPDK Socket: {self.spdk_rpc_socket_path}")
         spdk_tgt_cmd_extra_args = self.config.get_with_default(
             "spdk", "tgt_cmd_extra_args", "")
-        cmd = [spdk_tgt_path, "-u", "-r", self.spdk_rpc_socket_path]
+        cmd = [spdk_tgt_path, "--wait-for-rpc", "-u", "-r", self.spdk_rpc_socket_path]
 
         iobuf_options = self.config.get_with_default("spdk", "iobuf_options", "")
         max_subsystems = self.config.getint_with_default("gateway",
                                                          "max_subsystems",
                                                          GatewayService.MAX_SUBSYSTEMS_DEFAULT)
-        if iobuf_options or max_subsystems > 0:
-            waiting_for_rpc = True
-            cmd += ["--wait-for-rpc"]
-
         # Add extra args from the conf file
         if spdk_tgt_cmd_extra_args:
             cmd += shlex.split(spdk_tgt_cmd_extra_args)
@@ -653,8 +653,8 @@ class GatewayServer:
             if iobuf_options:
                 self._initialize_iobuf_options(iobuf_options)
 
-            if waiting_for_rpc:
-                self._initialize_framework()
+            # Set config and enable dsa accel module offload.
+            self._probe_dsa()
 
             self.spdk_rpc_ping_client = rpc_client.JSONRPCClient(
                 self.spdk_rpc_socket_path,
@@ -670,6 +670,7 @@ class GatewayServer:
                 log_level=protocol_log_level,
                 conn_retries=conn_retries,
             )
+
         except Exception:
             self.logger.exception("Unable to initialize SPDK")
             raise
@@ -831,14 +832,26 @@ class GatewayServer:
             self.logger.exception("IObuf set options returned with error")
             pass
 
-    def _initialize_framework(self):
-        """In case we started SPDK with the "wait for rpc" flag, we need to call this"""
+    def _accel_config(self):
+        # Instantiate DsaUtils and run config
+        if self.config.getboolean_with_default("spdk", "enable_dsa_acceleration", True):
+            dsa_utils = DsaUtils(self.logger)
+            dsa_utils.config()
+        else:
+            self.logger.info("DSA acceleration device configuration is disabled")
 
+    def _probe_dsa(self):
+        """Initializes dsa accel module offload."""
         try:
+            if self.config.getboolean_with_default("spdk", "enable_dsa_acceleration", True):
+                res = rpc_dsa.dsa_scan_accel_module(self.spdk_rpc_client, config_kernel_mode=True)
+                self.logger.debug(f"dsa_scan_accel_module: {res=}")
+            else:
+                self.logger.info("DSA acceleration module scanning is disabled")
             spdk.rpc.framework_start_init(self.spdk_rpc_client)
         except Exception:
-            self.logger.exception("Framework start init returned with error")
-            pass
+            self.logger.exception("Failed to probe dsa accel module offload")
+            raise
 
     def _create_transport(self, trtype):
         """Initializes a transport type."""

--- a/control/utils.py
+++ b/control/utils.py
@@ -21,6 +21,9 @@ from typing import Tuple, List
 from cryptography.fernet import Fernet
 import cryptography.exceptions
 import base64
+import json
+import subprocess
+from pathlib import Path
 
 
 class GatewayEnumUtils:
@@ -662,3 +665,126 @@ class NIC:
             f"ip v4: {','.join(self.ipv4_addresses)}\n"
             f"ip v6: {','.join(self.ipv6_addresses)}\n"
         )
+
+
+class DsaUtils:
+    def __init__(self, logger):
+        self.logger = logger
+
+    def _build_dsa_config(self):
+        pci_id = ("0x8086", "0x0b25")
+        base_path = Path("/sys/bus/pci/devices")
+        json_list = []
+        count = 0
+
+        for dev_path in base_path.iterdir():
+            vendor_file = dev_path / "vendor"
+            device_file = dev_path / "device"
+
+            if not vendor_file.exists() or not device_file.exists():
+                continue
+
+            vendor = vendor_file.read_text().strip()
+            device = device_file.read_text().strip()
+
+            if (vendor, device) == pci_id:
+                dsa_dev = f"dsa{count}"
+                entry = {
+                    "dev": dsa_dev,
+                    "read_buffer_limit": 0,
+                    "groups": [
+                        {
+                            "dev": f"group{count}.0",
+                            "grouped_workqueues": [
+                                {
+                                    "dev": f"wq{count}.0",
+                                    "mode": "dedicated",
+                                    "size": 32,
+                                    "group_id": 0,
+                                    "priority": 10,
+                                    "block_on_fault": 1,
+                                    "max_batch_size": 32,
+                                    "max_transfer_size": 16384,
+                                    "type": "user",
+                                    "driver_name": "user",
+                                    "name": "app1",
+                                    "threshold": 0
+                                }
+                            ],
+                            "grouped_engines": [
+                                {
+                                    "dev": f"engine{count}.0",
+                                    "group_id": 0
+                                }
+                            ]
+                        },
+                        {
+                            "dev": f"group{count}.1",
+                            "grouped_workqueues": [
+                                {
+                                    "dev": f"wq{count}.1",
+                                    "mode": "dedicated",
+                                    "size": 32,
+                                    "group_id": 1,
+                                    "priority": 10,
+                                    "block_on_fault": 1,
+                                    "max_batch_size": 32,
+                                    "max_transfer_size": 2097152,
+                                    "type": "user",
+                                    "driver_name": "user",
+                                    "name": "app2",
+                                    "threshold": 0
+                                }
+                            ],
+                            "grouped_engines": [
+                                {
+                                    "dev": f"engine{count}.1",
+                                    "group_id": 1
+                                }
+                            ]
+                        }
+                    ]
+                }
+                json_list.append(entry)
+                count += 1
+
+        return json_list, count
+
+    def _run_command(self, cmd, label):
+        try:
+            output = subprocess.check_output(cmd, text=True)
+            self.logger.info(f"{label} Output:\n{output}")
+        except subprocess.CalledProcessError:
+            self.logger.exception(f"{label} failed:")
+
+    def config(self):
+        conf_file = "/tmp/dsa_config.json"
+        config_data, count = self._build_dsa_config()
+
+        if count == 0:
+            self.logger.warning("No matching DSA devices found (8086:0b25).")
+            return
+
+        self.logger.info(f"Found {count} matching DSA devices. Loading config.")
+        with open(conf_file, 'w') as f:
+            json.dump(config_data, f, indent=2)
+
+        try:
+            commands = [
+                (["accel-config", "info"], "Before config - info"),
+                (["accel-config", "list"], "Before config - list"),
+                (["accel-config", "load-config", "-c", conf_file, "-e"], "Load config"),
+                (["accel-config", "info"], "After config - info"),
+                (["accel-config", "list"], "After config - list"),
+            ]
+
+            for cmd, label in commands:
+                self._run_command(cmd, label)
+        finally:
+            try:
+                os.remove(conf_file)
+                self.logger.info(f"Removed DSA config file: {conf_file}")
+            except OSError as e:
+                # ENOENT is fine
+                if e.errno != errno.ENOENT:
+                    self.logger.exception(f"Error removing DSA config file {conf_file}")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -136,12 +136,17 @@ services:
         CONTAINER_REGISTRY:
       labels:
         io.ceph.nvmeof:
+    privileged: true # accel-config
     volumes:
       # sudo bash -c 'echo 2048 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages'
       # https://spdk.io/doc/containers.html
       # TODO: Pending of https://github.com/spdk/spdk/issues/2973
       - /dev/hugepages:/dev/hugepages
       - /dev/vfio/vfio:/dev/vfio/vfio
+      # accel-config
+      - /dev/dsa:/dev/dsa
+      - /dev/char:/dev/char
+      # accel-config
       - $NVMEOF_CONFIG:/src/ceph-nvmeof.conf
       - /tmp/coredump:/tmp/coredump # core dump
       - /var/log/ceph:/var/log/ceph
@@ -150,6 +155,7 @@ services:
       - SYS_ADMIN # huge-pages
       - CAP_SYS_NICE # RTE
       - SYS_PTRACE # gdb
+      - SYS_RAWIO # idxd/dsa
     ulimits:
       nofile: $NVMEOF_NOFILE
       memlock: -1


### PR DESCRIPTION
# idxd/dsa

This pull request introduces support for Intel's Data Streaming Accelerator (DSA) by adding the necessary build steps, configuration logic, and container permissions to allow the Ceph NVMe-oF Gateway's underlying SPDK process to discover, configure, and utilize Intel DSA devices managed by the kernel idxd driver for acceleration offload. It specifically configures dedicated WQs using accel-config and initializes the DSA acceleration module within SPDK via RPCs, the WQ mode configuration based on accel-config [storage profile](https://github.com/intel/idxd-config/blob/stable/contrib/configs/storage_profile.conf) and SPDK[ acceleration framework](https://spdk.io/doc/accel_fw.html) sample configuration.

# Data flow

```
+---------------------------+
|  SPDK Reactor Thread L    |  ← Bound to CPU Core on Socket X
|  SPDK Reactor Thread M    |
|  SPDK Reactor Thread N    |
|  (NUMA Node X)            |
+---------------------------+
             |
             v
+---------------------------+
|  Shared Work Queue X      |
+---------------------------+
             |
             v
+---------------------------+
|  IDXD Kernel Driver       |  ← Uses DSA device on NUMA Node X
+---------------------------+
             |
             v
+---------------------------+
|  Intel DSA Hardware       |  ← NUMA-local to Socket X
|  (e.g., dsaX)             |
+---------------------------+
```

On multi-socket systems, each SPDK reactor thread is pinned to a core on a specific NUMA node. To minimize latency and maximize throughput, the reactor thread utilizes a DSA hardware device (via the idxd driver) that is NUMA-local to its CPU socket. This avoids costly cross-socket memory access and improves DMA performance.

## Linux Kernel

The Intel data streaming accelerator driver (IDXD) is fully supported in RHEL 9.4 and loaded during boot by default.

The Intel DSA device [is included](https://elixir.bootlin.com/linux/v6.15/source/drivers/vfio/pci/vfio_pci.c#L74) in the default deny list of the vfio-pci driver.

### Boot command line
Tested boot command line
```
$ cat /proc/cmdline
BOOT_IMAGE=(hd1,gpt2)/vmlinuz-5.14.0-570.17.1.el9_6.x86_64 root=/dev/mapper/rhel-root ro crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M resume=/dev/mapper/rhel-swap rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap intel_iommu=on,sm_on no5lvl
```

#### intel_iommu=on,sm_on
Intel DSA usage with user space memory requires Intel VT-d to be enabled. 
VT-d with scalable mode support (CONFIG_INTEL_IOMMU_SVM in kernel configuration) is necessary for Shared Virtual Memory (SVM). SVM allows the DSA device to operate in the application's virtual memory space and enables operations from pageable memory, avoiding the need to pin memory for DMA operations. The SPDK documentation explicitly states that to leverage the Linux idxd kernel driver for DSA devices, you need a kernel with the driver loaded and must add intel_iommu=on,sm_on to the kernel boot commands.

#### no5lvl
- https://github.com/intel/idxd-config/issues/46#issuecomment-2159614409
- [Valid kernel command line parameters shows as "Unknown kernel command line parameters:"](https://access.redhat.com/solutions/7016469)

#### How to modify the kernel command-line
- [RHEL9](https://access.redhat.com/solutions/6668601)

## Integration of accel-config

The Dockerfile.spdk is modified to include a step that clones, builds, and installs the accel-config utility and its library (libaccel-config) from the Intel GitHub repository ([intel/idxd-config](https://github.com/intel/idxd-config)).

The developer version of the accel-config library (libaccel-config) [is required](https://github.com/ceph/spdk/blob/2f8edabb7f818430cf7bfe8ba695242e6510f85c/configure#L752-L754) to leverage the Linux idxd driver from SPDK.

Also accel-config is used to configure Intel DSA devices and Work Queues (WQs) via the Linux sysfs interface, and DSA devices managed by the idxd kernel driver.

## DSA Device Configuration Logic

A new Python class DsaUtils is added in control/utils.py. This class finds Intel DSA devices on the system using their PCI ID 0x0b25 by examining entries in /sys/bus/pci/devices. If DSA devices are found, it generates a configuration structure compatible with accel-config in JSON format and applies the work queue configuration to hardware.

## SPDK Integration

A new method _probe_dsa() is added which calls SPDK RPC  `dsa_scan_accel_module` with `config_kernel_mode=True` to initialize the DSA acceleration module using the built-in Linux kernel idxd driver, initializing a  DSA hardware module and then starting the framework assigns supported operations (like copy, fill, etc.) to that module. The SPDK Accel framework theoretically supports a variety of operations (see reference [here](https://github.com/ceph/spdk/blob/85a10c98e70a1d3bc6c166e2f2939b3e5bae37dc/include/spdk/accel.h#L34-L46)). However, in practice, the SPDK NVMe-oF TCP transport  offloads only CRC32C calculations for data digests to the Accel framework, which then routes these requests to the DSA hardware via the IDXD driver. There are conditions if  CRC32C offload could be used , see [here](https://github.com/ceph/spdk/blob/b42328da736e1b51572d8c3ef759851a7746513a/lib/nvmf/tcp.c#L1260) and [here](https://github.com/ceph/spdk/blob/b42328da736e1b51572d8c3ef759851a7746513a/lib/nvmf/tcp.c#L2253).

# Container run time - Docker Compose Configuration

- The docker-compose.yaml file is updated to provide the necessary permissions and device access for the SPDK container to interact with the DSA devices via the kernel driver.

- privileged: true is added, which grants the container extensive capabilities, including access to host devices and filesystem manipulation, used for DSA devices configuration

- The SYS_RAWIO capability is added. According to the Intel DSA User Guide, a process with CAP_SYS_RAW_IO capability can map the work submission portal into its address space.

- /dev/dsa and /dev/char are mounted into the container. The /dev/dsa directory contains WQ device files like /dev/dsa/wqD.Q created by the driver for enabled WQs.

# Data Digests for TCP Connections and DSA Offload

The decision to enable the feature (data digest) is made by the host via the CLI flags and negotiated with the target.

The NVMe-over-Fabrics specification includes optional Header and Data digest fields within the NVMe/TCP Protocol Data Units (PDUs). These digests are added to the PDU structure and are included or omitted based on negotiation during connection establishment. The digest algorithm specified is CRC32C.

The primary purpose of PDU Header and Data digests is to **ensure data integrity** over the TCP/IP fabric.

*   **Header Digest (HDGST):** Protects the PDU header. A header digest error is treated as a **fatal transport error** and results in the connection being terminated.
*   **Data Digest (DDGST):** Protects the PDU data . A data digest error is treated as a **non-fatal transport error** . If detected by the host in a C2HData PDU, the host continues processing but fails the command with a non-fatal transport error status if the controller indicated success. If detected by the controller in a CapsuleCmd (with in-capsule data) or H2CData PDU, the controller fails the command with a non-fatal transport error status.

## How to use Data Digests with `nvme connect`

The `nvme` command-line interface, when connecting using the TCP transport (`--transport=tcp`), provides specific flags to request the use of digests from the target:

*   `--hdr-digest` (`-g`): Requests that the target enable PDU Header Digest generation and verification for this connection.
*   `--data-digest` (`-G`): Requests that the target enable PDU Data Digest generation and verification for this connection.

These flags, when included in the `nvme connect` command, signal the host's capability and desire to use these digest features during the connection establishment phase (specifically, via the Initialize Connection Request (ICReq) PDU. The target indicates its agreement or disagreement in the Initialize Connection Response (ICResp) PDU . Digests are only enabled if both the host (via the `nvme connect` flag) and the target (via its configuration) agree.

**Example `nvme connect` command requesting header and data digest:**

```bash
# nvme connect -t tcp --hdr-digest --data-digest --traddr 192.168.13.3 -s 4420 -n nqn.2016-06.io.spdk:cnode1
```

If you use the default nvme connect flags, which means omitting the --hdr-digest and --data-digest flags, the DSA offload capability on the SPDK target for accelerating data digest calculations specifically for this NVMe/TCP connection will not be utilized.

