### PR TITLE
atom sha bump and automatic rebalancing test enable

### DIFF
--- a/.env
+++ b/.env
@@ -71,7 +71,7 @@ CEPH_SHA=latest
 CEPH_DEVEL_MGR_PATH=../ceph
 
 # Atom
-ATOM_SHA=269ce6fd8ec65bfe6eb25d19415f13927bd80e60
+ATOM_SHA=f33642d1e01df5b1a6a4140f3b31b33a4bbfd945
 
 # Demo settings
 RBD_POOL=rbd

--- a/tests/atom/clusterBuildTestsRun.sh
+++ b/tests/atom/clusterBuildTestsRun.sh
@@ -46,7 +46,7 @@ cd ceph-nvmeof-atom
 git checkout $ATOM_SHA
 
 # Build atom images based on the cloned repo
-docker build -t nvmeof_atom:$ATOM_SHA .
+sudo docker build -t nvmeof_atom:$ATOM_SHA .
 
 set -x
 if [ "$5" != "nightly" ]; then
@@ -69,6 +69,7 @@ if [ "$5" != "nightly" ]; then
         --failover-num=2 \
         --failover-num-after-upgrade=2 \
         --rbd-size=200M \
+        --seed=0 \
         --fio-devices-num=1 \
         --lb-timeout=20 \
         --config-dbg-mon=10 \
@@ -80,9 +81,11 @@ if [ "$5" != "nightly" ]; then
         --nvmeof-daemon-remove \
         --redeploy-gws \
         --github-action-deployment \
-        --skip-ns-rebalancing-test \
+        --dont-use-mtls \
         --journalctl-to-console \
         --dont-power-off-cloud-vms \
+        --ibm-cloud-key=nokey \
+        --github-nvmeof-token=nokey \
         --env=m6
 else
     sudo docker run \
@@ -101,9 +104,10 @@ else
         --subsystem-num=118 \
         --ns-num=8 \
         --subsystem-max-ns-num=1024 \
-        --failover-num=6 \
+        --failover-num=10 \
         --failover-num-after-upgrade=2 \
         --rbd-size=200M \
+        --seed=0 \
         --fio-devices-num=1 \
         --lb-timeout=20 \
         --config-dbg-mon=10 \
@@ -116,10 +120,11 @@ else
         --redeploy-gws \
         --github-action-deployment \
         --dont-use-mtls \
-        --skip-ns-rebalancing-test \
         --journalctl-to-console \
         --dont-power-off-cloud-vms \
         --dont-use-hugepages \
+        --ibm-cloud-key=nokey \
+        --github-nvmeof-token=nokey \
         --env=m6
 fi
 set +x


### PR DESCRIPTION
- all tests are running now (no skip tests)
- 10 cycles in nightly run (instead of 6)
- update to latest atom sha
- change m6 nodes