### PR TITLE
server.py: remove '<pool>.<group>' from metadata id

### DIFF
--- a/control/server.py
+++ b/control/server.py
@@ -301,6 +301,8 @@ class GatewayServer:
             "daemon_type": "gateway",          # "nvmeof: 3 <daemon_type> active (3 hosts)"
             "group": self.config.get_with_default("gateway", "group", ""),
         }
+        metadata["id"] = metadata["id"].removeprefix(
+            f"{metadata['pool_name']}.{metadata['group']}.")
         self.ceph_utils.service_daemon_register(conn, metadata)
 
     def _monitor_client_version(self) -> str:


### PR DESCRIPTION
In service_map registeration, shorten "id" by
removing rbd pool name and gw group name.

Before: `"id": "mypool.mygroup1.ceph-nvme-vm8.fntlci"`
After: `"id": "ceph-nvme-vm8.fntlci"`

This helps to display short gateway names in "ceph -s" output. Exmaple:
```
    nvmeof (mygroup1) : 2 gateways active (ceph-nvme-vm13.azfdpk, ceph-nvme-vm14.hdsoxl)
    nvmeof (mygroup2) : 2 gateways active (ceph-nvme-vm11.hnooxs, ceph-nvme-vm12.wcjcjs)
```

Related PR: https://github.com/ceph/ceph/pull/61624