### PR TITLE
cluster.py: extract interface and add ClusterPoolAllocator and FlatBdevsPerCluster

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -575,7 +575,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["sanity", "no_huge", "ns_lb_change", "no_subsystems", "auto_load_balance", "state_transitions", "state_transitions_both_gws", "state_transitions_loop", "state_transitions_rand_loop", "late_registration", "late_registration_loop", "4gws", "4gws_loop", "4gws_create_delete", "4gws_create_delete_loop", "namespaces", "namespaces_loop", "mtls", "notify", "ceph_status", "blocklist", "main_exit"]
+        test: ["sanity", "no_huge", "ns_lb_change", "no_subsystems", "auto_load_balance", "state_transitions", "state_transitions_both_gws", "state_transitions_loop", "state_transitions_rand_loop", "late_registration", "late_registration_loop", "4gws", "4gws_loop", "4gws_create_delete", "4gws_create_delete_loop", "namespaces", "namespaces_loop", "mtls", "notify", "ceph_status", "blocklist", "main_exit", "cluster_pool", "flat_bdev_per_cluster"]
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 1024  # 4 spdk instances

--- a/README.md
+++ b/README.md
@@ -324,6 +324,52 @@ This is automatically done in the `make setup` step. The amount of hugepages can
 mem_size=4096
 ```
 
+### Mapping SPDK BDEVs into a CEPH RADOS Cluster Context
+
+NVMEoF namespaces utilize SPDK BDEVs which map into CEPH RADOS client cluster contexts, and the mapping strategy impacts both performance and resource allocation. Multiple BDEVs can be allocated to a single CEPH cluster context, influencing I/O efficiency, cluster scalability, and system overhead. The choice of mapping strategy affects:
+
+- _Cluster context allocation cost_: Creating and maintaining CEPH cluster contexts incurs resource overhead.
+- _I/O bottlenecks_: If too many BDEVs share the same context, contention may degrade performance.
+- _Scalability_: The approach must balance between efficient resource usage and avoiding excessive cluster context creation.
+
+#### Mapping Strategies
+
+##### 1. Legacy ANA Group-Based Mapping
+
+A CEPH cluster context is allocated per ANA group.
+
+The number of BDEVs assigned to each cluster context is controlled by the bdevs_per_cluster configuration parameter. This strategy ensures alignment with ANA group allocation but may lead to uneven distribution across cluster contexts.
+
+```ini
+[spdk]
+bdevs_per_cluster = 32
+```
+
+##### 2. Flat BDEVs per Cluster Mapping
+
+Ignores ANA groups and directly assigns BDEVs to cluster contexts. The number of BDEVs per cluster context is determined by the flat_bdevs_per_cluster parameter. Offers a more uniform distribution but might not align well with underlying ANA group optimizations.
+
+```ini
+[spdk]
+flat_bdevs_per_cluster = 32
+```
+- [Example configuration](https://github.com/baum/ceph-nvmeof/blob/cluster-allocation/tests/ceph-nvmeof.flat_bdevs_per_cluster.conf)
+
+##### 3. Cluster Pool-Based Mapping
+
+The maximum number of cluster contexts is pre-defined by the cluster_pool_size configuration parameter.
+
+When a new BDEV is created, it is assigned to the cluster context with the fewest BDEVs. This dynamic approach balances workload distribution but may introduce overhead in tracking and rebalancing BDEV allocations.
+
+```ini
+[spdk]
+cluster_pool_size = 32
+```
+- [Example configuration](https://github.com/baum/ceph-nvmeof/blob/cluster-allocation/tests/ceph-nvmeof.cluster_pool.conf)
+
+Choosing the appropriate strategy depends on workload characteristics, expected BDEV-to-cluster context ratios, and system performance goals.
+
+
 ## Development
 
 ### Set-up

--- a/control/cluster.py
+++ b/control/cluster.py
@@ -1,0 +1,257 @@
+#
+#  Copyright (c) 2025 International Business Machines
+#  All rights reserved.
+#
+#  SPDX-License-Identifier: LGPL-3.0-or-later
+#
+
+from abc import ABC, abstractmethod
+from .config import GatewayConfig
+from collections import defaultdict
+from typing import Dict
+import spdk.rpc.bdev as rpc_bdev
+
+
+# Interface for cluster allocation strategy
+class ClusterAllocationStrategy(ABC):
+    @abstractmethod
+    def get_cluster(self, anagrp: int) -> str:
+        """Get cluster name, used by bdev allocation"""
+        pass
+
+    @abstractmethod
+    def put_cluster(self, name: str) -> None:
+        """Free cluster name, updates the reference count"""
+        pass
+
+    # Protected methods used by concrete classes
+    def _init_common(self, config: GatewayConfig, gs) -> None:
+        """Init common cluster context management variables"""
+        self.config = config
+        self.gs = gs
+        self.librbd_core_mask = self.config.get_with_default(
+            "spdk", "librbd_core_mask", None
+        )
+        self.rados_id = self.config.get_with_default("ceph", "id", "")
+        if self.rados_id == "":
+            self.rados_id = None
+
+    def _alloc_cluster(self, name: str) -> str:
+        """Allocates a new Rados cluster context with SPDK"""
+        nonce = rpc_bdev.bdev_rbd_register_cluster(
+            self.gs.spdk_rpc_client,
+            name=name,
+            user_id=self.rados_id,
+            core_mask=self.librbd_core_mask,
+        )
+        self.gs.set_cluster_nonce(name, nonce)
+        return name
+
+    def _free_cluster(self, name: str) -> str:
+        """Unregister SPDK Rados cluster context"""
+        ret = rpc_bdev.bdev_rbd_unregister_cluster(self.gs.spdk_rpc_client, name=name)
+        self.gs.logger.info(f"Free cluster {name=} {ret=}")
+        assert ret
+
+
+class AnaGrpBdevsPerCluster(ClusterAllocationStrategy):
+    def __init__(self, config: GatewayConfig, gs) -> None:
+        """Init cluster context management variables"""
+        self._init_common(config, gs)
+        self.clusters = defaultdict(dict)
+        self.bdevs_per_cluster = self.config.getint("spdk", "bdevs_per_cluster")
+        if self.bdevs_per_cluster < 1:
+            raise Exception(
+                f"invalid configuration: spdk.bdevs_per_cluster "
+                f"{self.bdevs_per_cluster} < 1"
+            )
+        self.gs.logger.info(f"NVMeoF bdevs per cluster: {self.bdevs_per_cluster}")
+
+    def get_cluster(self, anagrp: int) -> str:
+        """Returns cluster name, enforcing bdev per cluster context"""
+        cluster_name = None
+        for name in self.clusters[anagrp]:
+            if self.clusters[anagrp][name] < self.bdevs_per_cluster:
+                cluster_name = name
+                break
+
+        if not cluster_name:
+            cluster_name = self._alloc_cluster_name(anagrp)
+            self._alloc_cluster(cluster_name)
+            self.clusters[anagrp][cluster_name] = 1
+        else:
+            self.clusters[anagrp][cluster_name] += 1
+        self.gs.logger.info(
+            f"get_cluster {cluster_name=} number bdevs: "
+            f"{self.clusters[anagrp][cluster_name]}"
+        )
+        return cluster_name
+
+    def put_cluster(self, name: str) -> None:
+        """Free cluster by name, update reference count"""
+        for anagrp in self.clusters:
+            if name in self.clusters[anagrp]:
+                self.clusters[anagrp][name] -= 1
+                assert self.clusters[anagrp][name] >= 0
+                # free the cluster context if no longer used by any bdev
+                if self.clusters[anagrp][name] == 0:
+                    self._free_cluster(name)
+                    self.clusters[anagrp].pop(name)
+                else:
+                    self.gs.logger.info(
+                        f"put_cluster {name=} number bdevs: "
+                        f"{self.clusters[anagrp][name]}"
+                    )
+                return
+
+        assert (
+            False
+        ), f"Cluster {name} is not found"  # we should find the cluster in our state
+
+    def _alloc_cluster_name(self, anagrp: int) -> str:
+        """Allocates a new cluster name for ana group"""
+        x = 0
+        while True:
+            name = f"cluster_context_{anagrp}_{x}"
+            if name not in self.clusters[anagrp]:
+                return name
+            x += 1
+
+
+class FlatBdevsPerCluster(ClusterAllocationStrategy):
+    def __init__(self, config: GatewayConfig, gs) -> None:
+        """Init cluster context management variables"""
+        self._init_common(config, gs)
+        self.flat_clusters: Dict[str, int] = {}
+        self.flat_bdevs_per_cluster = self.config.getint(
+            "spdk", "flat_bdevs_per_cluster"
+        )
+        if self.flat_bdevs_per_cluster < 1:
+            raise Exception(
+                f"invalid configuration: spdk.flat_bdevs_per_cluster "
+                f"{self.flat_bdevs_per_cluster} < 1"
+            )
+        self.gs.logger.info(
+            f"NVMeoF flat bdevs per cluster: {self.flat_bdevs_per_cluster}"
+        )
+
+    def get_cluster(self, anagrp: int) -> str:
+        """Returns cluster name, bdev per cluster context while ignoring the ana group"""
+        cluster_name = None
+        for name in self.flat_clusters:
+            if self.flat_clusters[name] < self.flat_bdevs_per_cluster:
+                cluster_name = name
+                break
+
+        if not cluster_name:
+            cluster_name = self._alloc_cluster_name()
+            self._alloc_cluster(cluster_name)
+            self.flat_clusters[cluster_name] = 1
+        else:
+            self.flat_clusters[cluster_name] += 1
+        self.gs.logger.info(
+            f"get_cluster {cluster_name=} number bdevs: "
+            f"{self.flat_clusters[cluster_name]}"
+        )
+        return cluster_name
+
+    def put_cluster(self, name: str) -> None:
+        """Free cluster by name, update reference count"""
+        if name in self.flat_clusters:
+            self.flat_clusters[name] -= 1
+            assert self.flat_clusters[name] >= 0
+            # free the cluster context if no longer used by any bdev
+            if self.flat_clusters[name] == 0:
+                self._free_cluster(name)
+                self.flat_clusters.pop(name)
+            else:
+                self.gs.logger.info(
+                    f"put_cluster {name=} number bdevs: " f"{self.flat_clusters[name]}"
+                )
+            return
+
+        assert (
+            False
+        ), f"Cluster {name} is not found"  # we should find the cluster in our state
+
+    def _alloc_cluster_name(self) -> str:
+        """Allocates a new cluster name, disregard ana group"""
+        x = 0
+        while True:
+            name = f"cluster_context_{x}"
+            if name not in self.flat_clusters:
+                return name
+            x += 1
+
+
+# Cluster pool implementation of ClusterAllocationStrategy
+class ClusterPoolAllocator(ClusterAllocationStrategy):
+    def __init__(self, config: GatewayConfig, gs) -> None:
+        """Init cluster context management variables"""
+        self._init_common(config, gs)
+        self.pool_size = self.config.getint("spdk", "cluster_pool_size")
+        if self.pool_size < 1:
+            raise Exception(
+                f"invalid configuration: spdk.cluster_pool_size "
+                f"{self.cluster_pool_size} < 1"
+            )
+        self.gs.logger.info(f"NVMeoF cluster pool size: {self.pool_size}")
+        # Initialize cluster names as "cluster_1", "cluster_2", ..., "cluster_n"
+        self.clusters = [f"cluster_{i + 1}" for i in range(self.pool_size)]
+        # Initialize usage counts for each cluster
+        self.usage_counts: Dict[str, int] = {cluster: 0 for cluster in self.clusters}
+
+    def get_cluster(self, anagrp: int) -> str:
+        """
+        Allocate the cluster with the minimum usage count.
+
+        Args:
+            anagrp (int): The ANA group (unused in this implementation).
+
+        Returns:
+            str: The name of the allocated cluster.
+        """
+        # Find the cluster with the minimum usage count
+        min_cluster = min(self.usage_counts, key=self.usage_counts.get)  # type: ignore
+        # Lazy cluster allocation
+        if self.usage_counts[min_cluster] == 0:
+            self._alloc_cluster(min_cluster)
+        # Increment the usage count for the allocated cluster
+        self.usage_counts[min_cluster] += 1
+        return min_cluster
+
+    def put_cluster(self, name: str) -> None:
+        """
+        Release a cluster and update its usage count.
+
+        Args:
+            name (str): The name of the cluster to release.
+
+        Raises:
+            AssertionError: If the cluster name does not exist in the pool.
+                            If invalid usage count detected.
+        """
+        # Assert that the cluster name exists in the pool
+        assert name in self.usage_counts, f"Cluster {name} does not exist in the pool."
+
+        # Decrement the usage count for the released cluster
+        assert (
+            self.usage_counts[name] > 0
+        ), f"Cluster {name} invalid usage count {self.usage_counts[name]}."
+        self.usage_counts[name] -= 1
+
+        # Lazy deallocate
+        if self.usage_counts[name] == 0:
+            self._free_cluster(name)
+
+
+# Factory function to return an instance of an cluster allocator according to config
+def get_cluster_allocator(config: GatewayConfig, gs) -> ClusterAllocationStrategy:
+    if config.is_param_defined("spdk", "bdevs_per_cluster"):
+        return AnaGrpBdevsPerCluster(config, gs)
+    elif config.is_param_defined("spdk", "flat_bdevs_per_cluster"):
+        return FlatBdevsPerCluster(config, gs)
+    elif config.is_param_defined("spdk", "cluster_pool_size"):
+        return ClusterPoolAllocator(config, gs)
+    else:
+        raise ValueError("Unknown cluster allocator in the config")

--- a/control/config.py
+++ b/control/config.py
@@ -28,6 +28,11 @@ class GatewayConfig:
             self.config = configparser.ConfigParser()
             self.config.read_file(f)
 
+    def is_param_defined(self, section, param):
+        if self.config.has_section(section):
+            return self.config.has_option(section, param)
+        return False
+
     def get(self, section, param):
         return self.config.get(section, param)
 

--- a/tests/ceph-nvmeof.cluster_pool.conf
+++ b/tests/ceph-nvmeof.cluster_pool.conf
@@ -71,13 +71,7 @@ server_cert = ./server.crt
 client_cert = ./client.crt
 
 [spdk]
-# Support multiple cluster allocation strategies
-# Legacy strategy, per ANA grp, max bdevs_per_cluster
-bdevs_per_cluster = 32
-# Flat bdevs per cluster, ignore ANA grp id
-# flat_bdevs_per_cluster = 32
-# Cluster pool
-# cluster_pool_size = 32
+cluster_pool_size = 32
 tgt_path = /usr/local/bin/nvmf_tgt
 #rpc_socket_dir = /var/tmp/
 #rpc_socket_name = spdk.sock

--- a/tests/ceph-nvmeof.flat_bdevs_per_cluster.conf
+++ b/tests/ceph-nvmeof.flat_bdevs_per_cluster.conf
@@ -71,13 +71,7 @@ server_cert = ./server.crt
 client_cert = ./client.crt
 
 [spdk]
-# Support multiple cluster allocation strategies
-# Legacy strategy, per ANA grp, max bdevs_per_cluster
-bdevs_per_cluster = 32
-# Flat bdevs per cluster, ignore ANA grp id
-# flat_bdevs_per_cluster = 32
-# Cluster pool
-# cluster_pool_size = 32
+flat_bdevs_per_cluster = 32
 tgt_path = /usr/local/bin/nvmf_tgt
 #rpc_socket_dir = /var/tmp/
 #rpc_socket_name = spdk.sock

--- a/tests/ha/cluster_pool.sh
+++ b/tests/ha/cluster_pool.sh
@@ -1,0 +1,1 @@
+sanity.sh

--- a/tests/ha/flat_bdev_per_cluster.sh
+++ b/tests/ha/flat_bdev_per_cluster.sh
@@ -1,0 +1,1 @@
+sanity.sh

--- a/tests/ha/start_up_cluster_pool.sh
+++ b/tests/ha/start_up_cluster_pool.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+# Check if GITHUB_WORKSPACE is defined
+if [ -n "$GITHUB_WORKSPACE" ]; then
+    test_dir="$GITHUB_WORKSPACE/tests/ha"
+else
+    test_dir=$(dirname $0)
+fi
+
+export NVMEOF_CONFIG=./tests/ceph-nvmeof.cluster_pool.conf
+$test_dir/start_up.sh

--- a/tests/ha/start_up_flat_bdev_per_cluster.sh
+++ b/tests/ha/start_up_flat_bdev_per_cluster.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+# Check if GITHUB_WORKSPACE is defined
+if [ -n "$GITHUB_WORKSPACE" ]; then
+    test_dir="$GITHUB_WORKSPACE/tests/ha"
+else
+    test_dir=$(dirname $0)
+fi
+
+export NVMEOF_CONFIG=./tests/ceph-nvmeof.flat_bdevs_per_cluster.conf
+$test_dir/start_up.sh


### PR DESCRIPTION
# cluster.py: extract interface and add ClusterPoolAllocator and FlatBdevsPerCluster

## New tests
### New strategy cluster pool

- [New strategy cluster_pool test](https://github.com/ceph/ceph-nvmeof/actions/runs/13152759708/job/36703655512?pr=1088)

### New strategy flat bdevs per cluster
- [New strategy flat_bdevs_per_cluster test](https://github.com/ceph/ceph-nvmeof/actions/runs/13227856205/job/36921190688?pr=1088)


# Mapping SPDK BDEVs into a CEPH RADOS Cluster Context

NVMEoF namespaces utilize SPDK BDEVs which map into CEPH RADOS client cluster contexts, and the mapping strategy impacts both performance and resource allocation. Multiple BDEVs can be allocated to a single CEPH cluster context, influencing I/O efficiency, cluster scalability, and system overhead. The choice of mapping strategy affects:

- _Cluster context allocation cost_: Creating and maintaining CEPH cluster contexts incurs resource overhead.
- _I/O bottlenecks_: If too many BDEVs share the same context, contention may degrade performance.
- _Scalability_: The approach must balance between efficient resource usage and avoiding excessive cluster context creation.

## Mapping Strategies

### 1. Legacy ANA Group-Based Mapping

A CEPH cluster context is allocated per ANA group.

The number of BDEVs assigned to each cluster context is controlled by the bdevs_per_cluster configuration parameter. This strategy ensures alignment with ANA group allocation but may lead to uneven distribution across cluster contexts.

```ini
[spdk]
bdevs_per_cluster = 32
```

### 2. Flat BDEVs per Cluster Mapping

Ignores ANA groups and directly assigns BDEVs to cluster contexts. The number of BDEVs per cluster context is determined by the flat_bdevs_per_cluster parameter. Offers a more uniform distribution but might not align well with underlying ANA group optimizations.

```ini
[spdk]
flat_bdevs_per_cluster = 32
```
- [Example configuration](https://github.com/baum/ceph-nvmeof/blob/cluster-allocation/tests/ceph-nvmeof.flat_bdevs_per_cluster.conf)

### 3. Cluster Pool-Based Mapping

The maximum number of cluster contexts is pre-defined by the cluster_pool_size configuration parameter.

When a new BDEV is created, it is assigned to the cluster context with the fewest BDEVs. This dynamic approach balances workload distribution but may introduce overhead in tracking and rebalancing BDEV allocations.

```ini
[spdk]
cluster_pool_size = 32
```
- [Example configuration](https://github.com/baum/ceph-nvmeof/blob/cluster-allocation/tests/ceph-nvmeof.cluster_pool.conf)

Choosing the appropriate strategy depends on workload characteristics, expected BDEV-to-cluster context ratios, and system performance goals.


