### PR TITLE
atom ci: get latest bin file from chacra (removing allow-mismatched-release flag in bootstrap)

### DIFF
--- a/.env
+++ b/.env
@@ -71,7 +71,7 @@ CEPH_SHA=latest
 CEPH_DEVEL_MGR_PATH=../ceph
 
 # Atom
-ATOM_SHA=662cc87e2757147c97734942eb1f7c93aebc3729
+ATOM_SHA=baebe89e804d5c21bbab9d71582309a6f0066bda
 
 # Demo settings
 RBD_POOL=rbd


### PR DESCRIPTION
- get latest bin file from chacra 
- removing allow-mismatched-release flag in bootstrap