### PR TITLE
tests/ha/ceph_status.sh: update assertion

### DIFF
--- a/tests/ha/ceph_status.sh
+++ b/tests/ha/ceph_status.sh
@@ -9,7 +9,7 @@ docker compose exec -T ceph ceph status
 
 echo "ℹ️  Step 1: verify 2 gateways"
 
-docker compose exec -T ceph ceph status | grep "nvmeof: 2 gateways active"
+docker compose exec -T ceph ceph status | grep "2 gateways: 2 active"
 
 echo "ℹ️  Step 2: stop a gateway"
 
@@ -19,4 +19,4 @@ sleep 5
 
 echo "ℹ️  Step 3: verify 1 gateway"
 
-docker compose exec -T ceph ceph status | grep "nvmeof: 1 gateway active"
+docker compose exec -T ceph ceph status | grep "2 gateways: 1 active"


### PR DESCRIPTION
update CI check according to changes in "ceph status" output introduced in https://github.com/ceph/ceph/pull/61624

New 'ceph status' output:
```
  services:
    mon:                      4 daemons, quorum ceph-nvme-vm31,ceph-nvme-vm28,ceph-nvme-vm30,ceph-nvme-vm29 (age 16m)
    mgr:                      ceph-nvme-vm31.wnfclf(active, since 18m), standbys: ceph-nvme-vm29.iuwqin, ceph-nvme-vm28.lnnyui, ceph-nvme-vm30.fitwnw
    osd:                      4 osds: 4 up (since 14m), 4 in (since 15m)
    nvmeof (mypool.mygroup1): 2 gateways: 1 active (ceph-nvme-vm30.kkcfux)
    nvmeof (mypool.mygroup2): 2 gateways: 2 active (ceph-nvme-vm28.mfqucr, ceph-nvme-vm29.hrizzl)
```