### PR TITLE
flake8 ver update fix

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -111,7 +111,6 @@ def test_state_notify_update(config, ioctx, local_state, omap_state):
 
     def _state_notify_update(update, is_add_req):
         nonlocal update_counter
-        nonlocal notify_event
         update_counter += 1
         elapsed = time.time() - start
         assert elapsed < update_interval_sec
@@ -140,7 +139,7 @@ def test_state_notify_update(config, ioctx, local_state, omap_state):
     version = 1
     update_interval_sec = 10
     state = GatewayStateHandler(config, local_state, omap_state,
-                                _state_notify_update, "test")
+                                _state_notify_update, None, "test")
     key = "namespace_test"
     state.update_interval = update_interval_sec
     state.use_notify = True


### PR DESCRIPTION
```
Verifying Python source files
9
flake8 control/*.py tests/*.py
10
tests/test_state.py:114:9: F824 `nonlocal notify_event` is unused: name is never assigned in scope
```