### PR TITLE
discovery service: restore default signal handlers

### DIFF
--- a/control/server.py
+++ b/control/server.py
@@ -399,6 +399,9 @@ class GatewayServer:
         assert self.discovery_pid is None
         self.discovery_pid = os.fork()
         if self.discovery_pid == 0:
+            self.logger.info("Forked for discovery service, restore default signal handlers")
+            signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
             self.logger.info("Starting ceph nvmeof discovery service")
             with DiscoveryService(self.config) as discovery:
                 discovery.start_service()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -69,6 +69,33 @@ class TestServer(unittest.TestCase):
         time.sleep(10)     # let it dump
         self.assert_no_core_files(self.core_dir)
 
+    def test_discovery_exit(self):
+        """Tests discovery service sub process exiting."""
+        test_config = copy.deepcopy(self.config)
+        signals = [signal.SIGABRT, signal.SIGTERM, signal.SIGKILL]
+
+        for sig in signals:
+            with self.assertRaises(SystemExit) as cm:
+                with GatewayServer(test_config) as gateway:
+                    gateway.set_group_id(0)
+                    gateway.serve()
+
+                    # Give the gateway some time to start
+                    time.sleep(2)
+
+                    # Send signal to the discovery service process
+                    assert gateway.discovery_pid
+                    os.kill(gateway.discovery_pid, sig)
+
+                    # Block on running keep alive ping
+                    gateway.keep_alive()
+
+            # Assert error exit code
+            self.validate_exception(cm.exception)
+
+            # Clean up cores
+            self.remove_core_files(self.core_dir)
+
     def test_monc_exit(self):
         """Tests monitor client sub process abort."""
         config_monc_abort = copy.deepcopy(self.config)


### PR DESCRIPTION
# discovery service: restore default signal handlers

The discovery service, forked from the gateway, inherits custom signal handlers for SIGCHLD (child process termination) and SIGTERM (termination request). These handlers, tailored for the gateway, can cause the discovery service to incorrectly attempt terminating subprocesses when a SIGTERM signal is received, potentially leading to errors or unexpected behavior.

To resolve this, we restore the default signal handlers for SIGCHLD and SIGTERM in the discovery service. This ensures that the service behaves appropriately when these signals are received, avoiding interference with subprocesses.

Issue: #1202 