### PR TITLE
Lock big OMAP files when reading their content

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["cli", "cli_change_lb", "cli_change_keys", "cli_change_ns_visibility", "cli_trash_rbd", "state", "multi_gateway", "server", "grpc", "omap_lock", "log_files", "nsid", "psk", "dhchap", "subsys_grp_name_append", "max_subsystems"]
+        test: ["cli", "cli_change_lb", "cli_change_keys", "cli_change_ns_visibility", "cli_trash_rbd", "state", "multi_gateway", "server", "grpc", "omap_lock", "log_files", "nsid", "psk", "dhchap", "subsys_grp_name_append", "max_subsystems", "omap_no_read_lock", "omap_read_lock", "omap_read_lock_ignore_errors", "big_omap"]
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance

--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -21,6 +21,9 @@ encryption_key = /etc/ceph/encryption.key
 rebalance_period_sec = 7
 max_gws_in_grp = 16
 max_ns_to_change_lb_grp = 8
+#abort_on_errors = True
+#omap_file_ignore_unlock_errors = False
+#omap_file_lock_on_read = True
 #omap_file_lock_duration = 20
 #omap_file_lock_retries = 30
 #omap_file_lock_retry_sleep_interval = 1.0
@@ -59,6 +62,7 @@ log_level=debug
 [discovery]
 addr = 0.0.0.0
 port = 8009
+#abort_on_errors = True
 
 [ceph]
 pool = rbd

--- a/control/discovery.py
+++ b/control/discovery.py
@@ -10,7 +10,7 @@
 import argparse
 import json
 from .config import GatewayConfig
-from .state import GatewayState, LocalGatewayState, OmapGatewayState, GatewayStateHandler
+from .state import GatewayState, LocalGatewayState, OmapLock, OmapGatewayState, GatewayStateHandler
 from .utils import GatewayLogger
 from .utils import GatewayUtilsCrypto
 
@@ -327,7 +327,11 @@ class DiscoveryService:
         self.version = 1
         self.config = config
         self.lock = threading.Lock()
-        self.omap_state = OmapGatewayState(self.config, f"discovery-{socket.gethostname()}")
+        self.abort_on_error = self.config.getboolean_with_default("discovery",
+                                                                  "abort_on_errors",
+                                                                  True)
+        self.omap_state = OmapGatewayState(self.config, None, f"discovery-{socket.gethostname()}")
+        self.omap_state.abort_on_error = self.abort_on_error
 
         self.gw_logger_object = GatewayLogger(config)
         self.logger = self.gw_logger_object.logger
@@ -344,6 +348,7 @@ class DiscoveryService:
             assert 0
         self.logger.info(f"discovery addr: {self.discovery_addr} port: {self.discovery_port}")
 
+        self.omap_lock = None
         self.sock = None
         self.conn_vals = {}
         self.connection_counter = 1
@@ -354,7 +359,7 @@ class DiscoveryService:
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self.omap_state:
-            self.omap_state.cleanup_omap()
+            self.omap_state.cleanup_omap(self.omap_lock)
             self.omap_state = None
 
         if self.selector:
@@ -390,8 +395,14 @@ class DiscoveryService:
     def _read_all(self) -> Dict[str, str]:
         """Reads OMAP and returns dict of all keys and values."""
 
-        omap_dict = self.omap_state.get_state()
-        return omap_dict
+        try:
+            omap_dict = self.omap_state.get_state()
+            return omap_dict
+        except Exception:
+            self.logger.exception("Failure getting OMAP state for discovery")
+            if self.abort_on_error:
+                raise
+        return {}
 
     def _get_vals(self, omap_dict, prefix):
         """Read values from the OMAP dict."""
@@ -1158,6 +1169,7 @@ class DiscoveryService:
                                             self.omap_state,
                                             self._state_notify_update,
                                             dummy_crypto, f"discovery-{socket.gethostname()}")
+        self.omap_lock = OmapLock(gateway_state, None)
         gateway_state.start_update()
 
         try:

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -554,7 +554,8 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
     def __init__(self, config: GatewayConfig, gateway_state: GatewayStateHandler,
                  rpc_lock, omap_lock: OmapLock, group_id: int, spdk_rpc_client,
-                 spdk_rpc_subsystems_client, ceph_utils: CephUtils) -> None:
+                 spdk_rpc_subsystems_client, ceph_utils: CephUtils,
+                 set_gateway_exit_message) -> None:
         """Constructor"""
         self.gw_logger_object = GatewayLogger(config)
         self.logger = self.gw_logger_object.logger
@@ -621,6 +622,13 @@ class GatewayService(pb2_grpc.GatewayServicer):
             "gateway",
             "enable_key_encryption",
             True)
+        # This is an option for development, normally we should abort the gateway on
+        # errors, this should only be used in case of some catastrophe when we
+        # want to keep the gateway up
+        self.abort_on_errors = self.config.getboolean_with_default(
+            "gateway",
+            "abort_on_errors",
+            True)
         self.ana_map = defaultdict(dict)
         self.ana_grp_state = {}
         self.ana_grp_ns_load = {}
@@ -655,6 +663,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
         self.spdk_version = None
         self.spdk_qos_timeslice = self.config.getint_with_default("spdk",
                                                                   "qos_timeslice_in_usecs", None)
+        self.set_gateway_exit_message = set_gateway_exit_message
 
     def get_directories_for_key_file(self, key_type: str,
                                      subsysnqn: str, create_dir: bool = False) -> []:
@@ -867,12 +876,33 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.info(f"Allocated cluster {name=} {nonce=}")
             self.cluster_nonce[name] = nonce
 
+    def abort_gateway_if_needed(self, where: str) -> None:
+        if self.abort_on_errors:
+            msg = f"Will abort gateway because of an error in {where}"
+            self.logger.critical(msg)
+            self.abort_on_errors = False
+            self.up_and_running = False
+            if self.set_gateway_exit_message is not None:
+                if not self.set_gateway_exit_message(msg):
+                    self.logger.warning(f"Can't get an indication about the gateway aborting. "
+                                        f"Will continue after an error in {where}")
+            else:
+                self.logger.warning(f"No gateway exit function set, will continue after "
+                                    f"an error in {where}")
+        else:
+            self.logger.warning(f"Gateway abort is disabled, will continue after "
+                                f"an error in {where}")
+
     def _grpc_function_with_lock(self, func, request, context):
         with self.rpc_lock:
             rc = func(request, context)
             if not self.omap_lock.omap_file_disable_unlock:
-                assert not self.omap_lock.locked(), f"OMAP is still locked when " \
-                                                    f"we're out of function {func}"
+                assert not self.omap_lock.write_locked_by_me(), \
+                    f"OMAP is still locked when exiting function {func.__name__}()\n" \
+                    f"locked by: {self.omap_lock.locked_by}, " \
+                    f"with cookie: {self.omap_lock.lock_cookie}" \
+                    f"current thread id: {threading.get_native_id()} " \
+                    f"locked: {self.omap_lock.is_exclusively_locked}"
             return rc
 
     def execute_grpc_function(self, func, request, context):
@@ -887,8 +917,16 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.ESHUTDOWN, error_message=errmsg)
 
-        return self.omap_lock.execute_omap_locking_function(
-            self._grpc_function_with_lock, func, request, context)
+        try:
+            rc = self.omap_lock.execute_omap_locking_function(
+                self._grpc_function_with_lock, func, request, context)
+        except Exception:
+            self.logger.exception(f"Failure while executing {func.__name__}()")
+            self.abort_gateway_if_needed(f"{func.__name__}()")
+            return pb2.req_status(status=errno.ESHUTDOWN,
+                                  error_message="Shutting down server")
+
+        return rc
 
     def create_bdev(self, anagrp: int, name, uuid, rbd_pool_name, rbd_image_name,
                     block_size, create_image, trash_image, rbd_image_size, context, peer_msg=""):
@@ -1520,8 +1558,11 @@ class GatewayService(pb2_grpc.GatewayServicer):
                          auto_visible, rbd_pool, rbd_image_name, trash_image, context):
         """Adds a namespace to a subsystem."""
 
-        if context:
-            assert self.omap_lock.locked(), "OMAP is unlocked when calling create_namespace()"
+        assert context is None or self.omap_lock.write_locked_by_me(), \
+            f"OMAP is unlocked when calling create_namespace()\n" \
+            f"in thread: {threading.get_native_id()}. Locked by: " \
+            f"{self.omap_lock.locked_by}, with cookie: {self.omap_lock.lock_cookie}, " \
+            f"locked: {self.omap_lock.is_exclusively_locked}"
 
         assert (rbd_pool and rbd_image_name) or ((not rbd_pool) and (not rbd_image_name)), \
             "RBD pool and image name should either be both set or both empty"
@@ -2325,9 +2366,11 @@ class GatewayService(pb2_grpc.GatewayServicer):
         if not context:
             return pb2.req_status(status=0, error_message=os.strerror(0))
 
-        # If we got here context is not None, so we must hold the OMAP lock
-        assert self.omap_lock.locked(), "OMAP is unlocked when calling " \
-                                        "remove_namespace_from_state()"
+        assert context is None or self.omap_lock.write_locked_by_me(), \
+            f"OMAP is unlocked when calling remove_namespace_from_state()\n" \
+            f"in thread: {threading.get_native_id()}. Locked by: " \
+            f"{self.omap_lock.locked_by}, with cookie: {self.omap_lock.lock_cookie}, " \
+            f"locked: {self.omap_lock.is_exclusively_locked}"
 
         # Update gateway state
         try:
@@ -2356,8 +2399,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
     def remove_namespace(self, subsystem_nqn, nsid, context):
         """Removes a namespace from a subsystem."""
 
-        if context:
-            assert self.omap_lock.locked(), "OMAP is unlocked when calling remove_namespace()"
+        assert context is None or self.omap_lock.write_locked_by_me(), \
+            f"OMAP is unlocked when calling remove_namespace()\n" \
+            f"in thread: {threading.get_native_id()}. Locked by: " \
+            f"{self.omap_lock.locked_by}, with cookie: {self.omap_lock.lock_cookie}, " \
+            f"locked: {self.omap_lock.is_exclusively_locked}"
+
         peer_msg = self.get_peer_message(context)
         namespace_failure_prefix = f"Failure removing namespace {nsid} from {subsystem_nqn}"
         self.logger.info(f"Received request to remove namespace {nsid} from "
@@ -3594,8 +3641,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
         if not context:
             return pb2.req_status(status=0, error_message=os.strerror(0))
 
-        if context:
-            assert self.omap_lock.locked(), "OMAP is unlocked when calling remove_host_from_state()"
+        assert context is None or self.omap_lock.write_locked_by_me(), \
+            f"OMAP is unlocked when calling remove_host_from_state()\n" \
+            f"in thread: {threading.get_native_id()}. Locked by: " \
+            f"{self.omap_lock.locked_by}, with cookie: {self.omap_lock.lock_cookie}, " \
+            f"locked: {self.omap_lock.is_exclusively_locked}"
+
         # Update gateway state
         try:
             self.gateway_state.remove_host(subsystem_nqn, host_nqn)
@@ -4332,9 +4383,11 @@ class GatewayService(pb2_grpc.GatewayServicer):
         if not context:
             return pb2.req_status(status=0, error_message=os.strerror(0))
 
-        if context:
-            assert self.omap_lock.locked(), "OMAP is unlocked when calling " \
-                                            "remove_listener_from_state()"
+        assert context is None or self.omap_lock.write_locked_by_me(), \
+            f"OMAP is unlocked when calling remove_listener_from_state()\n" \
+            f"in thread: {threading.get_native_id()}. Locked by: " \
+            f"{self.omap_lock.locked_by}, with cookie: {self.omap_lock.lock_cookie}, " \
+            f"locked: {self.omap_lock.is_exclusively_locked}"
 
         host_name = host_name.strip()
         listener_hosts = []

--- a/control/server.py
+++ b/control/server.py
@@ -99,6 +99,8 @@ class GatewayServer:
         discovery_pid: Subprocess running Ceph nvmeof discovery service
     """
 
+    MAX_TIME_TO_WAIT_FOR_GATEWAY_EXIT = 30
+
     def __init__(self, config: GatewayConfig):
         self.config = config
         self.gw_logger_object = GatewayLogger(self.config)
@@ -121,6 +123,9 @@ class GatewayServer:
         self.omap_state = None
         self.omap_lock = None
         self.crypto = None
+        self.gateway_state = None
+        self.exiting = False
+        self.is_gateway_process = True
         enc_key = None
         enc_key_file = self.config.get_with_default("gateway", "encryption_key", "")
         if enc_key_file:
@@ -140,6 +145,9 @@ class GatewayServer:
         self.name = self.config.get("gateway", "name")
         if not self.name:
             self.name = socket.gethostname()
+        self.system_exit_message = None
+        self.system_exit_message_lock = threading.Lock()
+        self.gateway_exit_started = threading.Event()
         self.logger.info(f"Starting gateway {self.name}")
 
     def __enter__(self):
@@ -147,16 +155,39 @@ class GatewayServer:
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Cleans up SPDK and server instances."""
+
+        gw_logger = self.gw_logger_object
+        logger = None
+        if gw_logger:
+            logger = gw_logger.logger
+
+        # In case we got here because the discovery exited, do nothing
+        if not self.is_gateway_process:
+            process_name = "discovery"
+            if logger:
+                logger.info(f"Exiting the {process_name} process.")
+            return
+        else:
+            process_name = "gateway"
         if self.gateway_rpc:
             self.gateway_rpc.up_and_running = False
-        if exc_type is not None:
-            self.logger.exception("GatewayServer exception occurred:\n{traceback}\n")
-        else:
-            self.logger.info("GatewayServer is terminating gracefully...")
-
+        if self.gateway_state:
+            self.gateway_state.up_and_running = False
+            if self.gateway_state.omap:
+                self.gateway_state.omap.up_and_running = False
         gw_name = self.name
-        gw_logger = self.gw_logger_object
-        logger = gw_logger.logger
+        if self.exiting:
+            if logger:
+                logger.debug("Already exiting, do nothing")
+            return
+        self.exiting = True
+
+        if logger:
+            if exc_type is not None:
+                logger.exception("GatewayServer exception occurred:\n{traceback}\n")
+            else:
+                logger.info("GatewayServer is terminating gracefully...")
+
         signal.signal(signal.SIGCHLD, signal.SIG_IGN)
         if self.monitor_client_process:
             self._stop_monitor_client()
@@ -201,8 +232,10 @@ class GatewayServer:
             self.omap_state = None
 
         if logger:
-            logger.info("Exiting the gateway process.")
-        gw_logger.compress_final_log_file(gw_name)
+            logger.info(f"Exiting the {process_name} process.")
+
+        if gw_logger and gw_name:
+            gw_logger.compress_final_log_file(gw_name)
 
     def set_group_id(self, id: int):
         self.logger.info(f"Gateway {self.name} group {id=}")
@@ -241,10 +274,10 @@ class GatewayServer:
         self.logger.info(f"Starting serve, monitor client version: "
                          f"{self._monitor_client_version()}")
 
-        omap_state = OmapGatewayState(self.config, f"gateway-{self.name}")
+        omap_state = OmapGatewayState(self.config, self.set_gateway_exit_message,
+                                      f"gateway-{self.name}")
         self.omap_state = omap_state
         local_state = LocalGatewayState()
-        omap_state.check_for_old_format_omap_files()
 
         # install SIGCHLD handler
         signal.signal(signal.SIGCHLD, sigchld_handler)
@@ -258,24 +291,25 @@ class GatewayServer:
         self.ceph_utils = CephUtils(self.config)
 
         # Start SPDK
-        self._start_spdk(omap_state)
+        self._start_spdk()
 
         # Start discovery service
         self._start_discovery_service()
 
         # Register service implementation with server
-        gateway_state = GatewayStateHandler(self.config, local_state, omap_state,
-                                            self.gateway_rpc_caller, self.crypto,
-                                            f"gateway-{self.name}")
-        self.omap_lock = OmapLock(omap_state, gateway_state, self.rpc_lock)
-        self.gateway_rpc = GatewayService(self.config, gateway_state, self.rpc_lock,
+        self.gateway_state = GatewayStateHandler(self.config, local_state, omap_state,
+                                                 self.gateway_rpc_caller, self.crypto,
+                                                 f"gateway-{self.name}")
+        self.omap_lock = OmapLock(self.gateway_state, self.rpc_lock)
+        self.gateway_rpc = GatewayService(self.config, self.gateway_state, self.rpc_lock,
                                           self.omap_lock, self.group_id, self.spdk_rpc_client,
-                                          self.spdk_rpc_subsystems_client, self.ceph_utils)
+                                          self.spdk_rpc_subsystems_client, self.ceph_utils,
+                                          self.set_gateway_exit_message)
         self.server = self._grpc_server(self._gateway_address())
         pb2_grpc.add_GatewayServicer_to_server(self.gateway_rpc, self.server)
 
         # Check for existing NVMeoF target state
-        gateway_state.start_update()
+        self.gateway_state.start_update()
 
         # Start server
         self.server.start()
@@ -400,6 +434,25 @@ class GatewayServer:
         self.discovery_pid = os.fork()
         if self.discovery_pid == 0:
             self.logger.info("Starting ceph nvmeof discovery service")
+            # Reset server related fields for the discovery process
+            self.is_gateway_process = False
+            self.spdk_process = None
+            self.monitor_client_process = None
+            self.spdk_log_file = None
+            self.spdk_log_file_path = None
+            self.monitor_client_log_file = None
+            self.monitor_client_log_file_path = None
+            self.omap_state = None
+            self.name = None
+            signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+            if self.server:
+                self.server.stop(None)
+                self.server = None
+            if self.gateway_rpc:
+                self.gateway_rpc.up_and_running = False
+                self.gateway_rpc = None
+            self.gateway_state = None
+            self.omap_lock = None
             with DiscoveryService(self.config) as discovery:
                 discovery.start_service()
             os._exit(0)
@@ -496,7 +549,7 @@ class GatewayServer:
 
         return log_file_path
 
-    def _start_spdk(self, omap_state):
+    def _start_spdk(self):
         """Starts SPDK process."""
 
         # Start target
@@ -719,7 +772,7 @@ class GatewayServer:
         # discovery service selector loop should exit due to KeyboardInterrupt exception
         try:
             os.kill(self.discovery_pid, signal.SIGINT)
-            os.waitpid(self.discovery_pid, 0)
+            os.waitpid(self.discovery_pid, os.WNOHANG)
         except (ChildProcessError, ProcessLookupError):
             pass          # ignore
         self.logger.info("Discovery service terminated")
@@ -783,6 +836,20 @@ class GatewayServer:
             self.logger.exception(f"Create Transport {trtype} returned with error")
             raise
 
+    def set_gateway_exit_message(self, msg):
+        with self.system_exit_message_lock:
+            self.system_exit_message = msg
+        return self.gateway_exit_started.wait(GatewayServer.MAX_TIME_TO_WAIT_FOR_GATEWAY_EXIT)
+
+    def exit_gateway_if_needed(self):
+        exit_msg = None
+        with self.system_exit_message_lock:
+            exit_msg = self.system_exit_message
+        if exit_msg is not None:
+            self.logger.error(f"System exit message was set to {exit_msg}")
+            self.gateway_exit_started.set()
+            raise SystemExit(exit_msg)
+
     def keep_alive(self):
         """Continuously confirms communication with SPDK process."""
         allowed_consecutive_spdk_ping_failures = self.config.getint_with_default(
@@ -806,6 +873,7 @@ class GatewayServer:
             spdk_ping_interval_in_seconds = 0.0
 
         while True:
+            self.exit_gateway_if_needed()
             if self.gateway_rpc:
                 if self.gateway_rpc.rebalance.rebalance_event.is_set():
                     self.logger.critical("Failure in rebalance, aborting")

--- a/control/state.py
+++ b/control/state.py
@@ -11,6 +11,7 @@ import time
 import threading
 import rados
 import errno
+import os
 import contextlib
 from typing import Dict
 from collections import defaultdict
@@ -306,14 +307,25 @@ class ReleasedLock:
 
 class OmapLock:
     OMAP_FILE_LOCK_NAME = "omap_file_lock"
-    OMAP_FILE_LOCK_COOKIE = "omap_file_cookie"
+    OMAP_FILE_LOCK_COOKIE_PREFIX = "omap_file_cookie"
+    EXCLUSIVE_LOCK_NAME = "exclusive"
+    SHARED_LOCK_NAME = "shared"
 
-    def __init__(self, omap_state, gateway_state, rpc_lock: threading.Lock) -> None:
-        self.logger = omap_state.logger
-        self.omap_state = omap_state
+    changes_lock = threading.Lock()
+    no_read_lock_warning_displayed = False
+    ignore_errors_warning_displayed = False
+    is_exclusively_locked = False
+    locked_by = {}
+    lock_cookie = []
+
+    def __init__(self, gateway_state, rpc_lock: threading.Lock) -> None:
+        self.logger = gateway_state.logger
+        self.omap_state = gateway_state.omap
+        self.omap_state.omap_lock = self
         self.gateway_state = gateway_state
         self.rpc_lock = rpc_lock
-        self.is_locked = False
+        self.logger.debug(f"Init OMAP lock, cookie: {self.build_omap_lock_cookie()}, thread: "
+                          f"{threading.get_native_id()}, self: {hex(id(self))}")
         self.omap_file_lock_duration = self.omap_state.config.getint_with_default(
             "gateway",
             "omap_file_lock_duration",
@@ -330,6 +342,36 @@ class OmapLock:
             "gateway",
             "omap_file_lock_retry_sleep_interval",
             1.0)
+        # This is a development flag, in case we run into issues with the read lock in the field
+        self.omap_file_lock_on_read = self.omap_state.config.getboolean_with_default(
+            "gateway",
+            "omap_file_lock_on_read",
+            True)
+        if not self.omap_file_lock_on_read and not OmapLock.no_read_lock_warning_displayed:
+            self.logger.warning("Will not lock OMAP for read, this might cause using an "
+                                "inconsistent state when big OMAP file are used")
+            with OmapLock.changes_lock:
+                OmapLock.no_read_lock_warning_displayed = True
+        # This is an option for development, normally we shouldn't get errors on unlock so
+        # the flag shouldn't make a difference. There might be case in which for some reason
+        # we take too long to handle something and the RBD unlocked the lock in the middle
+        # of the processing. The deafult is to abort the gateway in such case. If we looked
+        # into the case and decidd there was no problem, or we want to continue anyway we
+        # can either increase the duration of the lock (omap_file_lock_duration) or set this
+        # flag to False, which will cause the gateway to just display an error message and
+        # continue. We might also get an error on read unlock for some unknown reason,
+        # this is not a critical condition so we can just set the flag to False to let
+        # the gate continue.
+        self.omap_file_ignore_unlock_errors = self.omap_state.config.getboolean_with_default(
+            "gateway",
+            "omap_file_ignore_unlock_errors",
+            False)
+        if self.omap_file_ignore_unlock_errors:
+            if not OmapLock.ignore_errors_warning_displayed:
+                self.logger.warning("OMAP unlock errors will be ignored, the gateway will continue")
+                with OmapLock.changes_lock:
+                    OmapLock.ignore_errors_warning_displayed = True
+
         self.lock_start_time = 0.0
         # This is used for testing purposes only. To allow us testing locking
         # from two gateways at the same time
@@ -340,34 +382,36 @@ class OmapLock:
         if self.omap_file_disable_unlock:
             self.logger.warning("Will not unlock OMAP file for testing purposes")
 
+    def build_omap_lock_cookie(self, exclusive_lock=True, cookie_suffix=None) -> str:
+        if cookie_suffix:
+            cookie_suffix = str(cookie_suffix) + "_"
+        else:
+            cookie_suffix = ""
+
+        cookie_prefix = f"{OmapLock.OMAP_FILE_LOCK_COOKIE_PREFIX}_" \
+                        f"{hex(id(self))}_{os.getpid()}_{threading.get_native_id()}_" \
+                        f"{cookie_suffix}"
+
+        if exclusive_lock:
+            omap_lock_cookie = f"{cookie_prefix}" \
+                               f"{OmapLock.EXCLUSIVE_LOCK_NAME}"
+        else:
+            omap_lock_cookie = f"{cookie_prefix}" \
+                               f"{OmapLock.SHARED_LOCK_NAME}"
+
+        return omap_lock_cookie
+
     #
     # We pass the context from the different functions here. It should point to a real object
     # in case we come from a real resource changing function, resulting from a CLI command. It
     # will be None in case we come from an automatic update which is done because the local
     # state is out of date. In case context is None, that is we're in the middle of an update
     # we should not try to lock the OMAP file as the code will not try to make changes there,
-    # only the local spdk calls are done in such a case.
+    # only the local SPDK calls are done in such a case.
     #
-    def __enter__(self):
-        if self.omap_file_lock_duration > 0:
-            self.lock_omap()
-            self.lock_start_time = time.monotonic()
-        return self
-
-    def __exit__(self, typ, value, traceback):
-        if self.omap_file_lock_duration > 0:
-            duration = 0.0
-            if self.lock_start_time:
-                duration = time.monotonic() - self.lock_start_time
-            self.lock_start_time = 0.0
-            self.unlock_omap()
-            if duration > self.omap_file_lock_duration:
-                self.logger.error(f"Operation ran for {duration:.2f} seconds, but the OMAP "
-                                  f"lock expired after {self.omap_file_lock_duration} seconds")
-
     def get_omap_lock_to_use(self, context):
         if context:
-            return self
+            return OmapWriteGuard(self)
         return contextlib.suppress()
 
     #
@@ -394,83 +438,283 @@ class OmapLock:
                     time.sleep(1)
 
         if need_to_update:
-            raise Exception(f"Unable to lock OMAP file after reloading "
-                            f"{self.omap_file_update_reloads} times, exiting")
+            raise RuntimeError(f"Unable to lock OMAP file after reloading "
+                               f"{self.omap_file_update_reloads} times, exiting")
 
-    def lock_omap(self):
+    def lock_omap(self, verify_versions=True, lock_exclusive=True, cookie_suffix=None):
         got_lock = False
-        assert self.rpc_lock.locked(), "The RPC lock is not locked."
+        if lock_exclusive:
+            assert self.rpc_lock and self.rpc_lock.locked(), \
+                "The RPC lock is not locked for exclusive OMAP lock."
+
+        if self.omap_file_lock_duration <= 0:
+            raise RuntimeError("Lock duration set to 0, should not try to lock OMAP")
 
         if not self.omap_state.ioctx:
             self.logger.warning("Not locking OMAP as Rados connection is closed")
-            raise Exception("An attempt to lock OMAP file after Rados connection was closed")
+            raise RuntimeError("An attempt to lock OMAP file after Rados connection was closed")
 
+        if lock_exclusive:
+            lock_kind = OmapLock.EXCLUSIVE_LOCK_NAME
+        else:
+            lock_kind = OmapLock.SHARED_LOCK_NAME
+
+        lock_cookie = self.build_omap_lock_cookie(lock_exclusive, cookie_suffix)
         for i in range(0, self.omap_file_lock_retries + 1):
             try:
-                self.omap_state.ioctx.lock_exclusive(self.omap_state.omap_name,
-                                                     self.OMAP_FILE_LOCK_NAME,
-                                                     self.OMAP_FILE_LOCK_COOKIE,
-                                                     "OMAP file changes lock",
-                                                     self.omap_file_lock_duration, 0)
+                if lock_exclusive:
+                    self.omap_state.ioctx.lock_exclusive(self.omap_state.omap_name,
+                                                         self.OMAP_FILE_LOCK_NAME,
+                                                         lock_cookie,
+                                                         "OMAP file changes lock",
+                                                         self.omap_file_lock_duration, 0)
+                else:
+                    self.omap_state.ioctx.lock_shared(self.omap_state.omap_name,
+                                                      self.OMAP_FILE_LOCK_NAME,
+                                                      lock_cookie,
+                                                      "",
+                                                      "OMAP file changes lock",
+                                                      self.omap_file_lock_duration, 0)
                 got_lock = True
+                self.logger.debug(f"Locked OMAP {lock_kind}, thread id: "
+                                  f"{threading.get_native_id()},"
+                                  f" id: {self.omap_state.id_text}, cookie: "
+                                  f"{lock_cookie}")
                 if i > 0:
-                    self.logger.info(f"Succeeded to lock OMAP file after {i} retries")
+                    self.logger.info(f"Succeeded to lock OMAP file ({lock_kind}) "
+                                     f"after {i} retries")
                 break
             except rados.ObjectExists:
-                self.logger.info("We already locked the OMAP file")
-                got_lock = True
-                break
+                self.logger.debug(f"OMAP was already locked by {OmapLock.locked_by} "
+                                  f", thread id: {threading.get_native_id()}, id: "
+                                  f"{self.omap_state.id_text}, cookie: "
+                                  f"{lock_cookie}")
+                if lock_exclusive:
+                    raise RuntimeError("An attempt to lock OMAP exclusively twice from "
+                                       "the same thread")
+                else:
+                    assert False, "Shouldn't get an ObjectExists exception for a shared lock"
             except rados.ObjectBusy:
-                self.logger.warning(
-                    f"The OMAP file is locked, will try again in "
-                    f"{self.omap_file_lock_retry_sleep_interval} seconds")
-                with ReleasedLock(self.rpc_lock):
-                    time.sleep(self.omap_file_lock_retry_sleep_interval)
+                if not lock_exclusive and self.write_locked_by_me():
+                    self.logger.info("No need to lock OMAP for read as we already "
+                                     "have it locked for write")
+                    raise FileExistsError("already hold write lock")
+                if len(OmapLock.locked_by) > 0:
+                    self.logger.debug(f"OMAP is locked by {OmapLock.locked_by} with cookie: "
+                                      f"{OmapLock.lock_cookie}, thread id: "
+                                      f"{threading.get_native_id()}, id: "
+                                      f"{self.omap_state.id_text}, cookie: "
+                                      f"{lock_cookie}")
+                else:
+                    self.logger.debug("OMAP is locked by an external locker")
+            except AttributeError:
+                # We got here beause ioctx was closed before trying to lock
+                self.logger.exception("Got an exception trying to lock")
+                raise RuntimeError("An attempt to lock OMAP file after Rados connection was closed")
             except Exception:
-                self.logger.exception("Unable to lock OMAP file, exiting")
-                raise
+                self.logger.exception(f"Unable to lock OMAP file ({lock_kind}), exiting")
+                raise RuntimeError(f"Unable to lock OMAP file ({lock_kind}), exiting")
+
+            time_to_sleep = self.omap_file_lock_retry_sleep_interval
+            if not lock_exclusive:
+                time_to_sleep /= 2.0
+            self.logger.warning(
+                f"The OMAP file is locked, will try again in "
+                f"{time_to_sleep} seconds")
+            if lock_exclusive:
+                with ReleasedLock(self.rpc_lock):
+                    time.sleep(time_to_sleep)
+            else:
+                time.sleep(time_to_sleep)
 
         if not got_lock:
-            self.logger.error(f"Unable to lock OMAP file after {self.omap_file_lock_retries} "
-                              f"tries. Exiting!")
-            raise Exception("Unable to lock OMAP file")
+            self.logger.error(f"Unable to lock OMAP file ({lock_kind}) after "
+                              f"{self.omap_file_lock_retries} tries. Exiting!")
+            raise RuntimeError(f"Unable to lock OMAP file ({lock_kind})")
 
-        self.is_locked = True
-        omap_version = self.omap_state.get_omap_version()
-        local_version = self.omap_state.get_local_version()
+        with OmapLock.changes_lock:
+            if lock_exclusive:
+                if OmapLock.is_exclusively_locked:
+                    assert False, \
+                        f"Got two exclusive locks, OMAP is locked by " \
+                        f"{OmapLock.locked_by} with cookie: " \
+                        f"{OmapLock.lock_cookie}, thread id: " \
+                        f"{threading.get_native_id()}, id: " \
+                        f"{self.omap_state.id_text}, cookie: " \
+                        f"{lock_cookie}"
+                else:
+                    assert not len(OmapLock.locked_by) and not len(OmapLock.lock_cookie), \
+                        f"Got exclusive lock with shared locks, OMAP is locked by " \
+                        f"{OmapLock.locked_by} with cookie: " \
+                        f"{OmapLock.lock_cookie}, thread id: " \
+                        f"{threading.get_native_id()}, id: " \
+                        f"{self.omap_state.id_text}, cookie: " \
+                        f"{lock_cookie}"
 
-        if omap_version > local_version:
-            self.logger.warning(f"Local version {local_version} differs from OMAP file "
-                                f"version {omap_version}. The file is not current, will "
-                                f"reload it and try again")
-            self.unlock_omap()
-            raise OSError(errno.EAGAIN,
-                          "Unable to lock OMAP file, file not current",
-                          self.omap_state.omap_name)
+            try:
+                OmapLock.locked_by[(threading.get_native_id(), lock_kind)] += 1
+            except KeyError:
+                OmapLock.locked_by[(threading.get_native_id(), lock_kind)] = 1
+            if lock_exclusive:
+                OmapLock.is_exclusively_locked = True
+            OmapLock.lock_cookie.append(lock_cookie)
 
-    def unlock_omap(self):
+        if verify_versions:
+            omap_version = self.omap_state.get_omap_version()
+            local_version = self.omap_state.get_local_version()
+
+            if omap_version > local_version:
+                self.logger.warning(f"Local version {local_version} differs from OMAP file "
+                                    f"version {omap_version}. The file is not current, will "
+                                    f"reload it and try again")
+                self.unlock_omap()
+                raise OSError(errno.EAGAIN,
+                              "Unable to lock OMAP file, file not current",
+                              self.omap_state.omap_name)
+
+    def do_unlock_omap(self, lock_cookie, lock_kind=""):
+        try:
+            self.omap_state.ioctx.unlock(self.omap_state.omap_name,
+                                         self.OMAP_FILE_LOCK_NAME,
+                                         lock_cookie)
+            self.logger.debug(f"OMAP was unlocked, thread id: "
+                              f"{threading.get_native_id()}, "
+                              f"id: {self.omap_state.id_text}, cookie: "
+                              f"{lock_cookie}")
+        except rados.ObjectNotFound:
+            self.logger.debug(f"OMAP lock not found, thread id: "
+                              f"{threading.get_native_id()}, "
+                              f"id: {self.omap_state.id_text}, cookie: "
+                              f"{lock_cookie}")
+            self.logger.error(f"No such lock, the {lock_kind} lock might have expired."
+                              f" Consider enlarging the OMAP lock duration field.")
+            if not self.omap_file_ignore_unlock_errors:
+                raise
+        except Exception:
+            self.logger.exception(f"Unable to {lock_kind} unlock OMAP file")
+            if not self.omap_file_ignore_unlock_errors:
+                raise
+
+    def unlock_omap(self, unlock_exclusive=True, cookie_suffix=None):
         if self.omap_file_disable_unlock:
             self.logger.warning("OMAP file unlock was disabled, will not unlock file")
             return
 
-        if not self.omap_state.ioctx:
-            self.is_locked = False
-            return
+        if unlock_exclusive:
+            lock_kind = OmapLock.EXCLUSIVE_LOCK_NAME
+        else:
+            lock_kind = OmapLock.SHARED_LOCK_NAME
 
+        lock_cookie = self.build_omap_lock_cookie(unlock_exclusive, cookie_suffix)
+        with OmapLock.changes_lock:
+            if self.omap_state.ioctx:
+                self.do_unlock_omap(lock_cookie, lock_kind)
+            else:
+                self.logger.warning("Trying to unlock OMAP when Rados connection is closed")
+                return
+
+            try:
+                OmapLock.locked_by[(threading.get_native_id(), lock_kind)] -= 1
+                if not OmapLock.locked_by[(threading.get_native_id(), lock_kind)]:
+                    OmapLock.locked_by.pop((threading.get_native_id(), lock_kind), None)
+            except KeyError:
+                pass
+
+            OmapLock.lock_cookie.remove(lock_cookie)
+            if unlock_exclusive:
+                OmapLock.is_exclusively_locked = False
+
+    def unlock_all_omap(self):
+        with OmapLock.changes_lock:
+            cookies = OmapLock.lock_cookie.copy()
+        for lock_cookie in cookies:
+            assert self.omap_state.ioctx, "Rados connection got closed in the middle of shutdown"
+            try:
+                self.do_unlock_omap(lock_cookie)
+            except Exception:
+                pass
+
+        OmapLock.reset_lock_markers()
+
+    def write_locked_by_me(self) -> bool:
+        lock_cookie = self.build_omap_lock_cookie(True)
+        thread_id = threading.get_native_id()
+        with OmapLock.changes_lock:
+            if not OmapLock.is_exclusively_locked:
+                return False
+            if (thread_id, OmapLock.EXCLUSIVE_LOCK_NAME) not in OmapLock.locked_by:
+                return False
+            return lock_cookie in OmapLock.lock_cookie
+
+    def reset_lock_markers():
+        with OmapLock.changes_lock:
+            OmapLock.is_exclusively_locked = False
+            OmapLock.locked_by = {}
+            OmapLock.lock_cookie = []
+
+
+class OmapReadGuard:
+    def __init__(self, omap_lock: OmapLock):
+        self.omap_lock = omap_lock
+        self.cookie_suffix = None
+        self.actually_locked = False
+        self.lock_start_time = 0.0
+
+    def __enter__(self):
         try:
-            self.omap_state.ioctx.unlock(self.omap_state.omap_name,
-                                         self.OMAP_FILE_LOCK_NAME,
-                                         self.OMAP_FILE_LOCK_COOKIE)
-        except rados.ObjectNotFound:
-            if self.is_locked:
-                self.logger.warning("No such lock, the lock duration might have passed")
+            if self.omap_lock.omap_file_lock_duration > 0:
+                self.cookie_suffix = time.time_ns()
+                self.omap_lock.lock_omap(False, False, self.cookie_suffix)
+                self.lock_start_time = time.monotonic()
+                self.actually_locked = True
+            return self
+        except FileExistsError:
+            # we can contiune as we already hold a write lock, but we shouldn't try to unlock
+            self.actually_locked = False
+            return self
         except Exception:
-            self.logger.exception("Unable to unlock OMAP file")
             pass
-        self.is_locked = False
+        return None
 
-    def locked(self):
-        return self.is_locked
+    def __exit__(self, typ, value, traceback):
+        if self.actually_locked:
+            self.omap_lock.unlock_omap(False, self.cookie_suffix)
+            duration = 0.0
+            if self.lock_start_time:
+                duration = time.monotonic() - self.lock_start_time
+            self.lock_start_time = 0.0
+            assert duration <= self.omap_lock.omap_file_lock_duration, \
+                f"Operation ran for {duration:.2f} seconds, but the " \
+                f"OMAP {OmapLock.SHARED_LOCK_NAME} lock expired after " \
+                f"{self.omap_lock.omap_file_lock_duration} seconds. Consider " \
+                f"enlarging the OMAP lock duration field."
+        self.cookie_suffix = None
+        self.actually_locked = False
+
+
+class OmapWriteGuard:
+    def __init__(self, omap_lock: OmapLock):
+        self.omap_lock = omap_lock
+        self.lock_start_time = 0.0
+
+    def __enter__(self):
+        if self.omap_lock.omap_file_lock_duration > 0:
+            self.omap_lock.lock_omap()
+            self.lock_start_time = time.monotonic()
+        return self
+
+    def __exit__(self, typ, value, traceback):
+        if self.omap_lock.omap_file_lock_duration > 0:
+            self.omap_lock.unlock_omap()
+            duration = 0.0
+            if self.lock_start_time:
+                duration = time.monotonic() - self.lock_start_time
+            self.lock_start_time = 0.0
+            assert duration <= self.omap_lock.omap_file_lock_duration, \
+                f"Operation ran for {duration:.2f} seconds, but the " \
+                f"OMAP {OmapLock.EXCLUSIVE_LOCK_NAME} lock expired after " \
+                f"{self.omap_lock.omap_file_lock_duration} seconds. Consider " \
+                f"enlarging the OMAP lock duration field."
 
 
 class OmapGatewayState(GatewayState):
@@ -493,19 +737,26 @@ class OmapGatewayState(GatewayState):
 
     OMAP_VERSION_KEY = "omap_version"
 
-    def __init__(self, config, id_text=""):
+    def __init__(self, config, set_gateway_exit_message, id_text=""):
         self.config = config
         self.version = 1
         self.logger = GatewayLogger(self.config).logger
         self.ioctx = None
         self.watch = None
+        self.omap_lock = None
         gateway_group = self.config.get("gateway", "group")
         self.omap_name = f"nvmeof.{gateway_group}.state" if gateway_group else "nvmeof.state"
         self.notify_timeout = self.config.getint_with_default("gateway",
                                                               "state_update_timeout_in_msec",
                                                               2000)
+        # This is a development flag, in case we run into issues with gateway crashes in the field
+        self.abort_on_error = self.config.getboolean_with_default("gateway",
+                                                                  "abort_on_errors",
+                                                                  True)
         self.conn = None
         self.id_text = id_text
+        self.up_and_running = True
+        self.set_gateway_exit_message = set_gateway_exit_message
 
         try:
             self.ioctx = self.open_rados_connection(self.config)
@@ -526,13 +777,6 @@ class OmapGatewayState(GatewayState):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.cleanup_omap()
-
-    def check_for_old_format_omap_files(self):
-        omap_dict = self.get_state()
-        for omap_item_key in omap_dict.keys():
-            if omap_item_key.startswith("bdev"):
-                raise Exception("Old OMAP file format, still contains bdevs, please "
-                                "remove file and try again")
 
     def open_rados_connection(self, config):
         ceph_pool = config.get("ceph", "pool")
@@ -572,23 +816,102 @@ class OmapGatewayState(GatewayState):
                 f" invalid number of values ({value_list}).")
             raise
 
-    def get_state(self) -> Dict[str, str]:
+    def read_omap_values(self):
         """Returns dict of all OMAP keys and values."""
         omap_list = [("", 0)]   # Dummy, non empty, list value. Just so we would enter the while
         omap_dict = {}
-        if not self.ioctx:
-            self.logger.warning("Trying to get OMAP state when Rados connection is closed")
-            return omap_dict
+
         # The number of items returned is limited by Ceph, so we need to read in
         # a loop until no more items are returned
+        get_omap_vals_count = 0
         while len(omap_list) > 0:
             last_key_read = omap_list[-1][0]
             with rados.ReadOpCtx() as read_op:
+                if not self.ioctx:
+                    raise RuntimeError("Trying to get OMAP state when Rados "
+                                       "connection is closed")
                 i, _ = self.ioctx.get_omap_vals(read_op, last_key_read, "", -1)
                 self.ioctx.operate_read_op(read_op, self.omap_name)
                 omap_list = list(i)
                 omap_dict.update(dict(omap_list))
+                get_omap_vals_count += 1
+
+        return omap_dict, get_omap_vals_count
+
+    def get_state_internal(self) -> Dict[str, str]:
+        """Returns dict of all OMAP keys and values."""
+
+        got_omap_lock = False
+        get_omap_vals_count = 0
+        omap_dict = None
+        if self.omap_lock and self.omap_lock.omap_file_lock_on_read:
+            try:
+                actually_locked = False
+                with OmapReadGuard(self.omap_lock) as guard:
+                    if guard is None:
+                        self.logger.error(f"Failed to lock OMAP file for read, will try "
+                                          f"to read atomically without a lock ({self.id_text})")
+                    else:
+                        got_omap_lock = True
+                        if guard.actually_locked:
+                            actually_locked = True
+                            self.logger.info(f"Locked OMAP file before reading its "
+                                             f"content ({self.id_text})")
+                        else:
+                            self.logger.info(f"OMAP file is already locked, read its "
+                                             f"content ({self.id_text})")
+                        omap_dict, get_omap_vals_count = self.read_omap_values()
+                if actually_locked:
+                    self.logger.info(f"Released OMAP file lock after reading "
+                                     f"content ({self.id_text})")
+                if omap_dict is not None:
+                    assert got_omap_lock
+                    return omap_dict
+            except Exception:
+                self.logger.exception(f"Failed to lock OMAP file ({self.id_text})")
+                # We passed the lock, so we got an exception trying to read
+                if got_omap_lock:
+                    raise
+
+        assert omap_dict is None
+        assert not got_omap_lock
+        omap_dict, get_omap_vals_count = self.read_omap_values()
+
+        if get_omap_vals_count > 2:
+            # We couldn't lock and read OMAP in several calls, which is not atomic
+            raise RuntimeError("We failed locking the OMAP file and we can't read it atomically")
+
         return omap_dict
+
+    def get_state(self, allow_abort_on_error=True) -> Dict[str, str]:
+        """Returns dict of all OMAP keys and values."""
+
+        if not self.up_and_running:
+            return None
+
+        try:
+            return self.get_state_internal()
+        except Exception:
+            self.logger.exception(f"Failure while getting state ({self.id_text})")
+            if self.abort_on_error and allow_abort_on_error:
+                msg = f"Will abort because of an error getting state ({self.id_text})"
+                self.logger.critical(msg)
+                self.up_and_running = False
+                if self.set_gateway_exit_message is not None:
+                    if not self.set_gateway_exit_message(msg):
+                        self.logger.warning(f"Can't get an indication about the gateway aborting."
+                                            f" Will continue after an error "
+                                            f"getting state ({self.id_text})")
+                        raise
+                else:
+                    self.logger.warning(f"No gateway exit function set, will continue after "
+                                        f"an error getting state ({self.id_text})")
+                    raise
+            else:
+                self.logger.warning(f"Abort on errors is disabled, will continue after "
+                                    f"an error getting state ({self.id_text})")
+                raise
+        return None
 
     def _add_key(self, key: str, val: str):
         """Adds key and value to the OMAP."""
@@ -689,7 +1012,10 @@ class OmapGatewayState(GatewayState):
                 pass
         if omap_lock and omap_lock.omap_file_lock_duration > 0:
             try:
-                omap_lock.unlock_omap()
+                # We already shutting down, no point in raising exceptions now
+                omap_lock.omap_file_ignore_unlock_errors = True
+                omap_lock.unlock_all_omap()
+                self.logger.debug(f"Unlocked all OMAP locks ({self.id_text})")
             except Exception:
                 pass
         if self.ioctx:
@@ -735,6 +1061,7 @@ class GatewayStateHandler:
                                                  "state_update_notify")
         self.update_is_active_lock = threading.Lock()
         self.id_text = id_text
+        self.up_and_running = True
 
     def add_namespace(self, subsystem_nqn: str, nsid: str, val: str):
         """Adds a namespace to the state data store."""
@@ -824,6 +1151,9 @@ class GatewayStateHandler:
     def _update_caller(self, notify_event):
         """Periodically calls for update."""
         while True:
+            if not self.up_and_running:
+                self.logger.warning("Server is going down, stop updates")
+                break
             update_time = time.time() + self.update_interval
             self.update()
             notify_event.wait(max(update_time - time.time(), 0))
@@ -1089,10 +1419,6 @@ class GatewayStateHandler:
             self.logger.warning("An update is already running, ignore")
             return False
 
-        if not self.omap.ioctx:
-            self.logger.warning("Can't update when Rados connection is closed")
-            return False
-
         with self.update_is_active_lock:
             prefix_list = [
                 GatewayState.SUBSYSTEM_PREFIX,
@@ -1103,10 +1429,25 @@ class GatewayStateHandler:
                 GatewayState.LISTENER_PREFIX,
             ]
 
+            if not self.omap.ioctx:
+                self.logger.warning("Can't update when Rados connection is closed")
+                return False
+
             # Get version and state from OMAP
-            omap_state_dict = self.omap.get_state()
-            omap_version = int(omap_state_dict[self.omap.OMAP_VERSION_KEY])
-            local_version = self.omap.get_local_version()
+            try:
+                omap_state_dict = self.omap.get_state(False)
+                if omap_state_dict is None:
+                    return False
+                omap_version = int(omap_state_dict[self.omap.OMAP_VERSION_KEY])
+                local_version = self.omap.get_local_version()
+            except RuntimeError:
+                self.logger.exception("Failure getting OMAP state")
+                return False
+            except Exception:
+                if not self.omap.ioctx:
+                    self.logger.warning("Can't update when Rados connection is closed")
+                    return False
+                raise
 
             self.logger.debug(f"Check local version {local_version} against OMAP version "
                               f"{omap_version} ({self.id_text}).")
@@ -1124,9 +1465,6 @@ class GatewayStateHandler:
                 grouped_added = self._group_by_prefix(added, prefix_list)
                 # Find OMAP changes
                 same_keys = omap_state_keys & local_state_keys
-                for key in same_keys:
-                    self.logger.debug(f"same key: {key}, local: {local_state_dict[key]},"
-                                      f"omap: {omap_state_dict[key]}")
                 changed = {
                     key: omap_state_dict[key]
                     for key in same_keys
@@ -1142,16 +1480,14 @@ class GatewayStateHandler:
                 only_host_key_changed = []
                 only_subsystem_key_changed = []
                 for key in changed.keys():
-                    self.logger.info(f"Changed key: {key} local-state: {local_state_dict[key]}"
-                                     f" omap-state: {omap_state_dict[key]}")
                     if key.startswith(GatewayState.NAMESPACE_PREFIX):
                         (should_process, new_lb_grp_id) = self.namespace_only_lb_group_id_changed(
                             local_state_dict[key],
                             omap_state_dict[key])
                         if should_process:
                             assert new_lb_grp_id, "Shouldn't get here with an empty lb group id"
-                            self.logger.info(f"Found {key} where only the load balancing group id "
-                                             f"has changed. The new group id is {new_lb_grp_id}")
+                            self.logger.debug(f"Found {key} where only the load balancing group id "
+                                              f"has changed. The new group id is {new_lb_grp_id}")
                             only_lb_group_changed.append((key, new_lb_grp_id))
 
                         (should_process,

--- a/tests/test_big_omap.py
+++ b/tests/test_big_omap.py
@@ -1,0 +1,202 @@
+import pytest
+from control.server import GatewayServer
+from control.cli import main as cli
+from control.cephutils import CephUtils
+import grpc
+from control.proto import gateway_pb2_grpc as pb2_grpc
+import copy
+import time
+import os
+
+image_prefix = "mytestdevimage"
+pool = "rbd"
+subsystem_prefix = "nqn.2016-06.io.spdk:cnode"
+host_prefix = "nqn.2014-08.org.nvmexpress:uuid:893a6752-fe9b-ca48-aa93-e4565f3288"
+subsystem_count = 128
+namespace_count = 8
+host_count = 12
+anagrpid = "1"
+anagrpid2 = "2"
+group_name = "group1"
+max_subsystems = 1024
+max_namespaces = 5120
+max_hosts = 5000
+update_interval = 300
+
+
+@pytest.fixture(scope="module")
+def two_gateways(config):
+    """Sets up and tears down two Gateways"""
+    nameA = "GatewayAA"
+    nameB = "GatewayBB"
+    sockA = f"spdk_{nameA}.sock"
+    sockB = f"spdk_{nameB}.sock"
+    config.config["gateway-logs"]["log_level"] = "debug"
+    config.config["gateway"]["group"] = group_name
+    config.config["gateway"]["max_subsystems"] = f"{max_subsystems}"
+    config.config["gateway"]["max_namespaces"] = f"{max_namespaces}"
+    config.config["gateway"]["max_hosts"] = f"{max_hosts}"
+    config.config["gateway"]["rebalance_period_sec"] = "0"
+    config.config["gateway"]["state_update_notify"] = "False"
+    config.config["gateway"]["state_update_interval_sec"] = f"{update_interval}"
+    addr = config.get("gateway", "addr")
+    configA = copy.deepcopy(config)
+    configB = copy.deepcopy(config)
+    configA.config["gateway"]["name"] = nameA
+    configA.config["gateway"]["override_hostname"] = nameA
+    configA.config["spdk"]["rpc_socket_name"] = sockA
+    if os.cpu_count() >= 4:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    else:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
+    portA = configA.getint("gateway", "port")
+    configB.config["gateway"]["name"] = nameB
+    configB.config["gateway"]["override_hostname"] = nameB
+    configB.config["spdk"]["rpc_socket_name"] = sockB
+    portB = portA + 2
+    discPortB = configB.getint("discovery", "port") + 1
+    configB.config["gateway"]["port"] = str(portB)
+    configB.config["discovery"]["port"] = str(discPortB)
+    if os.cpu_count() >= 4:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    else:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
+
+    ceph_utils = CephUtils(config)
+    with (GatewayServer(configA) as gatewayA, GatewayServer(configB) as gatewayB):
+        ceph_utils.execute_ceph_monitor_command(
+            "{" + f'"prefix":"nvme-gw create", "id": "{nameA}", "pool": "{pool}", '
+                  f'"group": "{group_name}"' + "}"
+        )
+        ceph_utils.execute_ceph_monitor_command(
+            "{" + f'"prefix":"nvme-gw create", "id": "{nameB}", "pool": "{pool}", '
+                  f'"group": "{group_name}"' + "}"
+        )
+        gatewayA.serve()
+        gatewayB.serve()
+
+        channelA = grpc.insecure_channel(f"{addr}:{portA}")
+        pb2_grpc.GatewayStub(channelA)
+        channelB = grpc.insecure_channel(f"{addr}:{portB}")
+        pb2_grpc.GatewayStub(channelB)
+
+        yield gatewayA, gatewayB
+        if gatewayA and gatewayA.server:
+            gatewayA.server.stop(grace=1)
+        if gatewayB and gatewayB.server:
+            gatewayB.server.stop(grace=1)
+
+
+def verify_one_namespace_lb_group(caplog, gw_port, subsys, nsid_to_verify, grp):
+    caplog.clear()
+    cli(["--server-port", gw_port, "--format", "json", "namespace", "list",
+         "--subsystem", subsys, "--nsid", str(nsid_to_verify)])
+    assert f'"nsid": {nsid_to_verify},' in caplog.text
+    assert f'"load_balancing_group": {grp},' in caplog.text
+
+
+def verify_namespaces(caplog, gw_port, subsys, first_nsid, last_nsid, grp):
+    for ns in range(first_nsid, last_nsid + 1):
+        verify_one_namespace_lb_group(caplog, gw_port, subsys, ns, grp)
+
+
+def verify_resources(caplog, gw_port, subsys_cnt, ns_cnt, grp):
+    for subsys_id in range(1, subsys_cnt + 1):
+        subsys = f"{subsystem_prefix}{subsys_id}"
+        verify_namespaces(caplog, gw_port, subsys, 1, ns_cnt, grp)
+
+
+def create_resources(caplog, subsys_cnt, host_cnt, ns_cnt, grp):
+    img_id = 1
+    for subsys_id in range(1, subsys_cnt + 1):
+        subsys = f"{subsystem_prefix}{subsys_id}"
+        caplog.clear()
+        cli(["subsystem", "add", "--subsystem", subsys, "--no-group-append",
+             "--max-namespaces", f"{2 * ns_cnt}"])
+        assert f"Adding subsystem {subsys}: Successful" in caplog.text
+        for ns_id in range(1, ns_cnt + 1):
+            caplog.clear()
+            image = f"{image_prefix}{ns_id}"
+            cli(["namespace", "add", "--subsystem", subsys, "--rbd-pool", pool,
+                 "--rbd-image", f"{image}{img_id}", "--size", "10MB", "--rbd-create-image",
+                 "--load-balancing-group", grp])
+            assert f"Adding namespace {ns_id} to {subsys}: Successful" in caplog.text
+            img_id += 1
+        for host_id in range(1, host_cnt + 1):
+            caplog.clear()
+            host_nqn = f"{host_prefix}{host_id:02x}"
+            cli(["host", "add", "--subsystem", subsys, "--host-nqn", host_nqn])
+            assert f"Adding host {host_nqn} to {subsys}: Successful" in caplog.text
+
+
+def create_listeners(caplog, gw_name, gw_port, subsys_cnt, addr, start_port):
+    port = int(start_port)
+    for subsys_id in range(1, subsys_cnt + 1):
+        subsys = f"{subsystem_prefix}{subsys_id}"
+        caplog.clear()
+        cli(["--server-port", gw_port, "listener", "add", "--subsystem", subsys,
+             "--host-name", gw_name, "--traddr", addr, "--trsvcid", str(port)])
+        assert f"Adding {subsys} listener at {addr}:{port}: Successful" in caplog.text
+        port += 1
+
+
+def change_namespace_lb_group(caplog, gw_port1, gw_port2, subsys, nsid, grp):
+    cli(["--server-port", gw_port1, "namespace", "change_load_balancing_group",
+         "--subsystem", subsys, "--nsid", str(nsid), "--load-balancing-group", grp])
+    cli(["--server-port", gw_port2, "namespace", "change_load_balancing_group",
+         "--subsystem", subsys, "--nsid", str(nsid), "--load-balancing-group", grp])
+
+
+def change_all_namespaces_lb_group(caplog, gw_port1, gw_port2, subsys, grp):
+    for ns in range(1, namespace_count + 1):
+        change_namespace_lb_group(caplog, gw_port1, gw_port2, subsys, ns, grp)
+
+
+def change_lb_group_for_all_subsystems(caplog, gw_port1, gw_port2, grp):
+    for subsys_id in range(1, subsystem_count + 1):
+        subsys = f"{subsystem_prefix}{subsys_id}"
+        change_all_namespaces_lb_group(caplog, gw_port1, gw_port2, subsys, grp)
+
+
+def test_big_omap(caplog, two_gateways):
+    gatewayA, gatewayB = two_gateways
+    gwA = gatewayA.gateway_rpc
+    gwB = gatewayB.gateway_rpc
+
+    create_resources(caplog, subsystem_count, host_count, namespace_count, anagrpid)
+    waitForUpdate = max(int(gwA.config.config["gateway"]["state_update_interval_sec"]),
+                        int(gwB.config.config["gateway"]["state_update_interval_sec"]))
+    waitForUpdate += 10
+    time.sleep(waitForUpdate)
+    for port in [gwA.config.config["gateway"]["port"],
+                 gwB.config.config["gateway"]["port"]]:
+        verify_resources(caplog, port, subsystem_count, namespace_count, anagrpid)
+
+    create_listeners(caplog, gwA.host_name, gwA.config.config["gateway"]["port"],
+                     subsystem_count, "127.0.0.1", 3000)
+    create_listeners(caplog, gwB.host_name, gwB.config.config["gateway"]["port"],
+                     subsystem_count, "127.0.0.1", 4000)
+
+    time.sleep(waitForUpdate)
+    change_lb_group_for_all_subsystems(caplog,
+                                       gwA.config.config["gateway"]["port"],
+                                       gwB.config.config["gateway"]["port"],
+                                       anagrpid2)
+    time.sleep(waitForUpdate)
+    for port in [gwA.config.config["gateway"]["port"],
+                 gwB.config.config["gateway"]["port"]]:
+        verify_resources(caplog, port, subsystem_count, namespace_count, anagrpid2)
+
+    configB = gwB.config
+    portB = gwB.config.config["gateway"]["port"]
+    gatewayB.__exit__(None, None, None)
+    time.sleep(15)
+    gatewayB = GatewayServer(configB)
+    ceph_utils = CephUtils(configB)
+    ceph_utils.execute_ceph_monitor_command(
+        "{" + f'"prefix":"nvme-gw create", "id": "{gatewayB.name}", "pool": "{pool}", '
+        f'"group": "{group_name}"' + "}"
+    )
+    gatewayB.serve()
+    time.sleep(waitForUpdate)
+    verify_resources(caplog, portB, subsystem_count, namespace_count, anagrpid2)

--- a/tests/test_cli_change_keys.py
+++ b/tests/test_cli_change_keys.py
@@ -6,6 +6,7 @@ import grpc
 from control.proto import gateway_pb2_grpc as pb2_grpc
 import copy
 import time
+import os
 
 image = "mytestdevimage"
 pool = "rbd"
@@ -38,7 +39,10 @@ def two_gateways(config):
     configA.config["gateway"]["name"] = nameA
     configA.config["gateway"]["override_hostname"] = nameA
     configA.config["spdk"]["rpc_socket_name"] = sockA
-    configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    if os.cpu_count() >= 4:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    else:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     portA = configA.getint("gateway", "port")
     configB.config["gateway"]["name"] = nameB
     configB.config["gateway"]["override_hostname"] = nameB
@@ -47,7 +51,10 @@ def two_gateways(config):
     discPortB = configB.getint("discovery", "port") + 1
     configB.config["gateway"]["port"] = str(portB)
     configB.config["discovery"]["port"] = str(discPortB)
-    configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    if os.cpu_count() >= 4:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    else:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
 
     ceph_utils = CephUtils(config)
     with (GatewayServer(configA) as gatewayA, GatewayServer(configB) as gatewayB):
@@ -85,6 +92,11 @@ def test_change_host_key(caplog, two_gateways):
     assert f"Adding host {hostnqn2} to {subsystem}: Successful" in caplog.text
     assert f"Host {hostnqn2} has a DH-HMAC-CHAP key but subsystem {subsystem} has none, " \
            f"a unidirectional authentication will be used" in caplog.text
+    time.sleep(15)
+    assert f"Received request to add host {hostnqn2} to " \
+           f"{subsystem}, context: <grpc._server" in caplog.text
+    assert f"Received request to add host {hostnqn2} to " \
+           f"{subsystem}, context: None" in caplog.text
     caplog.clear()
     cli(["host", "change_key", "--subsystem", subsystem,
          "--host-nqn", hostnqn1, "--dhchap-key", key2])

--- a/tests/test_cli_change_lb.py
+++ b/tests/test_cli_change_lb.py
@@ -8,6 +8,7 @@ import grpc
 from control.proto import gateway_pb2_grpc as pb2_grpc
 import copy
 import time
+import os
 
 image = "mytestdevimage"
 pool = "rbd"
@@ -36,7 +37,10 @@ def two_gateways(config):
     configA.config["gateway"]["name"] = nameA
     configA.config["gateway"]["override_hostname"] = nameA
     configA.config["spdk"]["rpc_socket_name"] = sockA
-    configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    if os.cpu_count() >= 4:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    else:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     portA = configA.getint("gateway", "port")
     configB.config["gateway"]["name"] = nameB
     configB.config["gateway"]["override_hostname"] = nameB
@@ -45,7 +49,10 @@ def two_gateways(config):
     discPortB = configB.getint("discovery", "port") + 1
     configB.config["gateway"]["port"] = str(portB)
     configB.config["discovery"]["port"] = str(discPortB)
-    configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    if os.cpu_count() >= 4:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    else:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
 
     ceph_utils = CephUtils(config)
     with (GatewayServer(configA) as gatewayA, GatewayServer(configB) as gatewayB):
@@ -188,6 +195,7 @@ def test_change_namespace_lb_group(caplog, two_gateways):
     assert '"w_mbytes_per_second": "0",' in caplog.text
     assert '"auto_visible": true,' in caplog.text
     assert '"hosts": []' in caplog.text
+    time.sleep(15)
     caplog.clear()
     cli(["--server-port", "5502", "--format", "json", "namespace", "list",
          "--subsystem", subsystem, "--nsid", "1"])

--- a/tests/test_cli_change_ns_visibility.py
+++ b/tests/test_cli_change_ns_visibility.py
@@ -6,6 +6,7 @@ import grpc
 from control.proto import gateway_pb2_grpc as pb2_grpc
 import copy
 import time
+import os
 
 image = "mytestdevimage"
 pool = "rbd"
@@ -28,7 +29,10 @@ def two_gateways(config):
     configA.config["gateway"]["name"] = nameA
     configA.config["gateway"]["override_hostname"] = nameA
     configA.config["spdk"]["rpc_socket_name"] = sockA
-    configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    if os.cpu_count() >= 4:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    else:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     portA = configA.getint("gateway", "port")
     configB.config["gateway"]["name"] = nameB
     configB.config["gateway"]["override_hostname"] = nameB
@@ -37,7 +41,10 @@ def two_gateways(config):
     discPortB = configB.getint("discovery", "port") + 1
     configB.config["gateway"]["port"] = str(portB)
     configB.config["discovery"]["port"] = str(discPortB)
-    configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    if os.cpu_count() >= 4:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    else:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
 
     ceph_utils = CephUtils(config)
     with (GatewayServer(configA) as gatewayA, GatewayServer(configB) as gatewayB):
@@ -73,6 +80,12 @@ def test_change_namespace_visibility(caplog, two_gateways):
     assert f"Adding namespace 1 to {subsystem}: Successful" in caplog.text
     caplog.clear()
     cli(["--format", "json", "namespace", "list", "--subsystem", subsystem, "--nsid", "1"])
+    assert '"nsid": 1' in caplog.text
+    assert '"auto_visible": true' in caplog.text
+    time.sleep(15)
+    caplog.clear()
+    cli(["--server-port", "5502", "--format", "json", "namespace", "list",
+         "--subsystem", subsystem, "--nsid", "1"])
     assert '"nsid": 1' in caplog.text
     assert '"auto_visible": true' in caplog.text
     caplog.clear()

--- a/tests/test_dhchap.py
+++ b/tests/test_dhchap.py
@@ -5,6 +5,7 @@ from control.cli import main_test as cli_test
 from control.cephutils import CephUtils
 import grpc
 import time
+import os
 
 image = "mytestdevimage"
 pool = "rbd"
@@ -79,7 +80,10 @@ def gateway(config):
     config.config["gateway"]["override_hostname"] = "GW1"
     config.config["gateway-logs"]["log_level"] = "debug"
     config.config["gateway"]["group"] = ""
-    config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x01"
+    if os.cpu_count() >= 4:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x01"
+    else:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     ceph_utils = CephUtils(config)
 
     with GatewayServer(config) as gateway:
@@ -116,7 +120,10 @@ def gateway_encryption_disabled(config):
     config.config["gateway-logs"]["log_level"] = "debug"
     config.config["gateway"]["group"] = ""
     config.config["gateway"]["enable_key_encryption"] = "False"
-    config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x02"
+    if os.cpu_count() >= 4:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x02"
+    else:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     ceph_utils = CephUtils(config)
 
     with GatewayServer(config) as gateway_encryption_disabled:
@@ -153,7 +160,10 @@ def gateway_no_encryption_key(config):
     config.config["gateway"]["group"] = ""
     config.config["gateway"]["enable_key_encryption"] = "True"
     config.config["gateway"]["encryption_key"] = "/etc/ceph/NOencryption.key"
-    config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x04"
+    if os.cpu_count() >= 4:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x04"
+    else:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     ceph_utils = CephUtils(config)
 
     with GatewayServer(config) as gateway_no_encryption_key:
@@ -190,7 +200,10 @@ def gateway_no_key_encryption_disabled(config):
     config.config["gateway"]["group"] = ""
     config.config["gateway"]["enable_key_encryption"] = "False"
     config.config["gateway"]["encryption_key"] = "/etc/ceph/NOencryption.key"
-    config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x08"
+    if os.cpu_count() >= 4:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x08"
+    else:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     ceph_utils = CephUtils(config)
 
     with GatewayServer(config) as gateway_no_key_encryption_disabled:

--- a/tests/test_multi_gateway.py
+++ b/tests/test_multi_gateway.py
@@ -105,7 +105,7 @@ def test_multi_gateway_coordination(config, image, conn):
 
     # Watch/Notify
     if update_notify:
-        time.sleep(1)
+        time.sleep(15)
         listB = json.loads(json_format.MessageToJson(
             stubB.list_subsystems(list_subsystems_req),
             preserving_proto_field_name=True, including_default_value_fields=True))['subsystems']
@@ -124,7 +124,7 @@ def test_multi_gateway_coordination(config, image, conn):
         assert nsListB[0]["rbd_pool_name"] == pool
 
     # Periodic update
-    time.sleep(update_interval_sec + 1)
+    time.sleep(update_interval_sec + 15)
     listB = json.loads(json_format.MessageToJson(
         stubB.list_subsystems(list_subsystems_req),
         preserving_proto_field_name=True, including_default_value_fields=True))['subsystems']

--- a/tests/test_omap_lock.py
+++ b/tests/test_omap_lock.py
@@ -3,6 +3,7 @@ import copy
 import grpc
 import json
 import time
+import os
 from google.protobuf import json_format
 from control.server import GatewayServer
 from control.cephutils import CephUtils
@@ -31,7 +32,10 @@ def setup_config(config, gw1_name, gw2_name, gw_group, update_notify, update_int
     configA.config["gateway"]["omap_file_lock_duration"] = str(lock_duration)
     configA.config["gateway"]["enable_spdk_discovery_controller"] = "True"
     configA.config["spdk"]["rpc_socket_name"] = sock1_name
-    configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    if os.cpu_count() >= 4:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    else:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     configB = copy.deepcopy(configA)
     portA = configA.getint("gateway", "port") + port_inc
     configA.config["gateway"]["port"] = str(portA)
@@ -40,7 +44,10 @@ def setup_config(config, gw1_name, gw2_name, gw_group, update_notify, update_int
     configB.config["gateway"]["override_hostname"] = gw2_name
     configB.config["gateway"]["port"] = str(portB)
     configB.config["spdk"]["rpc_socket_name"] = sock2_name
-    configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    if os.cpu_count() >= 4:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    else:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
 
     return configA, configB
 
@@ -155,23 +162,32 @@ def create_resource_by_index(stub, i, caplog):
     if caplog is not None:
         assert f"create_subsystem {subsystem}: True" in caplog.text
         assert f"Failure creating subsystem {subsystem}" not in caplog.text
+        caplog.clear()
     namespace_req = pb2.namespace_add_req(subsystem_nqn=subsystem,
                                           rbd_pool_name=pool, rbd_image_name=image, block_size=4096,
                                           create_image=True, size=16 * 1024 * 1024, force=True)
     ret_namespace = stub.namespace_add(namespace_req)
     assert ret_namespace.status == 0
+    assert ret_namespace.nsid > 0
+    if caplog is not None:
+        assert f"subsystem_add_ns: {ret_namespace.nsid}" in caplog.text
+        assert "Failure adding namespace " not in caplog.text
+        caplog.clear()
     hostnqn = build_host_nqn(i)
     host_req = pb2.add_host_req(subsystem_nqn=subsystem, host_nqn=hostnqn)
     ret_host = stub.add_host(host_req)
     assert ret_host.status == 0
+    if caplog is not None:
+        assert f"add_host {hostnqn}: True" in caplog.text
+        assert f"Failure adding host {hostnqn} to {subsystem}" not in caplog.text
+        caplog.clear()
     host_req = pb2.add_host_req(subsystem_nqn=subsystem, host_nqn="*")
     ret_host = stub.add_host(host_req)
     assert ret_host.status == 0
     if caplog is not None:
-        assert f"add_host {hostnqn}: True" in caplog.text
         assert "add_host *: True" in caplog.text
         assert f"Failure allowing open host access to {subsystem}" not in caplog.text
-        assert f"Failure adding host {hostnqn} to {subsystem}" not in caplog.text
+        caplog.clear()
 
 
 def check_resource_by_index(i, subsys_list, hosts_info):
@@ -280,9 +296,12 @@ def test_trying_to_lock_twice(config, image, conn_lock_twice, caplog):
     caplog.clear()
     stubA, stubB = conn_lock_twice
 
-    with pytest.raises(Exception):
-        create_resource_by_index(stubA, 100000, None)
-        create_resource_by_index(stubB, 100001, None)
+    try:
+        with pytest.raises(Exception):
+            create_resource_by_index(stubA, 100000, None)
+            create_resource_by_index(stubB, 100001, None)
+    except SystemExit:
+        pass
     assert "OMAP file unlock was disabled, will not unlock file" in caplog.text
     assert "The OMAP file is locked, will try again in" in caplog.text
     assert "Unable to lock OMAP file" in caplog.text
@@ -299,7 +318,6 @@ def test_multi_gateway_concurrent_changes(config, image, conn_concurrent, caplog
             create_resource_by_index(stubA, i, caplog)
         else:
             create_resource_by_index(stubB, i, caplog)
-        assert "failed" not in caplog.text.lower()
     listener_req = pb2.create_listener_req(nqn=f"{subsystem_prefix}0",
                                            host_name=gwA.host_name,
                                            adrfam="ipv4",
@@ -311,7 +329,7 @@ def test_multi_gateway_concurrent_changes(config, image, conn_concurrent, caplog
            f"{subsystem_prefix}0 at 127.0.0.1:5001" in caplog.text
     assert "create_listener: True" in caplog.text
 
-    timeout = 15  # Maximum time to wait (in seconds)
+    timeout = 30  # Maximum time to wait (in seconds)
     start_time = time.time()
     expected_warning_other_gw = f"Listener not created as gateway's host name {gwB.host_name} " \
                                 f"differs from requested host {gwA.host_name}"

--- a/tests/test_omap_no_read_lock.py
+++ b/tests/test_omap_no_read_lock.py
@@ -1,0 +1,66 @@
+import pytest
+from control.server import GatewayServer
+from control.cephutils import CephUtils
+import grpc
+from control.proto import gateway_pb2_grpc as pb2_grpc
+import time
+
+pool = "rbd"
+group_name = "GROUPNAME"
+
+
+@pytest.fixture(scope="module")
+def gateway(config):
+    """Sets up and tears down Gateway"""
+
+    config.config["gateway"]["group"] = group_name
+    addr = config.get("gateway", "addr")
+    port = config.getint("gateway", "port")
+    config.config["gateway"]["omap_file_lock_on_read"] = "False"
+    config.config["gateway-logs"]["log_level"] = "debug"
+    ceph_utils = CephUtils(config)
+
+    with GatewayServer(config) as gateway:
+
+        # Start gateway
+        gateway.gw_logger_object.set_log_level("debug")
+        ceph_utils.execute_ceph_monitor_command(
+            "{" + f'"prefix":"nvme-gw create", "id": "{gateway.name}", "pool": "{pool}", '
+            f'"group": "{group_name}"' + "}"
+        )
+        gateway.serve()
+
+        # Bind the client and Gateway
+        channel = grpc.insecure_channel(f"{addr}:{port}")
+        stub = pb2_grpc.GatewayStub(channel)
+        yield gateway.gateway_rpc, stub
+
+        # Stop gateway
+        gateway.server.stop(grace=1)
+        gateway.gateway_rpc.gateway_state.delete_state()
+
+
+def test_no_read_lock(caplog, gateway):
+    gw, _ = gateway
+    lookfor = "Will not lock OMAP for read, this might cause using an inconsistent state when " \
+              "big OMAP file are used"
+    found = 0
+    time.sleep(10)
+    for oneline in caplog.get_records("setup"):
+        if oneline.message == lookfor:
+            found += 1
+    assert found == 1
+    caplog.clear()
+    gw.gateway_state.omap.get_state()
+    assert "Locked OMAP file before reading its content" not in caplog.text
+    assert "Released OMAP file lock after reading content" not in caplog.text
+    gw.rpc_lock.acquire()
+    caplog.clear()
+    gw.omap_lock.lock_omap()
+    assert "Locked OMAP exclusive" in caplog.text
+    assert "Locked OMAP shared" not in caplog.text
+    caplog.clear()
+    gw.gateway_state.omap.get_state()
+    assert "The OMAP file is locked, will try again in" not in caplog.text
+    gw.omap_lock.unlock_omap()
+    gw.rpc_lock.release()

--- a/tests/test_omap_read_lock.py
+++ b/tests/test_omap_read_lock.py
@@ -1,0 +1,158 @@
+import pytest
+from control.server import GatewayServer
+from control.cephutils import CephUtils
+from control.state import OmapLock
+import grpc
+from control.proto import gateway_pb2_grpc as pb2_grpc
+import copy
+import time
+import os
+import rados
+
+pool = "rbd"
+host_prefix = "nqn.2014-08.org.nvmexpress:uuid:893a6752-fe9b-ca48-aa93-e4565f3288"
+
+
+@pytest.fixture(scope="module")
+def two_gateways(config):
+    """Sets up and tears down two Gateways"""
+    grp = "group2"
+    nameA = "GatewayAA"
+    nameB = "GatewayBB"
+    sockA = f"spdk_{nameA}.sock"
+    sockB = f"spdk_{nameB}.sock"
+    config.config["gateway-logs"]["log_level"] = "debug"
+    config.config["gateway"]["group"] = grp
+    config.config["gateway"]["max_subsystems"] = "1024"
+    config.config["gateway"]["max_namespaces"] = "5120"
+    config.config["gateway"]["max_hosts"] = "5000"
+    config.config["gateway"]["rebalance_period_sec"] = "0"
+    config.config["gateway"]["state_update_notify"] = "False"
+    config.config["gateway"]["state_update_interval_sec"] = "300"
+    addr = config.get("gateway", "addr")
+    configA = copy.deepcopy(config)
+    configB = copy.deepcopy(config)
+    configA.config["gateway"]["name"] = nameA
+    configA.config["gateway"]["override_hostname"] = nameA
+    configA.config["spdk"]["rpc_socket_name"] = sockA
+    if os.cpu_count() >= 4:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x02"
+    else:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
+    portA = configA.getint("gateway", "port")
+    configB.config["gateway"]["name"] = nameB
+    configB.config["gateway"]["override_hostname"] = nameB
+    configB.config["spdk"]["rpc_socket_name"] = sockB
+    portB = portA + 2
+    discPortB = configB.getint("discovery", "port") + 1
+    configB.config["gateway"]["port"] = str(portB)
+    configB.config["discovery"]["port"] = str(discPortB)
+    if os.cpu_count() >= 4:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    else:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
+
+    ceph_utils = CephUtils(config)
+    with (GatewayServer(configA) as gatewayA, GatewayServer(configB) as gatewayB):
+        ceph_utils.execute_ceph_monitor_command(
+            "{" + f'"prefix":"nvme-gw create", "id": "{nameA}", "pool": "{pool}", '
+                  f'"group": "{grp}"' + "}"
+        )
+        ceph_utils.execute_ceph_monitor_command(
+            "{" + f'"prefix":"nvme-gw create", "id": "{nameB}", "pool": "{pool}", '
+                  f'"group": "{grp}"' + "}"
+        )
+        gatewayA.serve()
+        gatewayB.serve()
+
+        channelA = grpc.insecure_channel(f"{addr}:{portA}")
+        pb2_grpc.GatewayStub(channelA)
+        channelB = grpc.insecure_channel(f"{addr}:{portB}")
+        pb2_grpc.GatewayStub(channelB)
+
+        yield gatewayA.gateway_rpc, gatewayB.gateway_rpc
+        gatewayA.gateway_rpc.gateway_state.delete_state()
+        gatewayB.gateway_rpc.gateway_state.delete_state()
+        gatewayA.server.stop(grace=1)
+        gatewayB.server.stop(grace=1)
+
+
+def test_mixing_locks(caplog, two_gateways):
+    gwA, gwB = two_gateways
+
+    caplog.clear()
+    gwA.gateway_state.omap.get_state()
+    assert "Locked OMAP file before reading its content" in caplog.text
+    assert "Released OMAP file lock after reading content" in caplog.text
+    gwA.rpc_lock.acquire()
+    gwB.rpc_lock.acquire()
+    caplog.clear()
+    gwA.omap_lock.lock_omap()
+    assert "Locked OMAP exclusive" in caplog.text
+    assert "Locked OMAP shared" not in caplog.text
+    time.sleep(19)     # A little less than omap_file_lock_duration
+    caplog.clear()
+    gwB.gateway_state.omap.get_state()
+    assert "The OMAP file is locked, will try again in" in caplog.text
+    assert "Succeeded to lock OMAP file (shared) after" in caplog.text
+    caplog.clear()
+    with pytest.raises(rados.ObjectNotFound):
+        gwA.omap_lock.unlock_omap()
+    assert "OMAP was unlocked" not in caplog.text
+    assert "No such lock, the exclusive lock might have expired" in caplog.text
+    OmapLock.reset_lock_markers()
+    time.sleep(25)
+    caplog.clear()
+    gwA.omap_lock.lock_omap(False, False, 1)
+    assert "Locked OMAP shared" in caplog.text
+    caplog.clear()
+    gwB.omap_lock.lock_omap(False, False, 2)
+    assert "Locked OMAP shared" in caplog.text
+    assert "We already locked the OMAP file" not in caplog.text
+    caplog.clear()
+    gwA.omap_lock.unlock_omap(False, 1)
+    assert "OMAP was unlocked" in caplog.text
+    caplog.clear()
+    gwB.omap_lock.unlock_omap(False, 2)
+    assert "OMAP was unlocked" in caplog.text
+    caplog.clear()
+    with pytest.raises(rados.ObjectNotFound):
+        gwA.omap_lock.unlock_omap(False, 1)
+    assert "OMAP was unlocked" not in caplog.text
+    assert "No such lock, the shared lock might have expired" in caplog.text
+    OmapLock.reset_lock_markers()
+    time.sleep(25)
+    caplog.clear()
+    gwA.omap_lock.lock_omap()
+    assert "Locked OMAP exclusive" in caplog.text
+    caplog.clear()
+    try:
+        gwA.omap_lock.lock_omap()
+    except RuntimeError as ex:
+        assert str(ex) == "An attempt to lock OMAP exclusively twice from the same thread"
+        pass
+    caplog.clear()
+    gwA.omap_lock.unlock_omap()
+    assert "OMAP was unlocked" in caplog.text
+    caplog.clear()
+    with pytest.raises(rados.ObjectNotFound):
+        gwA.omap_lock.unlock_omap()
+    assert "OMAP was unlocked" not in caplog.text
+    assert "No such lock, the exclusive lock might have expired" in caplog.text
+    OmapLock.reset_lock_markers()
+    time.sleep(25)
+    caplog.clear()
+    gwA.omap_lock.lock_omap()
+    assert "Locked OMAP exclusive" in caplog.text
+    gotFileExists = False
+    caplog.clear()
+    try:
+        gwA.omap_lock.lock_omap(False, False, 3)
+    except FileExistsError:
+        gotFileExists = True
+    assert "No need to lock OMAP for read as we already have it locked for write" in caplog.text
+    assert "Locked OMAP shared" not in caplog.text
+    assert gotFileExists
+    gwA.omap_lock.unlock_omap()
+    gwA.rpc_lock.release()
+    gwB.rpc_lock.release()

--- a/tests/test_omap_read_lock_ignore_errors.py
+++ b/tests/test_omap_read_lock_ignore_errors.py
@@ -1,0 +1,60 @@
+import pytest
+from control.server import GatewayServer
+from control.cephutils import CephUtils
+import grpc
+from control.proto import gateway_pb2_grpc as pb2_grpc
+import time
+
+pool = "rbd"
+group_name = "GROUPNAME"
+
+
+@pytest.fixture(scope="module")
+def gateway(config):
+    """Sets up and tears down Gateway"""
+
+    config.config["gateway"]["group"] = group_name
+    addr = config.get("gateway", "addr")
+    port = config.getint("gateway", "port")
+    config.config["gateway"]["omap_file_ignore_unlock_errors"] = "True"
+    config.config["gateway-logs"]["log_level"] = "debug"
+    ceph_utils = CephUtils(config)
+
+    with GatewayServer(config) as gateway:
+
+        # Start gateway
+        gateway.gw_logger_object.set_log_level("debug")
+        ceph_utils.execute_ceph_monitor_command(
+            "{" + f'"prefix":"nvme-gw create", "id": "{gateway.name}", "pool": "{pool}", '
+            f'"group": "{group_name}"' + "}"
+        )
+        gateway.serve()
+
+        # Bind the client and Gateway
+        channel = grpc.insecure_channel(f"{addr}:{port}")
+        pb2_grpc.GatewayStub(channel)
+        yield gateway.gateway_rpc
+
+        # Stop gateway
+        gateway.server.stop(grace=1)
+        gateway.gateway_rpc.gateway_state.delete_state()
+
+
+def test_ignore_unlock_errors(caplog, gateway):
+    gw = gateway
+    lookfor = "OMAP unlock errors will be ignored, the gateway will continue"
+    found = 0
+    time.sleep(10)
+    for oneline in caplog.get_records("setup"):
+        if oneline.message == lookfor:
+            found += 1
+    assert found == 1
+    caplog.clear()
+    gw.rpc_lock.acquire()
+    gw.omap_lock.lock_omap()
+    assert "Locked OMAP exclusive" in caplog.text
+    assert "Locked OMAP shared" not in caplog.text
+    time.sleep(25)     # A little more than omap_file_lock_duration
+    caplog.clear()
+    gw.omap_lock.unlock_omap()
+    assert "No such lock, the exclusive lock might have expired" in caplog.text

--- a/tests/test_psk.py
+++ b/tests/test_psk.py
@@ -5,6 +5,7 @@ from control.cli import main_test as cli_test
 from control.cephutils import CephUtils
 import grpc
 import time
+import os
 
 image = "mytestdevimage"
 pool = "rbd"
@@ -63,7 +64,10 @@ def gateway(config):
     config.config["gateway"]["override_hostname"] = "GW1"
     config.config["gateway-logs"]["log_level"] = "debug"
     config.config["gateway"]["group"] = ""
-    config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    if os.cpu_count() >= 4:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    else:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     ceph_utils = CephUtils(config)
 
     with GatewayServer(config) as gateway:
@@ -100,7 +104,10 @@ def gateway_no_encryption_key(config):
     config.config["gateway-logs"]["log_level"] = "debug"
     config.config["gateway"]["group"] = ""
     config.config["gateway"]["encryption_key"] = "/etc/ceph/NOencryption.key"
-    config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    if os.cpu_count() >= 4:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    else:
+        config.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     ceph_utils = CephUtils(config)
 
     with GatewayServer(config) as gateway_no_encryption_key:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -22,7 +22,7 @@ def local_state():
 @pytest.fixture
 def omap_state(config):
     """Sets up and tears down OMAP state object."""
-    omap = OmapGatewayState(config, "test")
+    omap = OmapGatewayState(config, None, "test")
     omap.delete_state()
     yield omap
     omap.delete_state()

--- a/tests/test_subsys_grp_name_append.py
+++ b/tests/test_subsys_grp_name_append.py
@@ -5,6 +5,7 @@ from control.cephutils import CephUtils
 import grpc
 from control.proto import gateway_pb2_grpc as pb2_grpc
 import copy
+import os
 
 image = "mytestdevimage"
 pool = "rbd"
@@ -31,7 +32,10 @@ def two_gateways(config):
     configA.config["gateway"]["name"] = nameA
     configA.config["gateway"]["override_hostname"] = nameA
     configA.config["spdk"]["rpc_socket_name"] = sockA
-    configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    if os.cpu_count() >= 4:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x03"
+    else:
+        configA.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
     portA = configA.getint("gateway", "port")
     configB.config["gateway"]["name"] = nameB
     configB.config["gateway"]["override_hostname"] = nameB
@@ -40,7 +44,10 @@ def two_gateways(config):
     discPortB = configB.getint("discovery", "port") + 1
     configB.config["gateway"]["port"] = str(portB)
     configB.config["discovery"]["port"] = str(discPortB)
-    configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    if os.cpu_count() >= 4:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "-m 0x0C"
+    else:
+        configB.config["spdk"]["tgt_cmd_extra_args"] = "--disable-cpumask-locks"
 
     ceph_utils = CephUtils(config)
     with (GatewayServer(configA) as gatewayA, GatewayServer(configB) as gatewayB):


### PR DESCRIPTION
In case the OMAP file is bigger than 1024 entries, the read of its content is not atomic. So, in such a case if the filer was modified while we were reading we lock the file and read again.

Fixes #1117