### PR TITLE
Reset discovery SIGTERM handler to default

### DIFF
--- a/control/server.py
+++ b/control/server.py
@@ -445,6 +445,7 @@ class GatewayServer:
             self.omap_state = None
             self.name = None
             signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
             if self.server:
                 self.server.stop(None)
                 self.server = None


### PR DESCRIPTION
The discovery service is forked from the gateway and inherits the SIGTERM handler which catch the signal and raise a SystemExit exception. Only, we have a problem right now where exception don't cause the discovery service process to exit. This causes the discovery to get stuck in a zombie state. The process is up but it doesn't really work. Until we fix the exceptions issue, we should allow terminating the discovery process by sending SIGTERM.