### PR TITLE
Add permissions to the github action file

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,6 +1,8 @@
 ---
 # yamllint disable rule:line-length
 name: "CI"
+permissions:
+  contents: read
 on:  # yamllint disable rule:truthy
   push:
     tags:


### PR DESCRIPTION
We get a warning from github because we don't permissions in our yaml file.