### PR TITLE
8.1 schedule: remove andstor/file-existence-action action

### DIFF
--- a/.github/workflows/squid-8.1-schedule.yml
+++ b/.github/workflows/squid-8.1-schedule.yml
@@ -186,20 +186,6 @@ jobs:
           # Managing pytest’s output: https://docs.pytest.org/en/7.1.x/how-to/output.html
           make run SVC="nvmeof" OPTS="--volume=$(pwd)/tests:/src/tests --entrypoint=python3" CMD="-m pytest --show-capture=all -s --full-trace -vv -rA tests/test_${{ matrix.test }}.py"
 
-      - name: Check coredump existence
-        if: success() || failure()
-        id: check_coredumps
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b  # v2, pinned to SHA for security reasons
-        with:
-          files: "/tmp/coredump/core.*"
-
-      - name: Upload ${{ matrix.test }} test core dumps
-        if: steps.check_coredumps.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: core_pytest_${{ matrix.test }}
-          path: /tmp/coredump/core.*
-
       - name: Copy ceph logs
         if: success() || failure()
         run: docker cp  ceph:/ceph/out /tmp/out
@@ -299,20 +285,6 @@ jobs:
       - name: Run bdevperf
         run: |
           ./tests/ha/demo_test.sh bdevperf_${{ matrix.security_protocol }}
-
-      - name: Check coredump existence
-        if: success() || failure()
-        id: check_coredumps
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b  # v2, pinned to SHA for security reasons
-        with:
-          files: "/tmp/coredump/core.*"
-
-      - name: Upload demo-${{ matrix.security_protocol }} core dumps
-        if: steps.check_coredumps.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: core_demo_${{ matrix.security_protocol }}
-          path: /tmp/coredump/core.*
 
       # For debugging purposes (provides an SSH connection to the runner)
       # - name: Setup tmate session
@@ -501,20 +473,6 @@ jobs:
           bdevperf="/usr/libexec/spdk/scripts/bdevperf.py"
           make exec SVC=bdevperf OPTS=-T CMD="$bdevperf -v -t $timeout -s $BDEVPERF_SOCKET perform_tests"
 
-      - name: Check coredump existence
-        if: success() || failure()
-        id: check_coredumps
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b  # v2, pinned to SHA for security reasons
-        with:
-          files: "/tmp/coredump/core.*"
-
-      - name: Upload demo core dumps
-        if: steps.check_coredumps.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: core_demo_discovery
-          path: /tmp/coredump/core.*
-
       - name: Display logs
         if: success() || failure()
         run: make logs OPTS=''
@@ -602,20 +560,6 @@ jobs:
         run: |
           . .env
           source "tests/ha/${{ matrix.test }}.sh"
-
-      - name: Check coredump existence
-        if: success() || failure()
-        id: check_coredumps
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b  # v2, pinned to SHA for security reasons
-        with:
-          files: "/tmp/coredump/core.*"
-
-      - name: Upload ha core dumps
-        if: steps.check_coredumps.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: core_demo_ha-${{ matrix.test }}
-          path: /tmp/coredump/core.*
 
       - name: Copy ceph logs
         if: success() || failure()


### PR DESCRIPTION
# 8.1 schedule: remove andstor/file-existence-action action

Reference: https://github.com/orgs/ceph/projects/11/views/1 
There appears to be a typo in the definition. Specifically, the action at andstor/file-existence-action is defined with a SHA that actually belongs to eps1lon/actions-label-merge-conflict@b8bf8341285ec9a4567d4318ba474fee998a6919. 

Please see the error message [here](https://github.com/ceph/ceph-nvmeof/actions/runs/15363031745) :
```
Error
andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 is not allowed to be used in ceph/ceph-nvmeof. Actions in this workflow must be: within a repository owned by ceph, created by GitHub, or matching the following: JJ/github-pr-contains-action@526dfe784d8604ea1c39b6c26609074de95b1ffd, Mergifyio/gha-mergify-merge-queue-labels-copier@1d2b277f94d52987008ec05b571fb68f2357e63f, andstor/file-existence-action@b8bf8341285ec9a4567d4318ba474fee998a6919, astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182, bdougie/take-action@1439165ac45a7461c2d89a59952cd7d941964b87, docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4, docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772, docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2, docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392, eps1lon/actions-label-merge-conflict@b8bf8341285ec9a4567d4318ba474fee998a6919, golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50...
```