### PR TITLE
atom: use specific build for ceph main latest build

### DIFF
--- a/tests/atom/clusterBuildTestsRun.sh
+++ b/tests/atom/clusterBuildTestsRun.sh
@@ -9,7 +9,11 @@ set -e
 VERSION=$1
 CEPH_BRANCH=$2
 if [ "$3" = "latest" ]; then
-    CEPH_SHA=$(curl -s https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/latest/centos/9/ | jq -r ".[] | select(.archs[] == \"$(uname -m)\" and .status == \"ready\") | .sha1")
+    if [ "$CEPH_BRANCH" = "main" ]; then
+        CEPH_SHA=$(curl -s https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/135cf5df119da6eded5a0f63cb040242a30d3a0a/centos/9/ | jq -r ".[] | select(.archs[] == \"$(uname -m)\" and .status == \"ready\") | .sha1")
+    else
+        CEPH_SHA=$(curl -s https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/latest/centos/9/ | jq -r ".[] | select(.archs[] == \"$(uname -m)\" and .status == \"ready\") | .sha1")
+    fi
 else
     CEPH_SHA=$3
 fi


### PR DESCRIPTION
Temporary fix:
Use sha1 135cf5df119da6eded5a0f63cb040242a30d3a0a
instead of latest main due to an issue in "latest main"

