### PR TITLE
Revert "atom: use specific build for ceph main latest build"

### DIFF
--- a/tests/atom/clusterBuildTestsRun.sh
+++ b/tests/atom/clusterBuildTestsRun.sh
@@ -9,11 +9,7 @@ set -e
 VERSION=$1
 CEPH_BRANCH=$2
 if [ "$3" = "latest" ]; then
-    if [ "$CEPH_BRANCH" = "main" ]; then
-        CEPH_SHA=$(curl -s https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/135cf5df119da6eded5a0f63cb040242a30d3a0a/centos/9/ | jq -r ".[] | select(.archs[] == \"$(uname -m)\" and .status == \"ready\") | .sha1")
-    else
-        CEPH_SHA=$(curl -s https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/latest/centos/9/ | jq -r ".[] | select(.archs[] == \"$(uname -m)\" and .status == \"ready\") | .sha1")
-    fi
+    CEPH_SHA=$(curl -s https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/latest/centos/9/ | jq -r ".[] | select(.archs[] == \"$(uname -m)\" and .status == \"ready\") | .sha1")
 else
     CEPH_SHA=$3
 fi


### PR DESCRIPTION
Revert https://github.com/ceph/ceph-nvmeof/pull/1355

The problem in shaman latest main build was fixed, so we can revert this now.

The issue with ceph latest seemed to be because an odd ceph main build was pushed by someone unintentionally.
Usually new ceph main jobs are automatically build daily using [ceph-dev-build](https://jenkins.ceph.com/job/ceph-dev-build/) jenkins job. Someone was testing another jenkins job [preserve-adarsha-test](https://jenkins.ceph.com/job/preserve-adarsha-test/) and it unknowingly pushed the build to shaman main builds: https://shaman.ceph.com/builds/ceph/main/
Recently pushed ceph main latest should work well! 