### PR TITLE
prometheus: host keep alive timeout fixes

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -4273,9 +4273,11 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
         assert self.rpc_lock.locked(), "RPC is unlocked when calling list_hosts_safe()"
         peer_msg = self.get_peer_message(context)
-        self.logger.info(f"Received request to list hosts for "
-                         f"{request.subsystem}, clear_alerts: {request.clear_alerts}, "
-                         f"context: {context}{peer_msg}")
+        log_level = logging.INFO if context else logging.DEBUG
+        self.logger.log(log_level,
+                        f"Received request to list hosts for "
+                        f"{request.subsystem}, clear_alerts: {request.clear_alerts}, "
+                        f"context: {context}{peer_msg}")
         try:
             ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client, nqn=request.subsystem)
             self.logger.debug(f"list_hosts: {ret}")

--- a/control/prometheus.py
+++ b/control/prometheus.py
@@ -214,7 +214,7 @@ class NVMeOFCollector:
         host_map = {}
         for subsys in subsystem_list:
             resp = self.gateway_rpc.list_hosts(pb2.list_hosts_req(subsystem=subsys.nqn,
-                                                                  clear_alerts=True))
+                                                                  clear_alerts=False))
             if resp.status != 0:
                 logger.error(f"Exporter failed to fetch host info for "
                              f"{subsys.nqn}: {resp.error_message}")


### PR DESCRIPTION
This PR fixes these two things:

1. prometheus: do not clear keepalive timeout alerts

When prometheus requests host information for
collecting prometheus metrics, do not clear keepalive
timeout alerts as it keeps resetting keepalive notifications
everytime prometheus calls _get_data() in background.

2. grpc: set logging level for list_hosts_safe

Currently, logging level is set as INFO level,
it should be set dynamically like list_connections_safe
or list_subsystems_safe.

Reason:
With recently added prometheus _get_host_map() method,
list_hosts() is called multiple times in background
when prometheus collects metrics.
With INFO level logging, the gateway logs get filled
with many lines of
"INFO grpc.py:4276 (7): Received request to list hosts for nqn.2016-06.io.spdk:cnode2.mygroup1, clear_alerts: False, context: None"