### PR TITLE
Give a proper error when adding a host to a non-existing subsystem

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -3824,6 +3824,13 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
+        # If this is not set the subsystem was not created yet
+        if request.subsystem_nqn not in self.subsys_serial:
+            pref = all_host_failure_prefix if request.host_nqn == "*" else host_failure_prefix
+            errmsg = f"{pref}: can't find subsystem {request.subsystem_nqn}"
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
+
         if request.host_nqn == "*":
             if self.host_info.does_subsystem_have_dhchap_key(request.subsystem_nqn):
                 errmsg = f"{all_host_failure_prefix}: Can't allow any host access " \

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1350,6 +1350,14 @@ class TestCreate:
         assert "error: the following arguments are required: --host-nqn/-t" in caplog.text
         assert rc == 2
 
+    def test_add_host_subsys_not_found(self, caplog):
+        caplog.clear()
+        cli(["host", "add", "--subsystem", "junk", "--host-nqn", host1])
+        assert f"Failure adding host {host1} to junk: can't find subsystem junk" in caplog.text
+        caplog.clear()
+        cli(["host", "add", "--subsystem", "junk", "--host-nqn", "*"])
+        assert "Failure allowing open host access to junk: can't find subsystem junk" in caplog.text
+
     @pytest.mark.parametrize("host", host_list)
     def test_add_host(self, caplog, host):
         caplog.clear()


### PR DESCRIPTION
Fixes #1337