### PR TITLE
Add 'get_thread_stats' rpc call

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -536,6 +536,51 @@ class GatewayClient:
         else:
             assert False
 
+    def gw_get_thread_stats(self, args):
+        """Show NVMf thread statistics for the gateway"""
+
+        out_func, err_func, _ = self.get_output_functions(args)
+        thread_stats = None
+        try:
+            get_thread_stats_req = pb2.get_thread_stats_req()
+            thread_stats = self.stub.get_thread_stats(get_thread_stats_req)
+        except Exception as ex:
+            err_msg = f"Failure getting gateway's NVMf thread statistics:\n{ex}"
+            thread_stats = pb2.thread_stats_info(status=errno.EINVAL,
+                                                 error_message=err_msg)
+        if args.format == "text" or args.format == "plain":
+            if thread_stats.status == 0:
+                if args.format == "text":
+                    table_format = "fancy_grid"
+                else:
+                    table_format = "plain"
+                stats_list = []
+                tick_rate = thread_stats.tick_rate
+                for thread in thread_stats.threads:
+                    stats_list.append([thread.name, thread.busy, thread.idle])
+                stats_out = tabulate(stats_list,
+                                     headers=["Name", "Busy", "Idle"],
+                                     tablefmt=table_format)
+                out_func(f"NVMf thread statistics for gateway (tick: "
+                         f"{tick_rate}):\n{stats_out}")
+            else:
+                err_func(f"{thread_stats.error_message}")
+        elif args.format == "json" or args.format == "yaml":
+            ret_str = json_format.MessageToJson(thread_stats, indent=4,
+                                                including_default_value_fields=True,
+                                                preserving_proto_field_name=True)
+            if args.format == "json":
+                out_func(ret_str)
+            elif args.format == "yaml":
+                obj = json.loads(ret_str)
+                out_func(yaml.dump(obj))
+        elif args.format == "python":
+            return thread_stats
+        else:
+            assert False
+
+        return thread_stats.status
+
     def gw_get_stats(self, args):
         """Show NVMf statistics for the gateway"""
 
@@ -699,6 +744,9 @@ class GatewayClient:
     gw_actions.append({"name": "listener_info",
                        "args": gw_listener_info_args,
                        "help": "Show listeners information for the gateway"})
+    gw_actions.append({"name": "get_thread_stats",
+                       "args": [],
+                       "help": "Show NVMf thread statistics for the gateway"})
     gw_actions.append({"name": "get_stats",
                        "args": [],
                        "help": "Show NVMf statistics for the gateway"})
@@ -720,6 +768,8 @@ class GatewayClient:
             return self.gw_listener_info(args)
         elif args.action == "get_stats":
             return self.gw_get_stats(args)
+        elif args.action == "get_thread_stats":
+            return self.gw_get_thread_stats(args)
         if not args.action:
             self.cli.parser.error(f"missing action for gw command (choose from "
                                   f"{GatewayClient.gw_choices})")

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -6937,6 +6937,42 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
         return self.execute_grpc_function(self.get_gateway_stats_safe, request, context)
 
+    def get_thread_stats_safe(self, request, context=None):
+        """Get SPDK thread stats"""
+
+        assert self.rpc_lock.locked(), "RPC is unlocked when calling get_thread_stats_safe()"
+        error_prefix = "Failure getting SPDK thread statistics"
+        peer_msg = self.get_peer_message(context)
+        self.logger.info(f"Received request to get spdk thread stats {peer_msg}")
+        try:
+            thread_stats = self.spdk_rpc_client.thread_get_stats()
+            self.logger.debug(f"thread_get_stats: {thread_stats}")
+            threads = []
+            for spdk_thread in thread_stats.get("threads", []):
+                thread = pb2.spdk_thread_info(
+                    name=spdk_thread.get("name"),
+                    busy=spdk_thread.get("busy"),
+                    idle=spdk_thread.get("idle"),
+                )
+                threads.append(thread)
+            return pb2.thread_stats_info(
+                status=0, error_message=os.strerror(0),
+                threads=threads, tick_rate=thread_stats.get("tick_rate", 0))
+        except Exception as ex:
+            self.logger.exception(error_prefix)
+            errmsg = f"{error_prefix}:\n{ex}"
+            resp = self.parse_json_exeption(ex)
+            status = errno.EINVAL
+            if resp:
+                status = resp["code"]
+                errmsg = f"{error_prefix}: {resp['message']}"
+            return pb2.thread_stats_info(status=status, error_message=errmsg)
+
+    def get_thread_stats(self, request, context=None):
+        """Get spdk thread statistics"""
+
+        return self.execute_grpc_function(self.get_thread_stats_safe, request, context)
+
     def get_gateway_log_level(self, request, context=None):
         """Get gateway's log level"""
 

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -145,6 +145,9 @@ service Gateway {
 
 	// Gets gateway's stats
 	rpc get_gateway_stats(get_gateway_stats_req) returns (gateway_stats_info) {}
+
+	// Gets spdk thread stats
+	rpc get_thread_stats(get_thread_stats_req) returns (thread_stats_info) {}
 }
 
 // Request messages
@@ -381,6 +384,9 @@ message show_gateway_listeners_info_req {
 message get_gateway_stats_req {
 }
 
+message get_thread_stats_req {
+}
+
 // From https://nvmexpress.org/wp-content/uploads/NVM-Express-1_4-2019.06.10-Ratified.pdf page 138
 // Asymmetric Namespace Access state for all namespaces in this ANA
 // Group when accessed through this controller.
@@ -547,6 +553,19 @@ message gateway_stats_info {
 	string error_message = 2;
 	uint64 tick_rate = 3;
 	repeated poll_group_info poll_groups = 4;
+}
+
+message thread_stats_info {
+	int32 status = 1;
+	string error_message = 2;
+    repeated spdk_thread_info threads = 3;
+	uint64 tick_rate = 4;
+}
+
+message spdk_thread_info {
+	string name = 1;
+	uint64 busy = 2;
+	uint64 idle = 3;
 }
 
 message listener_info {


### PR DESCRIPTION
So it can be used to request spdk thread
stats by ceph-cli for nvmeof-top tool.

```
[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:add-thread-grpc-cli --server-address x.x.x.x gw get_thread_stats
NVMf thread statistics for gateway (tick: 2394300000):
╒═════════════════════════╤════════════╤══════════════╕
│ Name                    │       Busy │       Thread │
╞═════════════════════════╪════════════╪══════════════╡
│ app_thread              │ 1660040834 │ 417832298046 │
├─────────────────────────┼────────────┼──────────────┤
│ nvmf_tgt_poll_group_000 │    3919138 │ 736604486670 │
├─────────────────────────┼────────────┼──────────────┤
│ nvmf_tgt_poll_group_001 │    3906262 │ 736604455728 │
├─────────────────────────┼────────────┼──────────────┤
│ nvmf_tgt_poll_group_002 │    3728682 │ 736604598920 │
├─────────────────────────┼────────────┼──────────────┤
│ nvmf_tgt_poll_group_003 │    3432992 │ 317393816264 │
╘═════════════════════════╧════════════╧══════════════╛
[root@vallari-vallari-cluster-node1 ~]#
```