### PR TITLE
nvmeof: optimize get_subsystems for predictable low latency

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -38,7 +38,6 @@ max_ns_to_change_lb_grp = 8
 #prometheus_frequency_slow_down_factor = 3.0
 #prometheus_cycles_to_adjust_speed = 3
 #prometheus_startup_delay = 240
-#prometheus_connection_list_cache_expiration = 60
 #verify_nqns = True
 #verify_keys = True
 #verify_listener_ip = True
@@ -51,7 +50,6 @@ max_ns_to_change_lb_grp = 8
 #max_namespaces = 4096
 #max_namespaces_per_subsystem = 512
 #max_hosts_per_subsystem = 128
-#subsystem_cache_expiration = 30
 #force_tls = False
 
 [gateway-logs]

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -46,6 +46,7 @@ from .utils import GatewayUtils
 from .utils import GatewayUtilsCrypto
 from .utils import GatewayLogger
 from .utils import NICS
+from .utils import NvmeofConnectionUtils
 from .state import GatewayState, GatewayStateHandler, OmapLock
 from .cephutils import CephUtils
 from .rebalance import Rebalance
@@ -59,54 +60,88 @@ MONITOR_POLLING_RATE_SEC = 2     # monitor polls gw each 2 seconds
 
 
 class SubsystemsCache:
-    SUBSYSTEMS_CACHE_EXPIRATION = 30
+    """Simple cache for subsystems data.
 
-    def __init__(self, expiration=None):
+    Refreshed by ping loop in main thread every 2 seconds (via spdk_ping_interval_in_seconds).
+    Never expires - always returns cached data (may be empty at startup).
+    """
+
+    def __init__(self, spdk_rpc_client=None, gateway_service=None):
         self.cache_lock = threading.Lock()
-        self.last_value_time = 0
-        self.subsystems = None
-        self.expiration = SubsystemsCache.SUBSYSTEMS_CACHE_EXPIRATION
-        if expiration is not None:
-            self.expiration = expiration
+        # Initial empty cached subsystems list object, never None
+        self.subsystems = pb2.subsystems_info()
+        self.spdk_rpc_client = spdk_rpc_client  # For making RPC calls
+        self.gateway_service = gateway_service  # For data enrichment
+        self.logger = gateway_service.logger if gateway_service else None
 
-    def _check_conditions(self) -> bool:
-        if not self.subsystems:
-            return False
-        if not self.last_value_time:
-            return False
-        if self.expiration and (time.time() - self.last_value_time >= self.expiration):
-            return False
-        return True
-
-    def get_subsystems(self):
+    def get(self):
+        """Get cached protobuf subsystems_info object. Always returns cached data (no RPC call).
+        """
         with self.cache_lock:
-            if not self._check_conditions():
-                return None
             return self.subsystems
 
-    def get_one_subsystem(self, subsys):
-        if not subsys:
-            return None
+    def refresh(self):
+        """Refresh cache by calling SPDK RPC.
 
-        with self.cache_lock:
-            if not self._check_conditions():
-                return None
-            for s in self.subsystems:
-                try:
-                    if s["nqn"] == subsys:
-                        return [s]
-                except Exception:
-                    pass
-        return None
+        Called by ping loop in the main thread every 2 seconds.
+        Returns True if successful, False if SPDK call failed.
+        """
+        try:
+            # Call SPDK to get current subsystems
+            ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client)
 
-    def set_subsystems(self, subsystems):
+            # Check if SPDK returned valid data
+            if ret is None:
+                self.logger.error("SPDK returned None for nvmf_get_subsystems")
+                return False  # Failed - SPDK returned invalid data
+
+            # Update cache with results
+            self._update_cache(ret)
+            return True  # Success
+
+        except Exception:
+            self.logger.exception("Failed to refresh cache from SPDK")
+            return False
+
+    def _update_cache(self, subsystems):
+        """Internal method to update cache data with nonces and protobuf conversion.
+
+        Private method - only called by refresh() and __init__().
+        Enriches subsystems data with nonces.
+        Converts enriched data to protobuf objects for fast retrieval.
+        """
+        # Enrich data before storing in cache
+        if not self.gateway_service:
+            self.logger.error("No gateway service available")
+            return
+
+        # Enrich subsystems with nonces (if gateway service available)
+        for s in subsystems:
+            # Enrich namespace information
+            ns_key = "namespaces"
+            if ns_key in s and self.gateway_service:
+                for n in s[ns_key]:
+                    bdev = n["bdev_name"]
+                    # Add cluster nonce
+                    with self.gateway_service.shared_state_lock:
+                        c = self.gateway_service.bdev_cluster[bdev]
+                        nonce = self.gateway_service.cluster_nonce[c]
+                    n["nonce"] = nonce
+
+        # Convert enriched data to protobuf objects
+        protobuf_subsystems = []
+        for s in subsystems:
+            subsystem = pb2.subsystem()
+            json_format.Parse(json.dumps(s), subsystem, ignore_unknown_fields=True)
+            protobuf_subsystems.append(subsystem)
+
+        # Create complete subsystems_info object
+        subsystems_info = pb2.subsystems_info(subsystems=protobuf_subsystems)
+
+        # Update cache with complete protobuf object
         with self.cache_lock:
-            if not subsystems:
-                self.subsystems = None
-                self.last_value_time = 0
-                return
-            self.last_value_time = time.time()
-            self.subsystems = subsystems
+            self.subsystems = subsystems_info
+        self.logger.debug(f"Cache refreshed with {len(protobuf_subsystems)} subsystems")
 
 
 class BdevStatus:
@@ -783,7 +818,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
         gateway_state: Methods for target state persistence
         spdk_rpc_client: Client of SPDK RPC server
         spdk_rpc_subsystems_client: Client of SPDK RPC server for get_subsystems
-        spdk_rpc_subsystems_lock: Mutex to hold while using get subsystems SPDK client
         shared_state_lock: guard mutex for bdev_cluster and cluster_nonce
         subsystem_nsid_bdev_and_uuid: map of nsid to bdev
         cluster_nonce: cluster context nonce map
@@ -824,7 +858,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
         self.group_id = group_id
         self.spdk_rpc_client = spdk_rpc_client
         self.spdk_rpc_subsystems_client = spdk_rpc_subsystems_client
-        self.spdk_rpc_subsystems_lock = threading.Lock()
         self.shared_state_lock = threading.Lock()
         self.gateway_name = self.config.get("gateway", "name")
         if not self.gateway_name:
@@ -910,11 +943,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
         self.cluster_allocator = get_cluster_allocator(config, self)
         self.subsys_max_ns = {}
         self.subsys_serial = {}
-        expiration = self.config.getint_with_default("gateway",
-                                                     "subsystem_cache_expiration",
-                                                     SubsystemsCache.SUBSYSTEMS_CACHE_EXPIRATION)
-        self.subsystems_cache = SubsystemsCache(expiration)
         self.host_info = SubsystemHostAuth()
+        # Initialize cache - refreshed by ping loop in main thread every 2 seconds
+        self.subsystems_cache = SubsystemsCache(
+            spdk_rpc_client=self.spdk_rpc_subsystems_client,
+            gateway_service=self
+        )
         self.up_and_running = True
         self.rebalance = Rebalance(self)
         self.spdk_version = None
@@ -1204,8 +1238,8 @@ class GatewayService(pb2_grpc.GatewayServicer):
         return resp
 
     def set_cluster_nonce(self, name: str, nonce: str) -> None:
+        self.logger.info(f"Allocated cluster {name=} {nonce=}")
         with self.shared_state_lock:
-            self.logger.info(f"Allocated cluster {name=} {nonce=}")
             self.cluster_nonce[name] = nonce
 
     def _grpc_function_with_lock(self, func, request, context):
@@ -1853,7 +1887,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 self.logger.debug(f"create_subsystem {request.subsystem_nqn}: {ret}")
                 self.subsys_max_ns[request.subsystem_nqn] = request.max_namespaces
                 self.subsys_serial[request.subsystem_nqn] = request.serial_number
-                self.subsystems_cache.set_subsystems(None)
 
                 dhchap_key_for_omap = request.dhchap_key
                 key_encrypted_for_omap = False
@@ -1988,7 +2021,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 self.subsystem_nsid_bdev_and_uuid.remove_namespace(request.subsystem_nqn)
                 self.remove_all_subsystem_key_files(request.subsystem_nqn)
                 self.remove_all_subsystem_keys_from_keyring(request.subsystem_nqn)
-                self.subsystems_cache.set_subsystems(None)
                 self.logger.debug(f"delete_subsystem {request.subsystem_nqn}: {ret}")
             except Exception as ex:
                 self.logger.exception(delete_subsystem_error_prefix)
@@ -2238,7 +2270,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                                             trash_image, read_only,
                                                             location)
             self.logger.debug(f"subsystem_add_ns: {nsid}")
-            self.subsystems_cache.set_subsystems(None)
             self.ana_grp_ns_load[anagrpid] += 1
             if anagrpid in self.ana_grp_subs_load:
                 if subsystem_nqn in self.ana_grp_subs_load[anagrpid]:
@@ -2646,7 +2677,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     anagrpid=request.anagrpid,
                 )
                 self.logger.debug(f"nvmf_subsystem_set_ns_ana_group: {ret}")
-                self.subsystems_cache.set_subsystems(None)
             except Exception as ex:
                 errmsg = f"{change_lb_group_failure_prefix}:\n{ex}"
                 resp = self.parse_json_exeption(ex)
@@ -2864,7 +2894,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     auto_visible=request.auto_visible,
                 )
                 self.logger.debug(f"nvmf_subsystem_set_ns_visible: {ret}")
-                self.subsystems_cache.set_subsystems(None)
                 if request.force and find_ret.host_count() > 0 and request.auto_visible:
                     self.logger.warning(f"Removing all hosts added to namespace {request.nsid} in "
                                         f"{request.subsystem_nqn} as it was set to be "
@@ -3138,7 +3167,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                         add_req, preserving_proto_field_name=True,
                         including_default_value_fields=True)
                     self.gateway_state.add_namespace(request.subsystem_nqn, request.nsid, json_req)
-                    self.subsystems_cache.set_subsystems(None)
                 except Exception as ex:
                     errmsg = f"Error persisting change for RBD trash image flag of namespace " \
                              f"{request.nsid} in {request.subsystem_nqn}"
@@ -3320,7 +3348,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 subsystem_nqn, nsid)
             self.ana_grp_ns_load[anagrpid] -= 1
             self.ana_grp_subs_load[anagrpid][subsystem_nqn] -= 1
-            self.subsystems_cache.set_subsystems(None)
         except Exception as ex:
             self.logger.exception(namespace_failure_prefix)
             errmsg = f"{namespace_failure_prefix}:\n{ex}"
@@ -3375,35 +3402,27 @@ class GatewayService(pb2_grpc.GatewayServicer):
         if not request.subsystem:
             request.subsystem = GatewayUtils.ALL_SUBSYSTEMS
 
+        # Always query SPDK directly (no cache) - CLI tool needs fresh data
         ret = None
-        if request.subsystem == GatewayUtils.ALL_SUBSYSTEMS:
-            ret = self.subsystems_cache.get_subsystems()
-        else:
-            ret = self.subsystems_cache.get_one_subsystem(request.subsystem)
-        self.logger.debug(f"list_namespaces (cache): {ret}")
-
-        if not ret:
-            with self.rpc_lock:
-                try:
-                    if request.subsystem == GatewayUtils.ALL_SUBSYSTEMS:
-                        ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client)
-                        if ret:
-                            self.subsystems_cache.set_subsystems(ret)
-                    else:
-                        ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client,
-                                                           nqn=request.subsystem)
-                    self.logger.debug(f"list_namespaces: {ret}")
-                except Exception as ex:
-                    errmsg = "Failure listing namespaces"
-                    self.logger.exception(errmsg)
-                    errmsg = f"{errmsg}:\n{ex}"
-                    resp = self.parse_json_exeption(ex)
-                    status = errno.EINVAL
-                    if resp:
-                        status = resp["code"]
-                        errmsg = f"Failure listing namespaces: {resp['message']}"
-                    return pb2.namespaces_info(status=status, error_message=errmsg,
-                                               subsystem_nqn=request.subsystem, namespaces=[])
+        with self.rpc_lock:
+            try:
+                if request.subsystem == GatewayUtils.ALL_SUBSYSTEMS:
+                    ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client)
+                else:
+                    ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client,
+                                                       nqn=request.subsystem)
+                self.logger.debug(f"list_namespaces (direct from SPDK): {ret}")
+            except Exception as ex:
+                errmsg = "Failure listing namespaces"
+                self.logger.exception(errmsg)
+                errmsg = f"{errmsg}:\n{ex}"
+                resp = self.parse_json_exeption(ex)
+                status = errno.EINVAL
+                if resp:
+                    status = resp["code"]
+                    errmsg = f"Failure listing namespaces: {resp['message']}"
+                return pb2.namespaces_info(status=status, error_message=errmsg,
+                                           subsystem_nqn=request.subsystem, namespaces=[])
 
         if not ret:
             ret = []
@@ -4635,7 +4654,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                         self.host_info.add_dhchap_host(request.subsystem_nqn,
                                                        request.host_nqn, request.dhchap_key)
                     self.host_info.add_host_nqn(request.subsystem_nqn, request.host_nqn)
-                self.subsystems_cache.set_subsystems(None)
             except Exception as ex:
                 if request.host_nqn == "*":
                     self.logger.exception(all_host_failure_prefix)
@@ -4785,7 +4803,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     self.host_info.remove_host_nqn(request.subsystem_nqn, request.host_nqn)
                     self.host_info.reset_host_keepalive_timeout_disconnection(
                         request.subsystem_nqn, request.host_nqn)
-                self.subsystems_cache.set_subsystems(None)
             except Exception as ex:
                 if request.host_nqn == "*":
                     self.logger.exception(all_host_failure_prefix)
@@ -5051,22 +5068,22 @@ class GatewayService(pb2_grpc.GatewayServicer):
         self.logger.log(log_level, f"Received request to list hosts for "
                                    f"{request.subsystem}, clear_alerts: {request.clear_alerts}, "
                                    f"context: {context}{peer_msg}")
-        ret = self.subsystems_cache.get_one_subsystem(request.subsystem)
-        self.logger.debug(f"list_hosts subsystem (cache): {ret}")
-        if not ret:
-            try:
-                ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client, nqn=request.subsystem)
-                self.logger.debug(f"list_hosts subsystem: {ret}")
-            except Exception as ex:
-                errmsg = "Failure listing hosts, can't get subsystem"
-                self.logger.exception(errmsg)
-                errmsg = f"{errmsg}:\n{ex}"
-                resp = self.parse_json_exeption(ex)
-                status = errno.EINVAL
-                if resp:
-                    status = resp["code"]
-                    errmsg = f"Failure listing hosts, can't get subsystem: {resp['message']}"
-                return pb2.hosts_info(status=status, error_message=errmsg, hosts=[])
+
+        # Always query SPDK directly (no cache) - CLI tool needs fresh data
+        ret = None
+        try:
+            ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client, nqn=request.subsystem)
+            self.logger.debug(f"list_hosts subsystem (direct from SPDK): {ret}")
+        except Exception as ex:
+            errmsg = "Failure listing hosts, can't get subsystem"
+            self.logger.exception(errmsg)
+            errmsg = f"{errmsg}:\n{ex}"
+            resp = self.parse_json_exeption(ex)
+            status = errno.EINVAL
+            if resp:
+                status = resp["code"]
+                errmsg = f"Failure listing hosts, can't get subsystem: {resp['message']}"
+            return pb2.hosts_info(status=status, error_message=errmsg, hosts=[])
 
         if not ret:
             ret = []
@@ -5180,23 +5197,22 @@ class GatewayService(pb2_grpc.GatewayServicer):
                          f"can't get controllers: {resp['message']}"
             return pb2.connections_info(status=status, error_message=errmsg, connections=[])
 
-        subsys_ret = self.subsystems_cache.get_one_subsystem(subsystem)
-        self.logger.debug(f"list_connections subsystems (cache): {subsys_ret}")
-        if not subsys_ret:
-            try:
-                subsys_ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client, nqn=subsystem)
-                self.logger.debug(f"list_connections subsystems: {subsys_ret}")
-            except Exception as ex:
-                errmsg = f"Failure listing connections for {subsystem}, can't get subsystem"
-                self.logger.exception(errmsg)
-                errmsg = f"{errmsg}:\n{ex}"
-                resp = self.parse_json_exeption(ex)
-                status = errno.EINVAL
-                if resp:
-                    status = resp["code"]
-                    errmsg = f"Failure listing connections for {subsystem}, " \
-                             f"can't get subsystem: {resp['message']}"
-                return pb2.connections_info(status=status, error_message=errmsg, connections=[])
+        # Always query SPDK directly (no cache) - CLI tool needs fresh data
+        subsys_ret = None
+        try:
+            subsys_ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client, nqn=subsystem)
+            self.logger.debug(f"list_connections subsystems (direct from SPDK): {subsys_ret}")
+        except Exception as ex:
+            errmsg = f"Failure listing connections for {subsystem}, can't get subsystem"
+            self.logger.exception(errmsg)
+            errmsg = f"{errmsg}:\n{ex}"
+            resp = self.parse_json_exeption(ex)
+            status = errno.EINVAL
+            if resp:
+                status = resp["code"]
+                errmsg = f"Failure listing connections for {subsystem}, " \
+                         f"can't get subsystem: {resp['message']}"
+            return pb2.connections_info(status=status, error_message=errmsg, connections=[])
 
         if not subsys_ret:
             subsys_ret = []
@@ -5224,46 +5240,15 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
         for conn in ctrl_ret:
             try:
-                traddr = ""
-                trsvcid = 0
-                adrfam = ""
-                trtype = "TCP"
-                hostnqn = conn["hostnqn"]
-                found = False
                 secure = False
                 psk = False
                 dhchap = False
 
-                for qp in qpair_ret:
-                    try:
-                        if qp["cntlid"] != conn["cntlid"]:
-                            continue
-                        if qp["state"] != "enabled":
-                            self.logger.debug(f"Qpair {qp} is not enabled")
-                            continue
-                        addr = qp["listen_address"]
-                        if not addr:
-                            continue
-                        traddr = addr["traddr"]
-                        if not traddr:
-                            continue
-                        trsvcid = int(addr["trsvcid"])
-                        try:
-                            trtype = addr["trtype"].upper()
-                        except Exception:
-                            pass
-                        try:
-                            adrfam = addr["adrfam"].lower()
-                        except Exception:
-                            pass
-                        found = True
-                        break
-                    except Exception:
-                        self.logger.exception(f"Got exception while parsing qpair: {qp}")
-                        pass
+                # Use shared utility to find qpair and extract address info
+                found, hostnqn, traddr, trsvcid, trtype, adrfam = \
+                    NvmeofConnectionUtils.find_qpair_for_controller(conn, qpair_ret, self.logger)
 
                 if not found:
-                    self.logger.debug(f"Can't find active qpair for connection {conn}")
                     continue
 
                 psk = self.host_info.is_psk_host(subsystem, hostnqn)
@@ -5275,11 +5260,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                         if lstnr in self.subsystem_listeners[subsystem]:
                             secure = True
                             break
-
-                if not trtype:
-                    trtype = "TCP"
-                if not adrfam:
-                    adrfam = "ipv4"
                 was_ka_timeout = \
                     self.host_info.was_host_disconnected_due_to_keepalive_timeout(
                         subsystem, hostnqn)
@@ -5452,8 +5432,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                  f"requested one \"{request.host_name}\". Listener will "
                                  f"be stashed to be used later by the right gateway.")
                 ret = True
-
-            self.subsystems_cache.set_subsystems(None)
 
             # Just in case SPDK failed with no exception
             if not ret:
@@ -5700,7 +5678,6 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                 lstnr = (adrfam, traddr, request.trsvcid, secur, active)
                                 if lstnr in self.subsystem_listeners[request.nqn]:
                                     self.subsystem_listeners[request.nqn].remove(lstnr)
-                    self.subsystems_cache.set_subsystems(None)
                 else:
                     errmsg = f"{delete_listener_error_prefix}: Gateway's host name must " \
                              f"match current host ({self.host_name}). You can continue to " \
@@ -5911,7 +5888,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
         return self.execute_grpc_function(self.show_gateway_listeners_info_safe, request, context)
 
     def list_subsystems_safe(self, request, context):
-        """List subsystems."""
+        """List subsystems.
+
+        Note: Always queries SPDK directly, bypassing cache.
+        This ensures CLI tools always get fresh data.
+        For performance-critical reads, use get_subsystems() instead.
+        """
 
         assert self.rpc_lock.locked(), "RPC is unlocked when calling list_subsystems_safe()"
         peer_msg = self.get_peer_message(context)
@@ -5932,31 +5914,26 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
         subsystems = []
         ret = None
-        if request.subsystem_nqn:
-            ret = self.subsystems_cache.get_one_subsystem(request.subsystem_nqn)
-        else:
-            ret = self.subsystems_cache.get_subsystems()
-        self.logger.debug(f"list_subsystems (cache): {ret}")
-        if not ret:
-            try:
-                if request.subsystem_nqn:
-                    ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client,
-                                                       nqn=request.subsystem_nqn)
-                else:
-                    ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client)
-                    if ret:
-                        self.subsystems_cache.set_subsystems(ret)
-                self.logger.debug(f"list_subsystems: {ret}")
-            except Exception as ex:
-                errmsg = "Failure listing subsystems"
-                self.logger.exception(errmsg)
-                errmsg = f"{errmsg}:\n{ex}"
-                resp = self.parse_json_exeption(ex)
-                status = errno.ENODEV
-                if resp:
-                    status = resp["code"]
-                    errmsg = f"Failure listing subsystems: {resp['message']}"
-                return pb2.subsystems_info_cli(status=status, error_message=errmsg, subsystems=[])
+
+        # Always query SPDK directly (no cache)
+        # CLI tools need fresh data, performance is not critical here
+        try:
+            if request.subsystem_nqn:
+                ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client,
+                                                   nqn=request.subsystem_nqn)
+            else:
+                ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_client)
+            self.logger.debug(f"list_subsystems (direct from SPDK): {ret}")
+        except Exception as ex:
+            errmsg = "Failure listing subsystems"
+            self.logger.exception(errmsg)
+            errmsg = f"{errmsg}:\n{ex}"
+            resp = self.parse_json_exeption(ex)
+            status = errno.ENODEV
+            if resp:
+                status = resp["code"]
+                errmsg = f"Failure listing subsystems: {resp['message']}"
+            return pb2.subsystems_info_cli(status=status, error_message=errmsg, subsystems=[])
 
         if not ret:
             ret = []
@@ -5989,55 +5966,21 @@ class GatewayService(pb2_grpc.GatewayServicer):
         return pb2.subsystems_info_cli(status=0, error_message=os.strerror(0),
                                        subsystems=subsystems)
 
-    def get_subsystems_safe(self, request, context):
-        """Gets subsystems."""
-
-        peer_msg = self.get_peer_message(context)
-        self.logger.debug(f"Received request to get subsystems, context: {context}{peer_msg}")
-        subsystems = []
-        ret = self.subsystems_cache.get_subsystems()
-        if not ret:
-            try:
-                ret = rpc_nvmf.nvmf_get_subsystems(self.spdk_rpc_subsystems_client)
-                if ret:
-                    self.subsystems_cache.set_subsystems(ret)
-            except Exception as ex:
-                self.logger.exception("get_subsystems failed")
-                if context:
-                    context.set_code(grpc.StatusCode.INTERNAL)
-                    context.set_details(f"{ex}")
-                return pb2.subsystems_info()
-
-        if not ret:
-            ret = []
-
-        for s in ret:
-            try:
-                s["has_dhchap_key"] = self.host_info.does_subsystem_have_dhchap_key(s["nqn"])
-                ns_key = "namespaces"
-                if ns_key in s:
-                    for n in s[ns_key]:
-                        bdev = n["bdev_name"]
-                        with self.shared_state_lock:
-                            nonce = self.cluster_nonce[self.bdev_cluster[bdev]]
-                        n["nonce"] = nonce
-                        find_ret = self.subsystem_nsid_bdev_and_uuid.find_namespace(s["nqn"],
-                                                                                    n["nsid"])
-                        n["auto_visible"] = find_ret.auto_visible
-                        n["hosts"] = find_ret.host_list
-                # Parse the JSON dictionary into the protobuf message
-                subsystem = pb2.subsystem()
-                json_format.Parse(json.dumps(s), subsystem, ignore_unknown_fields=True)
-                subsystems.append(subsystem)
-            except Exception:
-                self.logger.exception(f"{s=} parse error")
-                pass
-
-        return pb2.subsystems_info(subsystems=subsystems)
-
     def get_subsystems(self, request, context):
-        with self.spdk_rpc_subsystems_lock:
-            return self.get_subsystems_safe(request, context)
+        """Gets subsystems.
+
+        Returns subsystems_info object from cache.
+        Cache is refreshed by ping loop in the main thread
+        every 2s with complete protobuf object creation.
+
+        Threading: Only cache_lock is needed, which is held by the cache when returning the value.
+        No other locks are required since this is a pure cache read operation.
+        """
+        self.logger.debug(f"Received request to get subsystems, context: {context}")
+
+        subsystems_info = self.subsystems_cache.get()
+        self.logger.debug(f"Returning {len(subsystems_info.subsystems)} subsystems from cache")
+        return subsystems_info
 
     def list_subsystems(self, request, context=None):
         return self.execute_grpc_function(self.list_subsystems_safe, request, context)

--- a/control/prometheus.py
+++ b/control/prometheus.py
@@ -11,9 +11,9 @@ import os
 import time
 import threading
 import inspect
-import types
 import math
 import spdk.rpc as rpc
+import spdk.rpc.nvmf as rpc_nvmf
 
 from .proto import gateway_pb2 as pb2
 from prometheus_client.core import REGISTRY, GaugeMetricFamily
@@ -21,6 +21,7 @@ from prometheus_client.core import CounterMetricFamily, InfoMetricFamily
 from prometheus_client import start_http_server, GC_COLLECTOR
 from functools import wraps
 from .utils import NICS
+from .utils import NvmeofConnectionUtils
 
 COLLECTION_ELAPSED_WARNING = 0.8   # Percentage of the refresh interval before a warning is issued
 REGISTRY.unregister(GC_COLLECTOR)  # Turn off garbage collector metrics
@@ -59,39 +60,126 @@ def timer(method):
     return call
 
 
-def connection_cache_with_timer(ttl_seconds=60):
-    def decorator(method):
-        @wraps(method)
-        def call(self, *args, **kwargs):
-            st = time.time()
-            cache_age = st - self.connection_map_cache_time
+class ConnectionsCache:
+    """Cache for connection data (controllers and qpairs from SPDK).
 
-            # Check if cache is still valid
-            if self.connection_map_cache is not None and cache_age < ttl_seconds:
-                # Cache hit
-                result = self.connection_map_cache
-                logger.debug(
-                    f'Connection cache hit (age: {cache_age:.1f}s of{ttl_seconds}s TTL)')
-            else:
-                # Cache miss - do the expensive work
-                logger.debug(f'Connection cache miss (age: {cache_age:.1f}s), refreshing...')
+    Refreshed by Prometheus collector during each _get_data() call.
+    Stores full connection information for all subsystems.
+    """
 
-                result = method(*args, **kwargs)
+    def __init__(self, spdk_rpc_client, gateway_rpc):
+        self.cache_lock = threading.Lock()
+        self.connections_map = {}  # subsystem_nqn -> pb2.connections_info
+        self.spdk_rpc_client = spdk_rpc_client
+        self.gateway_rpc = gateway_rpc
 
-                # Update cache
-                self.connection_map_cache = result
-                self.connection_map_cache_time = st
+    def get(self):
+        """Get cached connections map. Returns dict of subsystem_nqn -> pb2.connections_info"""
+        with self.cache_lock:
+            return self.connections_map
 
-                logger.debug(f'Connection cache refreshed (valid for {ttl_seconds}s)')
+    def refresh(self, subsystem_list):
+        """Refresh cache by calling SPDK RPC for all subsystems.
 
-            # Record timing
-            elapsed = time.time() - st
-            if hasattr(self, 'method_timings'):
-                self.method_timings[method.__name__] = elapsed
+        Args:
+            subsystem_list: List of subsystem protobuf objects to refresh connections for
+        """
+        try:
+            new_connections_map = {}
+            for subsys in subsystem_list:
+                subsystem_nqn = subsys.nqn
+                connections_info = self._get_connections_for_subsystem(subsys)
+                if connections_info:
+                    new_connections_map[subsystem_nqn] = connections_info
 
-            return result
-        return call
-    return decorator
+            # Update cache atomically
+            with self.cache_lock:
+                self.connections_map = new_connections_map
+
+            logger.debug(f"ConnectionsCache refreshed for {len(new_connections_map)} subsystems")
+        except Exception:
+            logger.exception("Failed to refresh ConnectionsCache")
+
+    def _get_connections_for_subsystem(self, subsys_protobuf):
+        """Get connections for a single subsystem by calling SPDK directly.
+
+        Args:
+            subsys_protobuf: Protobuf subsystem object from cached subsystems_info
+
+        Returns pb2.connections_info or None on error.
+        """
+        try:
+            subsystem_nqn = subsys_protobuf.nqn
+
+            # Call SPDK directly for this subsystem
+            qpair_ret = rpc_nvmf.nvmf_subsystem_get_qpairs(
+                self.spdk_rpc_client, nqn=subsystem_nqn)
+            ctrl_ret = rpc_nvmf.nvmf_subsystem_get_controllers(
+                self.spdk_rpc_client, nqn=subsystem_nqn)
+
+            connections = []
+            host_nqns = []
+
+            # Build list of host NQNs from cached subsystem protobuf data
+            for h in subsys_protobuf.hosts:
+                try:
+                    host_nqns.append(h.nqn)
+                except Exception:
+                    pass
+
+            # Build connections from controllers and qpairs
+            for conn in ctrl_ret:
+                try:
+                    # Use shared utility to find qpair and extract address info
+                    found, hostnqn, traddr, trsvcid, trtype, adrfam = \
+                        NvmeofConnectionUtils.find_qpair_for_controller(conn, qpair_ret)
+
+                    if not found:
+                        continue
+
+                    # Check keepalive timeout status (like gateway does)
+                    was_ka_timeout = \
+                        self.gateway_rpc.host_info.was_host_disconnected_due_to_keepalive_timeout(
+                            subsystem_nqn, hostnqn)
+
+                    # Create connection object (simplified for Prometheus - no PSK/DHCHAP)
+                    one_conn = pb2.connection(
+                        nqn=hostnqn, connected=True,
+                        traddr=traddr, trsvcid=trsvcid,
+                        trtype=trtype, adrfam=adrfam,
+                        qpairs_count=conn["num_io_qpairs"],
+                        controller_id=conn["cntlid"],
+                        subsystem=subsystem_nqn,
+                        disconnected_due_to_keepalive_timeout=was_ka_timeout
+                    )
+                    connections.append(one_conn)
+                    if hostnqn in host_nqns:
+                        host_nqns.remove(hostnqn)
+                except Exception:
+                    pass
+
+            # Add disconnected hosts
+            for nqn in host_nqns:
+                # Check keepalive timeout status for disconnected hosts too
+                was_ka_timeout = \
+                    self.gateway_rpc.host_info.was_host_disconnected_due_to_keepalive_timeout(
+                        subsystem_nqn, nqn)
+                one_conn = pb2.connection(
+                    nqn=nqn, connected=False, traddr="<n/a>", trsvcid=0,
+                    qpairs_count=-1, controller_id=-1,
+                    subsystem=subsystem_nqn,
+                    disconnected_due_to_keepalive_timeout=was_ka_timeout
+                )
+                connections.append(one_conn)
+
+            return pb2.connections_info(
+                status=0, error_message=os.strerror(0),
+                subsystem_nqn=subsystem_nqn, connections=connections
+            )
+
+        except Exception:
+            logger.exception(f"Failed to get connections for {subsystem_nqn}")
+            return None
 
 
 def start_httpd(**kwargs):
@@ -167,16 +255,10 @@ class NVMeOFCollector:
         self.spdk_thread_stats = {}
         self.subsystems = []
         self.connections = {}
-        self.hosts = {}
         self.method_timings = {}
 
-        # Cache for connection map
-        self.connection_map_cache = None           # Store cached connection data
-        self.connection_map_cache_time = 0           # Last time the connection cache was refreshed
-        cache_ttl = self.gw_config.getint_with_default(
-            "gateway", "prometheus_connection_list_cache_expiration", 60)
-        decorated_method = connection_cache_with_timer(cache_ttl)(self._get_connection_map)
-        self._get_connection_map = types.MethodType(decorated_method, self)
+        # Connections cache - refreshed during each _get_data() call
+        self.connections_cache = ConnectionsCache(spdk_rpc_client, gateway_rpc)
 
         if self.bdev_pools:
             logger.info(f"Stats restricted to bdevs in the following pool(s): "
@@ -239,35 +321,13 @@ class NVMeOFCollector:
 
     @timer
     def _get_subsystems(self):
-        """Fetch aggregated subsystem information"""
-        subsystems_info = self.gateway_rpc.get_subsystems(pb2.get_subsystems_req(), None)
+        """Fetch aggregated subsystem information from cache"""
+        subsystems_info = self.gateway_rpc.subsystems_cache.get()
         return subsystems_info.subsystems
 
-    def _get_connection_map(self, subsystem_list):
-        """Fetch connection information for all defined subsystems"""
-        connection_map = {}
-        for subsys in subsystem_list:
-            resp = self.gateway_rpc.list_connections(pb2.list_connections_req(subsystem=subsys.nqn))
-            if resp.status != 0:
-                logger.error(f"Exporter failed to fetch connection info for "
-                             f"{subsys.nqn}: {resp.error_message}")
-                continue
-            connection_map[subsys.nqn] = resp
-        return connection_map
-
-    @timer
-    def _get_host_map(self, subsystem_list):
-        """Fetch host information for all defined subsystems"""
-        host_map = {}
-        for subsys in subsystem_list:
-            resp = self.gateway_rpc.list_hosts(pb2.list_hosts_req(subsystem=subsys.nqn,
-                                                                  clear_alerts=True))
-            if resp.status != 0:
-                logger.error(f"Exporter failed to fetch host info for "
-                             f"{subsys.nqn}: {resp.error_message}")
-                continue
-            host_map[subsys.nqn] = resp
-        return host_map
+    def _get_connection_map(self):
+        """Fetch connection information from ConnectionsCache (already populated)"""
+        return self.connections_cache.get()
 
     def _get_data(self):
         """Gather data from the SPDK"""
@@ -279,10 +339,11 @@ class NVMeOFCollector:
         logger.debug("Done with _get_spdk_thread_stats()")
         self.subsystems = self._get_subsystems()
         logger.debug("Done with _get_subsystems()")
-        self.connections = self._get_connection_map(self.subsystems)
+        # Refresh connections cache with fresh data from SPDK
+        self.connections_cache.refresh(self.subsystems)
+        logger.debug("Done with _refresh_connections_cache()")
+        self.connections = self._get_connection_map()
         logger.debug("Done with _get_connection_map()")
-        self.hosts = self._get_host_map(self.subsystems)
-        logger.debug("Done with _get_host_map()")
 
     def _log_timings(self):
         """Log timing for each method"""
@@ -292,7 +353,6 @@ class NVMeOFCollector:
         logger.debug(f"_get_spdk_thread_stats(): {t.get('_get_spdk_thread_stats', 0):.2f}s")
         logger.debug(f"_get_subsystems(): {t.get('_get_subsystems', 0):.2f}s")
         logger.debug(f"_get_connection_map(): {t.get('_get_connection_map', 0):.2f}s")
-        logger.debug(f"_get_host_map(): {t.get('_get_host_map', 0):.2f}s")
 
     @ttl
     def collect(self):
@@ -545,12 +605,7 @@ class NVMeOFCollector:
                     f"{conn.traddr}:{conn.trsvcid}" if conn.connected else "<n/a>"
                 ], 1 if conn.connected else 0)
 
-            try:
-                host_info = self.hosts[nqn]
-            except KeyError:
-                logger.debug(f"couldn't find {nqn} in host list, skipping")
-                continue
-            for host in host_info.hosts:
+            for host in subsys.hosts:
                 host_keep_alive_timeout.add_metric([
                     self.gw_metadata.name,
                     nqn,

--- a/control/server.py
+++ b/control/server.py
@@ -96,7 +96,6 @@ class GatewayServer:
         gateway_rpc: GatewayService implementation
         server: gRPC server instance to receive gateway client requests
         spdk_rpc_client: Client of SPDK RPC server
-        spdk_rpc_ping_client: Ping client of SPDK RPC server
         spdk_rpc_subsystems_client: subsystems client of SPDK RPC server
         spdk_rpc_prometheus_client: prometheus client of SPDK RPC server
         spdk_process: Subprocess running SPDK NVMEoF target application
@@ -674,13 +673,6 @@ class GatewayServer:
             # Notice that some SPDK calls can't be made after framework init
             self._init_framework()
 
-            self.spdk_rpc_ping_client = rpc_client.JSONRPCClient(
-                self.spdk_rpc_socket_path,
-                None,
-                timeout,
-                log_level=protocol_log_level,
-                conn_retries=conn_retries,
-            )
             self.spdk_rpc_subsystems_client = rpc_client.JSONRPCClient(
                 self.spdk_rpc_socket_path,
                 None,
@@ -977,13 +969,14 @@ class GatewayServer:
                 consecutive_ping_failures = 0
 
     def _ping(self):
-        """Confirms communication with SPDK process."""
-        try:
-            spdk.rpc.spdk_get_version(self.spdk_rpc_ping_client)
-            return True
-        except Exception:
-            self.logger.exception("spdk_get_version failed")
-            return False
+        """Confirms communication with SPDK process and refreshes subsystems cache.
+
+        This serves dual purpose:
+        1. Health check: Verify SPDK is responding
+        2. Cache refresh: Update subsystems cache with fresh data
+        """
+        # Delegate to cache - it handles RPC call and update internally
+        return self.gateway_rpc.subsystems_cache.refresh()
 
     def probe_huge_pages(self):
         """Probe kernel's huge pages confiuguration"""

--- a/control/utils.py
+++ b/control/utils.py
@@ -817,3 +817,71 @@ class DsaUtils:
                 # ENOENT is fine
                 if e.errno != errno.ENOENT:
                     self.logger.exception(f"Error removing DSA config file {conf_file}")
+
+
+class NvmeofConnectionUtils:
+    """Utilities for NVMe-oF connection processing."""
+
+    @staticmethod
+    def find_qpair_for_controller(controller, qpair_list, logger=None):
+        """Find matching qpair for a controller.
+
+        Matches qpair to controller by cntlid and returns transport address info.
+
+        Args:
+            controller: Controller dict from SPDK (must have "cntlid", "hostnqn")
+            qpair_list: List of qpair dicts from SPDK
+            logger: Optional logger for debug messages
+
+        Returns:
+            tuple: (found: bool, hostnqn: str, traddr: str, trsvcid: int,
+                   trtype: str, adrfam: str)
+            If not found, returns (False, hostnqn, "", 0, "", "")
+        """
+        found = False
+        hostnqn = controller.get("hostnqn", "")
+        traddr = ""
+        trsvcid = 0
+        adrfam = ""
+        trtype = "TCP"
+
+        for qp in qpair_list:
+            try:
+                if qp.get("cntlid") != controller.get("cntlid"):
+                    continue
+                if qp.get("state") != "enabled":
+                    if logger:
+                        logger.debug(f"Qpair {qp} is not enabled")
+                    continue
+                addr = qp.get("listen_address")
+                if not addr:
+                    continue
+                traddr = addr.get("traddr")
+                if not traddr:
+                    continue
+                trsvcid = int(addr.get("trsvcid", 0))
+                try:
+                    trtype = addr.get("trtype", "").upper()
+                except Exception:
+                    pass
+                try:
+                    adrfam = addr.get("adrfam", "").lower()
+                except Exception:
+                    pass
+                found = True
+                break
+            except Exception:
+                if logger:
+                    logger.exception(f"Got exception while parsing qpair: {qp}")
+                pass
+
+        if not found and logger:
+            logger.debug(f"Can't find active qpair for connection {controller}")
+
+        # Apply defaults if not set
+        if not trtype:
+            trtype = "TCP"
+        if not adrfam:
+            adrfam = "ipv4"
+
+        return found, hostnqn, traddr, trsvcid, trtype, adrfam

--- a/tests/ha/no_subsystems.sh
+++ b/tests/ha/no_subsystems.sh
@@ -15,7 +15,7 @@ NQN="nqn.2016-06.io.spdk:cnode1"
  verify_gw_exists_and_no_subs()
  {
      IP=$1
-     subs=$(docker compose run -T --rm nvmeof-cli --server-address $IP --server-port 5500 --output stdio --format json get_subsystems)
+     subs=$(docker compose run -T --rm nvmeof-cli --server-address $IP --server-port 5500 --output stdio --format json subsystem list)
      echo "show subsystems after del : $subs"
      if echo "$subs" | grep -q '"subsystems": \[\]'; then
        echo "The string contains 'subsystems:[]' on GW  ip $IP"
@@ -31,7 +31,7 @@ NQN="nqn.2016-06.io.spdk:cnode1"
   for i in $(seq 2); do
 
      docker compose run -T --rm nvmeof-cli --server-address $ip --server-port 5500 subsystem del -n $NQN --force
-     sleep 2
+     sleep 2 # brief wait for OMAP sync across gateways
      verify_gw_exists_and_no_subs  $ip
      verify_gw_exists_and_no_subs  $ip2
 

--- a/tests/test_cli_change_lb.py
+++ b/tests/test_cli_change_lb.py
@@ -90,15 +90,21 @@ def verify_namespaces(caplog, gw_port, subsys, first_nsid, last_nsid, grp):
         verify_one_namespace_lb_group(caplog, gw_port, subsys, str(ns), grp)
 
 
-def verify_namespaces_using_get_subsystems(caplog, gw_port, subsys, first_nsid, last_nsid, grp):
+def verify_namespaces_using_list(caplog, gw_port, subsys, first_nsid, last_nsid, grp):
+    """Verify namespaces using direct SPDK query (via namespace list).
+
+    Queries SPDK directly via 'namespace list' to get real-time data,
+    bypassing the get_subsystems cache.
+    """
     caplog.clear()
-    subsys_info = cli_test(["--server-port", gw_port, "get_subsystems"])
-    assert len(subsys_info.subsystems) == 1
-    assert subsys_info.subsystems[0].nqn == subsys
-    assert len(subsys_info.subsystems[0].namespaces) >= last_nsid
+    # Use namespace list which queries SPDK directly (no cache)
+    ns_info = cli_test(["--server-port", gw_port, "namespace", "list", "--subsystem", subsys])
+    assert ns_info.status == 0
+    assert ns_info.subsystem_nqn == subsys
+    assert len(ns_info.namespaces) >= last_nsid
     for ns in range(first_nsid, last_nsid + 1):
-        assert subsys_info.subsystems[0].namespaces[ns - 1].nsid == ns
-        assert subsys_info.subsystems[0].namespaces[ns - 1].anagrpid == grp
+        assert ns_info.namespaces[ns - 1].nsid == ns
+        assert ns_info.namespaces[ns - 1].configured_load_balancing_group == grp
 
 
 def verify_namespaces_using_spdk_get_subsystems(caplog, gw, subsys, first_nsid, last_nsid, grp):
@@ -331,14 +337,14 @@ def test_change_namespace_lb_group(caplog, two_gateways):
     verify_namespaces(caplog, "5502", subsystem, 1 + (namespace_count // 2),
                       namespace_count, anagrpid2)
 
-    verify_namespaces_using_get_subsystems(caplog, "5500", subsystem, 1, namespace_count // 2,
-                                           int(anagrpid))
-    verify_namespaces_using_get_subsystems(caplog, "5500", subsystem, 1 + (namespace_count // 2),
-                                           namespace_count, int(anagrpid2))
-    verify_namespaces_using_get_subsystems(caplog, "5502", subsystem, 1, namespace_count // 2,
-                                           int(anagrpid))
-    verify_namespaces_using_get_subsystems(caplog, "5502", subsystem, 1 + (namespace_count // 2),
-                                           namespace_count, int(anagrpid2))
+    verify_namespaces_using_list(caplog, "5500", subsystem, 1, namespace_count // 2,
+                                 int(anagrpid))
+    verify_namespaces_using_list(caplog, "5500", subsystem, 1 + (namespace_count // 2),
+                                 namespace_count, int(anagrpid2))
+    verify_namespaces_using_list(caplog, "5502", subsystem, 1, namespace_count // 2,
+                                 int(anagrpid))
+    verify_namespaces_using_list(caplog, "5502", subsystem, 1 + (namespace_count // 2),
+                                 namespace_count, int(anagrpid2))
 
     verify_namespaces_using_spdk_get_subsystems(caplog, gatewayA, subsystem, 1,
                                                 namespace_count // 2, int(anagrpid))
@@ -360,14 +366,14 @@ def test_change_namespace_lb_group(caplog, two_gateways):
     verify_namespaces(caplog, "5502", subsystem, 1 + (namespace_count // 2),
                       namespace_count, anagrpid)
 
-    verify_namespaces_using_get_subsystems(caplog, "5500", subsystem, 1, namespace_count // 2,
-                                           int(anagrpid2))
-    verify_namespaces_using_get_subsystems(caplog, "5500", subsystem, 1 + (namespace_count // 2),
-                                           namespace_count, int(anagrpid))
-    verify_namespaces_using_get_subsystems(caplog, "5502", subsystem, 1, namespace_count // 2,
-                                           int(anagrpid2))
-    verify_namespaces_using_get_subsystems(caplog, "5502", subsystem, 1 + (namespace_count // 2),
-                                           namespace_count, int(anagrpid))
+    verify_namespaces_using_list(caplog, "5500", subsystem, 1, namespace_count // 2,
+                                 int(anagrpid2))
+    verify_namespaces_using_list(caplog, "5500", subsystem, 1 + (namespace_count // 2),
+                                 namespace_count, int(anagrpid))
+    verify_namespaces_using_list(caplog, "5502", subsystem, 1, namespace_count // 2,
+                                 int(anagrpid2))
+    verify_namespaces_using_list(caplog, "5502", subsystem, 1 + (namespace_count // 2),
+                                 namespace_count, int(anagrpid))
 
     verify_namespaces_using_spdk_get_subsystems(caplog, gatewayA, subsystem, 1,
                                                 namespace_count // 2, int(anagrpid2))


### PR DESCRIPTION
# nvmeof: optimize get_subsystems for predictable low latency

Refactor get_subsystems gRPC call to achieve consistent low latency by eliminating cache misses and reducing per-call overhead.

Changes:
- Combine SPDK ping with subsystems cache refresh in main thread
- Remove all cache invalidation logic
- Separate list_* methods from get_subsystems caching
- Simplify SubsystemsCache interface

The cache is now updated exclusively by the ping loop in the main thread, ensuring predictable performance for monitoring and API clients while CLI tools get fresh data on every invocation.