### PR TITLE
Fix CEPHADM_STRAY_DAEMON health warning

### DIFF
--- a/control/server.py
+++ b/control/server.py
@@ -351,8 +351,6 @@ class GatewayServer:
             "daemon_type": "gateway",          # "nvmeof: 3 <daemon_type> active (3 hosts)"
             "group": self.config.get_with_default("gateway", "group", ""),
         }
-        metadata["id"] = metadata["id"].removeprefix(
-            f"{metadata['pool_name']}.{metadata['group']}.")
         self.ceph_utils.service_daemon_register(conn, metadata)
 
     def _monitor_client_version(self) -> str:


### PR DESCRIPTION
Currently, sometimes this warnings comes up
when service_map's id is not same as cephadm's
daemon_id:
```
[root@cephnvme-vm14 ~]# ceph health detail
HEALTH_WARN 4 stray daemon(s) not managed by cephadm
[WRN] CEPHADM_STRAY_DAEMON: 4 stray daemon(s) not managed by cephadm
    stray daemon nvmeof.cephnvme-vm11.mjgszk on host cephnvme-vm11 not managed by cephadm
    stray daemon nvmeof.cephnvme-vm12.iofwcf on host cephnvme-vm12 not managed by cephadm
    stray daemon nvmeof.cephnvme-vm13.jfatyv on host cephnvme-vm13 not managed by cephadm
    stray daemon nvmeof.cephnvme-vm14.tagurc on host cephnvme-vm14 not managed by cephadm
```
This commit fixes that.