### PR TITLE
Prevent adding host with DHCHAP keys if the subsystem is open, and vice versa

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -4375,7 +4375,15 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 errmsg = f"{all_host_failure_prefix}: Can't allow any host access " \
                          f"on a subsystem having a DH-HMAC-CHAP key"
                 self.logger.error(errmsg)
-                return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+                return pb2.req_status(errno.EACCES, error_message=errmsg)
+            dhchap_host_list = self.host_info.get_hosts_with_dhchap_key(request.subsystem_nqn)
+            if dhchap_host_list:
+                errmsg = f"{all_host_failure_prefix}: Can't allow any host access " \
+                         f"on a subsystem having a host with a DH-HMAC-CHAP key. " \
+                         f"All such hosts need to be removed from the subsystem first " \
+                         f"or their DH-HMAC-CHAP key should be cleared"
+                self.logger.error(errmsg)
+                return pb2.req_status(status=errno.EACCES, error_message=errmsg)
 
         if request.host_nqn != "*" and self.host_info.is_any_host_allowed(request.subsystem_nqn):
             self.logger.warning(f"A specific host {request.host_nqn} was added to subsystem "
@@ -4411,11 +4419,18 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
-        if request.dhchap_key and request.host_nqn == "*":
-            errmsg = f"{all_host_failure_prefix}: DH-HMAC-CHAP key is " \
-                     f"only allowed for specific hosts"
-            self.logger.error(errmsg)
-            return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+        if request.dhchap_key:
+            if request.host_nqn == "*":
+                errmsg = f"{all_host_failure_prefix}: DH-HMAC-CHAP key is " \
+                         f"only allowed for specific hosts"
+                self.logger.error(errmsg)
+                return pb2.req_status(status=errno.EACCES, error_message=errmsg)
+            elif self.host_info.is_any_host_allowed(request.subsystem_nqn):
+                errmsg = f"{host_failure_prefix}: DH-HMAC-CHAP key is " \
+                         f"not allowed for hosts on subsystems which are open for all hosts. " \
+                         f"You need to remove the open access in order to add the host"
+                self.logger.error(errmsg)
+                return pb2.req_status(status=errno.EACCES, error_message=errmsg)
 
         if self.force_tls and request.host_nqn != "*" and not request.psk:
             errmsg = f"{host_failure_prefix}: host must have a PSK key"
@@ -4865,6 +4880,13 @@ class GatewayService(pb2_grpc.GatewayServicer):
             errmsg = f"{failure_prefix}: Host must have a DH-HMAC-CHAP key if the subsystem has one"
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.ENOKEY, error_message=errmsg)
+
+        if request.dhchap_key and self.host_info.is_any_host_allowed(request.subsystem_nqn):
+            errmsg = f"{failure_prefix}: DH-HMAC-CHAP key is " \
+                     f"not allowed for hosts on subsystems which are open for all hosts. " \
+                     f"You need to remove the open access in order to set a key for the host"
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.EACCES, error_message=errmsg)
 
         host_already_exist = self.matching_host_exists(context, request.subsystem_nqn,
                                                        request.host_nqn)
@@ -6033,6 +6055,13 @@ class GatewayService(pb2_grpc.GatewayServicer):
             errmsg = f"{failure_prefix}: Can't change DH-HMAC-CHAP key for a discovery subsystem"
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+
+        if request.dhchap_key and self.host_info.is_any_host_allowed(request.subsystem_nqn):
+            errmsg = f"{failure_prefix}: DH-HMAC-CHAP key is " \
+                     f"not allowed for subsystems which are open for all hosts. " \
+                     f"You need to remove the open access in order to set a key for the subsystem"
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.EACCES, error_message=errmsg)
 
         omap_lock = self.omap_lock.get_omap_lock_to_use(context)
         with omap_lock:

--- a/tests/test_dhchap.py
+++ b/tests/test_dhchap.py
@@ -17,6 +17,7 @@ subsystem5 = "nqn.2016-06.io.spdk:cnode5"
 subsystem6 = "nqn.2016-06.io.spdk:cnode6"
 subsystem7 = "nqn.2016-06.io.spdk:cnode7"
 subsystem8 = "nqn.2016-06.io.spdk:cnode8"
+subsystem9 = "nqn.2016-06.io.spdk:cnode9"
 hostnqn1 = "nqn.2014-08.org.nvmexpress:uuid:22207d09-d8af-4ed2-84ec-a6d80b0cf7eb"
 hostnqn2 = "nqn.2014-08.org.nvmexpress:uuid:22207d09-d8af-4ed2-84ec-a6d80b0cf7ec"
 hostnqn4 = "nqn.2014-08.org.nvmexpress:uuid:6488a49c-dfa3-11d4-ac31-b232c6c68a8a"
@@ -34,6 +35,8 @@ hostnqn15 = "nqn.2014-08.org.nvmexpress:uuid:22207d09-d8af-4ed2-84ec-a6d80b0cf7f
 hostnqn16 = "nqn.2014-08.org.nvmexpress:uuid:22207d09-d8af-4ed2-84ec-a6d80b0cf7fa"
 hostnqn17 = "nqn.2014-08.org.nvmexpress:uuid:22207d09-d8af-4ed2-84ec-a6d80b0cf7fb"
 hostnqn18 = "nqn.2014-08.org.nvmexpress:uuid:22207d09-d8af-4ed2-84ec-a6d80b0cf7fc"
+hostnqn19 = "nqn.2014-08.org.nvmexpress:uuid:22207d09-d8af-4ed2-84ec-a6d80b0cf7fd"
+hostnqn20 = "nqn.2014-08.org.nvmexpress:uuid:22207d09-d8af-4ed2-84ec-a6d80b0cf7fe"
 
 discovery_nqn = "nqn.2014-08.org.nvmexpress.discovery"
 
@@ -49,6 +52,8 @@ hostdhchap8 = "DHHC-1:01:eNNXGjidEHHStbUi2Gmpps0JcnofReFfy+NaulguGgt327hz:"
 hostdhchap9 = "DHHC-1:01:KD+sfH3/o2bRQoV0ESjBUywQlMnSaYpZISUbVa0k0nsWpNST:"
 hostdhchap10 = "DHHC-1:00:rWf0ZFYO7IgWGttM8w6jUrAY4cTQyqyXPdmxHeOSve3w5QU9:"
 hostdhchap11 = "DHHC-1:02:j3uUz05r5aQy42vX4tDXqVf9HgUPPdEp3kXTgUWl9EphsG7jwpr9KSIt3bmRLXBijPTIDQ==:"
+hostdhchap12 = "DHHC-1:00:H27KJjCURbgMdd8GvwtlwuOJPvb47lYaQ25FbAHU93QetO/G:"
+hostdhchap13 = "DHHC-1:00:yHe1wb+oNGR/PB8WQJYBTok32yKwKWpphbGaXLa8WjOW1bYE:"
 
 badhostdhchap1 = "xDHHC-1:01:eNNXGjidEHHStbUi2Gmpps0JcnofReFfy+NaulguGgt327hz:"
 badhostdhchap2 = "DHHC-1:01eNNXGjidEHHStbUi2Gmpps0JcnofReFfy+NaulguGgt327hz:"
@@ -397,6 +402,34 @@ def test_add_host_bad_keys(caplog, gateway):
          "--dhchap-key", badhostdhchap13])
     assert f'Failure adding host {hostnqn15} to {subsystem}: Invalid DH-HMAC-CHAP key ' \
            f'"{badhostdhchap13}": CRC-32 checksums mismatch' in caplog.text
+
+
+def test_add_host_with_key_to_open_subsystem(caplog, gateway):
+    cli(["subsystem", "add", "--subsystem", subsystem9, "--no-group-append"])
+    assert f"Adding subsystem {subsystem9}: Successful" in caplog.text
+    cli(["host", "add", "--subsystem", subsystem9, "--host-nqn", "*"])
+    assert f"Allowing open host access to {subsystem9}: Successful" in caplog.text
+    cli(["host", "add", "--subsystem", subsystem9, "--host-nqn", hostnqn19,
+         "--dhchap-key", hostdhchap12])
+    assert f'Failure adding host {hostnqn19} to {subsystem9}: DH-HMAC-CHAP key ' \
+           f'is not allowed for hosts on subsystems which are open for all hosts.' in caplog.text
+    cli(["host", "add", "--subsystem", subsystem9, "--host-nqn", hostnqn19])
+    assert f"Adding host {hostnqn19} to {subsystem9}: Successful" in caplog.text
+    cli(["host", "change_key", "--subsystem", subsystem9, "--host-nqn", hostnqn19,
+         "--dhchap-key", hostdhchap12])
+    assert f"Failure changing DH-HMAC-CHAP key for host {hostnqn19} on " \
+           f"subsystem {subsystem9}: DH-HMAC-CHAP key is not allowed for hosts on subsystems " \
+           f"which are open for all hosts." in caplog.text
+    cli(["host", "del", "--subsystem", subsystem9, "--host-nqn", "*"])
+    assert f"Disabling open host access to {subsystem9}: Successful" in caplog.text
+    cli(["host", "change_key", "--subsystem", subsystem9, "--host-nqn", hostnqn19,
+         "--dhchap-key", hostdhchap12])
+    assert f"Changing key for host {hostnqn19} on subsystem {subsystem9}: Successful" in caplog.text
+    cli(["host", "add", "--subsystem", subsystem9, "--host-nqn", hostnqn20,
+         "--dhchap-key", hostdhchap13])
+    assert f"Adding host {hostnqn20} to {subsystem9}: Successful" in caplog.text
+    cli(["subsystem", "del", "--subsystem", subsystem9])
+    assert f"Deleting subsystem {subsystem9}: Successful" in caplog.text
 
 
 def test_dhchap_subsystem_key(caplog, gateway):


### PR DESCRIPTION

Fixes: #1608