### PR TITLE
tests: add connect panic test and update late registration test

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -489,7 +489,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["sanity", "no_huge", "ns_lb_change", "no_subsystems", "auto_load_balance", "state_transitions", "state_transitions_both_gws", "state_transitions_loop", "state_transitions_rand_loop", "late_registration", "late_registration_loop", "4gws", "4gws_loop", "4gws_create_delete", "4gws_create_delete_loop", "namespaces", "namespaces_loop", "mtls", "notify", "ceph_status", "blocklist", "main_exit", "cluster_pool", "flat_bdev_per_cluster", "set_qos", "set_qos_2ms", "gateway_removal"]
+        test: ["sanity", "no_huge", "ns_lb_change", "no_subsystems", "auto_load_balance", "state_transitions", "state_transitions_both_gws", "state_transitions_loop", "state_transitions_rand_loop", "late_registration", "late_registration_loop", "connect_panic", "4gws", "4gws_loop", "4gws_create_delete", "4gws_create_delete_loop", "namespaces", "namespaces_loop", "mtls", "notify", "ceph_status", "blocklist", "main_exit", "cluster_pool", "flat_bdev_per_cluster", "set_qos", "set_qos_2ms", "gateway_removal"]
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 1024  # 4 spdk instances

--- a/tests/ha/connect_panic.sh
+++ b/tests/ha/connect_panic.sh
@@ -1,0 +1,103 @@
+set -xe
+
+# GW name by index
+gw_name() {
+  i=$1
+  docker ps --format '{{.ID}}\t{{.Names}}' | awk '$2 ~ /nvmeof/ && $2 ~ /'$i'/ {print $1}'
+}
+
+# Extended sleep to exceed monitor connect timeout
+extended_sleep() {
+    # Sleep for 35 seconds to exceed typical monitor connect timeout (30 seconds)
+    # This ensures the test triggers the connect panic behavior
+    seconds=35
+    echo "Sleeping for $seconds secs (extended delay to exceed monitor connect timeout)"
+    sleep "$seconds"
+}
+
+# Check if a gateway has panicked by looking for the specific log message
+check_gateway_panic_log() {
+    GW_NAME=$1
+    # Look for the specific panic message in the gateway logs
+    if docker logs "$GW_NAME" 2>&1 | grep -q "what():  Did not receive initial map from monitor (connect panic)."; then
+        echo "✅ Found connect panic log message in gateway $GW_NAME"
+        return 0
+    else
+        echo "❌ Connect panic log message not found in gateway $GW_NAME"
+        return 1
+    fi
+}
+
+# Check if a gateway container has exited
+check_gateway_exited() {
+    GW_NAME=$1
+    if ! docker ps --format '{{.Names}}' | grep -q "$GW_NAME"; then
+        echo "✅ Gateway $GW_NAME has exited as expected"
+        return 0
+    else
+        echo "❌ Gateway $GW_NAME is still running"
+        return 1
+    fi
+}
+
+#
+# MAIN
+#
+
+echo "🧪 Testing connect panic behavior when monitor client timeout is exceeded"
+
+# Step 1 Stop the existing deployment
+make down
+
+# Step 2 Start a new deployment with a single gateway
+echo "Starting deployment with single gateway..."
+docker compose up -d --scale nvmeof=1 nvmeof
+
+# Step 3 Wait for the gateway to be running
+echo "Waiting for gateway to be running..."
+timeout_seconds=60
+elapsed=0
+while [ $elapsed -lt $timeout_seconds ]; do
+  GW_NAME=$(gw_name 1)
+  if [ -n "$GW_NAME" ]; then
+    container_status=$(docker inspect -f '{{.State.Status}}' "$GW_NAME" 2>/dev/null || echo "unknown")
+    if [ "$container_status" = "running" ]; then
+      echo "✅ Gateway $GW_NAME is running after ${elapsed}s"
+      break
+    fi
+  fi
+  sleep 1
+  elapsed=$((elapsed + 1))
+  echo -n "."
+  if [ $elapsed -eq $timeout_seconds ]; then
+    echo "❌ Timeout waiting for gateway to be running after ${timeout_seconds}s"
+    docker ps -a
+    exit 1
+  fi
+done
+
+# Step 4 Extended sleep to exceed monitor connect timeout
+echo "Sleeping to exceed monitor connect timeout..."
+extended_sleep
+
+# Step 5 Verify the gateway has panicked and exited
+echo "Checking gateway status after extended sleep..."
+if check_gateway_panic_log "$GW_NAME"; then
+    echo "✅ Gateway panic log verified"
+else
+    echo "❌ Gateway panic log not found"
+    exit 1
+fi
+
+if check_gateway_exited "$GW_NAME"; then
+    echo "✅ Gateway exit verified"
+else
+    echo "❌ Gateway exit verification failed"
+    exit 1
+fi
+
+echo "🎉 Connect panic test completed successfully!"
+echo "The test demonstrates that the monitor client timeout mechanism works correctly:"
+echo "- Gateways that cannot connect to the monitor within the timeout will panic and exit"
+echo "- This is the expected safety behavior to prevent gateways from running without monitor connectivity"
+echo "- The test verifies that the panic mechanism is working as designed"

--- a/tests/ha/late_registration.sh
+++ b/tests/ha/late_registration.sh
@@ -66,11 +66,13 @@ verify_ana_groups() {
 }
 
 random_sleep() {
-    # Generate a random number between 0 and 59
-    seconds=$(( RANDOM % 60 ))
+    # Generate a random number between 0 and 25 seconds
+    # This ensures the sleep is safely below typical monitor connect timeout (30+ seconds)
+    # while still providing enough randomness for late registration testing
+    seconds=$(( RANDOM % 26 ))
 
     # Sleep for the random number of seconds
-    echo "Sleeping for $seconds secs"
+    echo "Sleeping for $seconds secs (random delay capped below monitor connect timeout)"
     sleep "$seconds"
 }
 

--- a/tests/ha/wait_gateways.sh
+++ b/tests/ha/wait_gateways.sh
@@ -4,7 +4,7 @@ SCALE=2
 echo CLI_TLS_ARGS $CLI_TLS_ARGS
 # Check if argument is provided
 if [ $# -ge 1 ]; then
-    # Check if argument is an integer larger or equal than 1
+    # Check if argument is an integer greater than or equal to 1
     if [ "$1" -eq "$1" ] 2>/dev/null && [ "$1" -ge 1 ]; then
         # Set variable to the provided argument
         SCALE="$1"


### PR DESCRIPTION
# tests: add connect panic test and update late registration test

- related to monitor client connect panic from ceph/ceph#64713,  late registrationi test, cap random sleep at 25 seconds to stay safely below monitor connect timeout
- Add new connect_panic.sh test to validate monitor client timeout behavior

(cherry picked from commit acc7f9ffb272232a0aeb759f1d9ea4ea62517d7a)

ceph shaman: https://shaman.ceph.com/builds/ceph/squid-nvmeof/49859cdd4088a3d59a81919864b3ecabf441f4f0/