### PR TITLE
Dockerfile.spdk: pass SPDK_GIT_COMMIT to RPM build

### DIFF
--- a/Dockerfile.spdk
+++ b/Dockerfile.spdk
@@ -21,6 +21,7 @@ ARG SPDK_CEPH_VERSION \
     SPDK_CONFIGURE_ARGS \
     SPDK_TARGET_ARCH \
     SPDK_MAKEFLAGS \
+    SPDK_GIT_COMMIT \
     ACCEL_CONFIG_SRC
 
 RUN <<EOF
@@ -31,6 +32,7 @@ RUN <<EOF
     echo SPDK_TARGET_ARCH=$SPDK_TARGET_ARCH
     echo SPDK_MAKEFLAGS=$SPDK_MAKEFLAGS
     echo CEPH_CLUSTER_CEPH_REPO_BASEURL=$CEPH_CLUSTER_CEPH_REPO_BASEURL
+    echo SPDK_GIT_COMMIT=$SPDK_GIT_COMMIT
     echo ACCEL_CONFIG_SRC=$ACCEL_CONFIG_SRC
     echo ======================================================================
 EOF
@@ -113,6 +115,7 @@ RUN \
     SPDK_VERSION=${SPDK_VERSION:?} \
     RPM_RELEASE=0 \
     MAKEFLAGS=$SPDK_MAKEFLAGS \
+    SPDK_GIT_COMMIT=$SPDK_GIT_COMMIT \
     rpmbuild/rpm.sh $SPDK_CONFIGURE_ARGS --target-arch="${SPDK_TARGET_ARCH:?}"
 
 # build bdevperf example, will not be a part of generated rpm


### PR DESCRIPTION
# Dockerfile.spdk: pass SPDK_GIT_COMMIT to RPM build

Issue: #1660

Pass SPDK git commit hash via build argument. In ceph-nvmeof context SPDK is used as a git submodule and the .git directory is not available in the container build context, automatic detection via `git rev-parse` fails. The commit hash is now provided by the parent Makefile as the SPDK_GIT_COMMIT build argument to Dockerfile.spdk.

SPDK git commit calculation and build flow:

1. Makefile calculates: `git rev-parse HEAD:spdk` (submodule commit from parent repo)
2. Exported as SPDK_GIT_COMMIT environment variable
3. Passed via docker-compose.yaml as build arg to Dockerfile.spdk
4. Dockerfile.spdk accepts as ARG and passes to RPM build: `SPDK_GIT_COMMIT=$SPDK_GIT_COMMIT rpmbuild/rpm.sh`
5. SPDK's mk/spdk.common.mk uses it to set: `COMMON_CFLAGS += -DSPDK_GIT_COMMIT=$(SPDK_GIT_COMMIT)`
6. Compiled into SPDK binaries and exposed in version info