### PR TITLE
Add subsystem add_network/del_network cmds

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -1018,6 +1018,7 @@ class GatewayClient:
                     ctrls_id = f"{s.min_cntlid}-{s.max_cntlid}"
                     has_dhchap = "Yes" if s.has_dhchap_key else "No"
                     allow_any = "Yes" if s.allow_any_host else "No"
+                    net_mask = '\n'.join(s.network_mask) if s.network_mask else ""
                     one_subsys = [s.subtype,
                                   s.nqn,
                                   s.serial_number,
@@ -1025,7 +1026,8 @@ class GatewayClient:
                                   s.namespace_count,
                                   s.max_namespaces,
                                   allow_any,
-                                  has_dhchap]
+                                  has_dhchap,
+                                  net_mask]
                     if created_without_key:
                         one_subsys.append("Yes" if s.created_without_key else "No")
                     subsys_list.append(one_subsys)
@@ -1036,7 +1038,7 @@ class GatewayClient:
                         table_format = "plain"
                     headers_list = ["Subtype", "NQN", "Serial\nNumber", "Controller IDs",
                                     "Namespace\nCount", "Max\nNamespaces", "Allow\nAny Host",
-                                    "DHCHAP\nKey"]
+                                    "DHCHAP\nKey", "Network\nMask"]
                     if created_without_key:
                         headers_list.append("Created\nWithout Key")
                     subsys_out = tabulate(subsys_list,
@@ -1118,6 +1120,76 @@ class GatewayClient:
 
         return ret.status
 
+    def subsystem_add_network_mask(self, args):
+        """Add subsystem's network mask"""
+
+        out_func, err_func, _ = self.get_output_functions(args)
+
+        req = pb2.add_subsystem_network_req(subsystem_nqn=args.subsystem,
+                                            network_mask=args.network_mask)
+        try:
+            ret = self.stub.add_subsystem_network(req)
+        except Exception as ex:
+            errmsg = f"Failure in adding network for subsystem {args.subsystem}"
+            ret = pb2.req_status(status=errno.EINVAL, error_message=f"{errmsg}:\n{ex}")
+
+        if args.format == "text" or args.format == "plain":
+            if ret.status == 0:
+                out_func(f"Network mask {args.network_mask} added to subsystem "
+                         f"{args.subsystem}: Successful")
+            else:
+                err_func(f"{ret.error_message}")
+        elif args.format == "json" or args.format == "yaml":
+            ret_str = json_format.MessageToJson(ret, indent=4,
+                                                including_default_value_fields=True,
+                                                preserving_proto_field_name=True)
+            if args.format == "json":
+                out_func(ret_str)
+            elif args.format == "yaml":
+                obj = json.loads(ret_str)
+                out_func(yaml.dump(obj))
+        elif args.format == "python":
+            return ret
+        else:
+            assert False
+
+        return ret.status
+
+    def subsystem_del_network_mask(self, args):
+        """Delete subsystem's network mask"""
+
+        out_func, err_func, _ = self.get_output_functions(args)
+
+        req = pb2.del_subsystem_network_req(subsystem_nqn=args.subsystem,
+                                            network_mask=args.network_mask)
+        try:
+            ret = self.stub.del_subsystem_network(req)
+        except Exception as ex:
+            err = f"Failure in deleting network {args.network_mask} for subsystem {args.subsystem}"
+            ret = pb2.req_status(status=errno.EINVAL, error_message=f"{err}:\n{ex}")
+
+        if args.format == "text" or args.format == "plain":
+            if ret.status == 0:
+                out_func(f"Network mask {args.network_mask} deleted for subsystem "
+                         f"{args.subsystem}: Successful")
+            else:
+                err_func(f"{ret.error_message}")
+        elif args.format == "json" or args.format == "yaml":
+            ret_str = json_format.MessageToJson(ret, indent=4,
+                                                including_default_value_fields=True,
+                                                preserving_proto_field_name=True)
+            if args.format == "json":
+                out_func(ret_str)
+            elif args.format == "yaml":
+                obj = json.loads(ret_str)
+                out_func(yaml.dump(obj))
+        elif args.format == "python":
+            return ret
+        else:
+            assert False
+
+        return ret.status
+
     subsys_add_args = [
         argument("--subsystem",
                  "-n",
@@ -1142,6 +1214,7 @@ class GatewayClient:
                  required=False),
         argument("--network-mask",
                  help="For this subnet, automatically create listeners for this subsystem",
+                 nargs='+',
                  required=False),
         argument("--secure-listeners",
                  help="Make all the auto-listeners for this subsystem secure",
@@ -1188,6 +1261,24 @@ class GatewayClient:
                  help="Subsystem NQN",
                  required=True),
     ]
+    subsys_del_network_args = [
+        argument("--subsystem",
+                 "-n",
+                 help="Subsystem NQN",
+                 required=True),
+        argument("--network-mask",
+                 help="Existing network mask to delete",
+                 required=True),
+    ]
+    subsys_add_network_args = [
+        argument("--subsystem",
+                 "-n",
+                 help="Subsystem NQN",
+                 required=True),
+        argument("--network-mask",
+                 help="New network mask to add",
+                 required=True),
+    ]
     subsystem_actions = []
     subsystem_actions.append({"name": "add",
                               "args": subsys_add_args,
@@ -1204,6 +1295,12 @@ class GatewayClient:
     subsystem_actions.append({"name": "del_key",
                               "args": subsys_del_key_args,
                               "help": "Delete subsystem inband authentication key"})
+    subsystem_actions.append({"name": "add_network",
+                              "args": subsys_add_network_args,
+                              "help": "Add a network mask in the subsystem"})
+    subsystem_actions.append({"name": "del_network",
+                              "args": subsys_del_network_args,
+                              "help": "Delete a network mask in the subsystem"})
     subsystem_choices = get_actions(subsystem_actions)
 
     @cli.cmd(subsystem_actions)
@@ -1219,6 +1316,10 @@ class GatewayClient:
             return self.subsystem_change_key(args)
         elif args.action == "del_key":
             return self.subsystem_del_key(args)
+        elif args.action == "add_network":
+            return self.subsystem_add_network_mask(args)
+        elif args.action == "del_network":
+            return self.subsystem_del_network_mask(args)
         if not args.action:
             self.cli.parser.error(f"missing action for subsystem command (choose "
                                   f"from {GatewayClient.subsystem_choices})")

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -889,6 +889,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
         self.cluster_allocator = get_cluster_allocator(config, self)
         self.subsys_max_ns = {}
         self.subsys_serial = {}
+        self.subsys_network = {}
         self.subsystems_cache = SubsystemsCache()
         self.host_info = SubsystemHostAuth()
         self.up_and_running = True
@@ -1826,6 +1827,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 self.logger.debug(f"create_subsystem {request.subsystem_nqn}: {ret}")
                 self.subsys_max_ns[request.subsystem_nqn] = request.max_namespaces
                 self.subsys_serial[request.subsystem_nqn] = request.serial_number
+                self.subsys_network[request.subsystem_nqn] = list(request.network_mask)
 
                 dhchap_key_for_omap = request.dhchap_key
                 key_encrypted_for_omap = False
@@ -1897,7 +1899,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
             except Exception:
                 status = errno.EINVAL
                 error_message = f"Created subsystem {request.subsystem_nqn}. "
-                error_message += "An error occured when creating default listeners."
+                error_message += "An error occured when adding network mask."
                 self.logger.exception(error_message)
         return pb2.subsys_status(status=status, error_message=error_message,
                                  nqn=request.subsystem_nqn)
@@ -1906,53 +1908,225 @@ class GatewayService(pb2_grpc.GatewayServicer):
         err_prefix = f"Failure creating subsystem {request.subsystem_nqn}: "
         return self.execute_grpc_function(self.create_subsystem_safe, request, context, err_prefix)
 
-    def _create_auto_listeners_safe(self, request, context=None):
+    def add_listeners(self, subsystem_nqn, ip_list, is_secure):
+        req_status = 0
+        for ip in ip_list:
+            hostname = self.host_name
+            port = os.getenv("NVMEOF_IO_PORT") or "4420"
+            adrfam = f'ipv{ip_address(ip).version}'
+            secure = is_secure
+            lstnr_req = pb2.create_listener_req(
+                nqn=subsystem_nqn,
+                host_name=hostname,
+                adrfam=adrfam,
+                traddr=ip,
+                trsvcid=int(port),
+                secure=secure,
+                verify_host_name=False)
+            rt = self.create_listener_safe(lstnr_req, None)
+            status = rt.status
+            if status != 0:
+                errmsg = f"Failure creating auto-listeners for {subsystem_nqn} " \
+                         f"subsystem: {rt.error_message}"
+                self.logger.error(errmsg)
+                if status != errno.EEXIST:
+                    req_status = status
+            else:
+                ip_ = GatewayUtils.escape_address_if_ipv6(ip)
+                self.logger.info(f'Automatically created listener at {ip_}:{port} for '
+                                 f'{subsystem_nqn}')
+        return req_status
+
+    def del_listeners(self, subsystem_nqn, ip_list):
+        req_status = 0
+        for ip in ip_list:
+            hostname = self.host_name
+            port = os.getenv("NVMEOF_IO_PORT") or "4420"
+            adrfam = f'ipv{ip_address(ip).version}'
+            lstnr_req = pb2.delete_listener_req(
+                nqn=subsystem_nqn,
+                host_name=hostname,
+                traddr=ip,
+                adrfam=adrfam,
+                trsvcid=int(port),
+                force=True)
+            rt = self.delete_listener_safe(lstnr_req, None)
+            status = rt.status
+            if status != 0:
+                errmsg = f"Failure deleting auto-listeners for {subsystem_nqn} " \
+                         f"subsystem: {rt.error_message}"
+                self.logger.error(errmsg)
+                if status != errno.ENOENT:
+                    req_status = status
+            else:
+                ip_ = GatewayUtils.escape_address_if_ipv6(ip)
+                self.logger.info(f'Automatically deleted listener at {ip_}:{port} for '
+                                 f'{subsystem_nqn}')
+        return req_status
+
+    def _create_auto_listeners_safe(self, request):
         """
         Internal method - Automatically create listeners for IPs within subnet of 'network_mask'
         request: create_subsystem_req type
         """
 
-        def _get_host_ips(subnet: str) -> list:
-            nics = NICS(self.logger, True)
-            return nics.get_ips_in_subnet(subnet)
         req_status = 0
         network_mask_subnets = request.network_mask
-        if network_mask_subnets:
-            subnet_list = network_mask_subnets.split(",")
-            for subnet in subnet_list:
-                found_host_ips = _get_host_ips(subnet)
-                for ip in found_host_ips:
-                    hostname = self.host_name
-                    port = os.getenv("NVMEOF_IO_PORT") or "4420"
-                    adrfam = f'ipv{ip_address(ip).version}'
-                    secure = request.secure_listeners
-                    lstnr_req = pb2.create_listener_req(
-                        nqn=request.subsystem_nqn,
-                        host_name=hostname,
-                        adrfam=adrfam,
-                        traddr=ip,
-                        trsvcid=int(port),
-                        secure=secure,
-                        verify_host_name=False)
-                    rt = self.create_listener_safe(lstnr_req, None)
-                    status = rt.status
-                    if status != 0:
-                        req_status = status
-                        errmsg = f"Failure creating auto-listeners for {request.subsystem_nqn} " \
-                                 f"subsystem: {rt.error_message}"
-                        self.logger.error(errmsg)
-                    else:
-                        ip_ = GatewayUtils.escape_address_if_ipv6(ip)
-                        self.logger.info(f'Automatically created listener at {ip_}:{port} for '
-                                         f'{request.subsystem_nqn}')
+        for subnet in set(network_mask_subnets):
+            found_host_ips = NICS(self.logger, True).get_ips_in_subnet(subnet)
+            req_status = self.add_listeners(request.subsystem_nqn, found_host_ips,
+                                            request.secure_listeners)
         if req_status != 0:
             err_msg = f"Failed to create auto-listeners for subsystem {request.subsystem_nqn}"
-            return pb2.req_status(status=status, error_message=err_msg)
+            return pb2.req_status(status=req_status, error_message=err_msg)
         return pb2.req_status(status=0, error_message=os.strerror(0))
 
     def create_auto_listeners(self, request):
+        """
+        Create auto-listeners for request.network_mask (Internal method)
+        request: create_subsystem_req type
+        """
         with self.rpc_lock:
-            return self._create_auto_listeners_safe(request, None)
+            return self._create_auto_listeners_safe(request)
+
+    def add_subsystem_network_safe(self, request, context):
+
+        assert self.rpc_lock.locked(), \
+            "RPC is unlocked when calling add_subsystem_network_safe()"
+
+        self.logger.info(
+            f"Received request to add network to subsystem {request.subsystem_nqn}, "
+            f"network mask: {request.network_mask}, context: {context}")
+
+        req_status = 0
+        omap_lock = self.omap_lock.get_omap_lock_to_use(context)
+        with omap_lock:
+            subsys_entry = None
+            state = self.gateway_state.local.get_state()
+            subsys_key = GatewayState.build_subsystem_key(request.subsystem_nqn)
+            try:
+                state_subsys = state[subsys_key]
+                subsys_entry = json_format.Parse(state_subsys, pb2.create_subsystem_req(),
+                                                 ignore_unknown_fields=True)
+            except Exception:
+                errmsg = f"Can't find entry for subsystem {request.subsystem_nqn}"
+                self.logger.error(errmsg)
+                return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
+            assert subsys_entry, f"Can't find entry for subsystem {request.subsystem_nqn}"
+            try:
+                network_to_add = request.network_mask
+                existing_network_masks = set(subsys_entry.network_mask)
+                if network_to_add in existing_network_masks:
+                    self.logger.warning(f"Network mask already exists for "
+                                        f"subsystem {request.subsystem_nqn}")
+                    return pb2.req_status(status=0, error_message=os.strerror(0))
+
+                found_ips = NICS(self.logger, True).get_ips_in_subnet(network_to_add)
+                req_status = self.add_listeners(request.subsystem_nqn, found_ips,
+                                                subsys_entry.secure_listeners)
+                if req_status != 0:
+                    self.logger.error(f'Failed to add all listeners in network mask '
+                                      f'{request.network_mask} (all IPs: {found_ips}) '
+                                      f'for subsystem {request.subsystem_nqn}.')
+                else:
+                    existing_network_masks.add(network_to_add)
+                    new_network_mask = list(existing_network_masks)
+                    self.subsys_network[request.subsystem_nqn] = new_network_mask
+                    if context:
+                        # remove listener from subsystem's OMAP
+                        subsys_entry.network_mask[:] = new_network_mask
+                        json_req = json_format.MessageToJson(
+                            subsys_entry, preserving_proto_field_name=True,
+                            including_default_value_fields=True)
+                        self.gateway_state.add_subsystem(request.subsystem_nqn, json_req)
+                    self.logger.info(f"Added network {request.network_mask} for subsystem"
+                                     f"{request.subsystem_nqn}")
+            except Exception as ex:
+                errmsg = f"Failure occured:\n{ex}"
+                self.logger.error(errmsg)
+                return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+        err_msg = os.strerror(0)
+        if req_status != 0:
+            err_msg = f"Failed to add network for subsystem {request.subsystem_nqn}"
+        return pb2.req_status(status=req_status, error_message=err_msg)
+
+    def add_subsystem_network(self, request, context=None):
+        """Add a network_mask on subsystem"""
+        err_prefix = f"Failure adding network {request.network_mask} for " \
+                     f"subsystem {request.subsystem_nqn}: "
+        return self.execute_grpc_function(self.add_subsystem_network_safe, request,
+                                          context, err_prefix)
+
+    def del_subsystem_network_safe(self, request, context):
+
+        assert self.rpc_lock.locked(), \
+            "RPC is unlocked when calling del_subsystem_network_safe()"
+
+        self.logger.info(
+            f"Received request to delete network to subsystem {request.subsystem_nqn}, "
+            f"network mask: {request.network_mask}, context: {context}")
+
+        req_status = 0
+        omap_lock = self.omap_lock.get_omap_lock_to_use(context)
+        with omap_lock:
+            subsys_entry = None
+            state = self.gateway_state.local.get_state()
+            subsys_key = GatewayState.build_subsystem_key(request.subsystem_nqn)
+            try:
+                state_subsys = state[subsys_key]
+                subsys_entry = json_format.Parse(state_subsys, pb2.create_subsystem_req(),
+                                                 ignore_unknown_fields=True)
+            except Exception:
+                errmsg = f"Can't find entry for subsystem {request.subsystem_nqn}"
+                self.logger.error(errmsg)
+                return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
+            assert subsys_entry, f"Can't find entry for subsystem {request.subsystem_nqn}"
+            try:
+                network_to_delete = request.network_mask
+                if not subsys_entry.network_mask:
+                    errmsg = f"No existing network mask found for " \
+                             f"subsystem {request.subsystem_nqn}"
+                    return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
+                existing_network_mask = set(subsys_entry.network_mask)
+                if network_to_delete not in existing_network_mask:
+                    self.logger.warning(f"Network mask {request.network_mask} not "
+                                        f"found for subsystem {request.subsystem_nqn}")
+                    return pb2.req_status(status=0, error_message=os.strerror(0))
+
+                found_ips = NICS(self.logger, True).get_ips_in_subnet(network_to_delete)
+                req_status = self.del_listeners(request.subsystem_nqn, found_ips)
+                if req_status != 0:
+                    self.logger.error(f'Failed to delete all listeners under network mask '
+                                      f'{request.network_mask} (all IPs: {found_ips}) '
+                                      f'for subsystem {request.subsystem_nqn}.')
+                else:
+                    existing_network_mask.remove(network_to_delete)
+                    new_network_mask = list(existing_network_mask)
+                    self.subsys_network[request.subsystem_nqn] = new_network_mask
+                    if context:
+                        # remove listener from subsystem's OMAP
+                        subsys_entry.network_mask[:] = new_network_mask
+                        json_req = json_format.MessageToJson(
+                            subsys_entry, preserving_proto_field_name=True,
+                            including_default_value_fields=True)
+                        self.gateway_state.add_subsystem(request.subsystem_nqn, json_req)
+                    self.logger.info(f"Deleted network {network_to_delete} for subsystem "
+                                     f"{request.subsystem_nqn}")
+            except Exception as ex:
+                errmsg = f"Failure occured:\n{ex}"
+                self.logger.error(errmsg)
+                return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+        err_msg = os.strerror(0)
+        if req_status != 0:
+            err_msg = f"Failed to delete network for subsystem {request.subsystem_nqn}"
+        return pb2.req_status(status=req_status, error_message=err_msg)
+
+    def del_subsystem_network(self, request, context=None):
+        """Delete a network_mask on subsystem"""
+        err_prefix = f"Failure deleting network {request.network_mask} for " \
+                     f"subsystem {request.subsystem_nqn}: "
+        return self.execute_grpc_function(self.del_subsystem_network_safe, request,
+                                          context, err_prefix)
 
     def get_subsystem_namespaces(self, nqn) -> list:
         ns_list = []
@@ -2015,6 +2189,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 ret = self.spdk_rpc_client.nvmf_delete_subsystem(nqn=request.subsystem_nqn)
                 self.subsys_max_ns.pop(request.subsystem_nqn)
                 self.subsys_serial.pop(request.subsystem_nqn)
+                self.subsys_network.pop(request.subsystem_nqn)
                 if request.subsystem_nqn in self.subsystem_listeners:
                     self.subsystem_listeners.pop(request.subsystem_nqn, None)
                 self.host_info.clean_subsystem(request.subsystem_nqn)
@@ -6090,6 +6265,9 @@ class GatewayService(pb2_grpc.GatewayServicer):
             try:
                 if s["subtype"] == "NVMe":
                     s["namespace_count"] = len(s["namespaces"])
+                    s["network_mask"] = []
+                    if s["nqn"] in self.subsys_network:
+                        s["network_mask"] = list(self.subsys_network[s['nqn']])
                     s["enable_ha"] = True
                     s["has_dhchap_key"] = self.host_info.does_subsystem_have_dhchap_key(s["nqn"])
                     s["created_without_key"] = \
@@ -6107,6 +6285,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     s["namespace_count"] = 0
                     s["enable_ha"] = False
                     s["has_dhchap_key"] = False
+                    s["network_mask"] = []
                 # Parse the JSON dictionary into the protobuf message
                 subsystem = pb2.subsystem_cli()
                 json_format.Parse(json.dumps(s), subsystem, ignore_unknown_fields=True)

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -47,6 +47,12 @@ service Gateway {
 	// Changes subsystem key
 	rpc change_subsystem_key(change_subsystem_key_req) returns(req_status) {}
 
+	// Add a subsystem network
+	rpc add_subsystem_network(add_subsystem_network_req) returns(req_status) {}
+
+	// Delete a subsystem network
+	rpc del_subsystem_network(del_subsystem_network_req) returns(req_status) {}
+
 	// List namespaces
 	rpc list_namespaces(list_namespaces_req) returns(namespaces_info) {}
 
@@ -248,7 +254,7 @@ message create_subsystem_req {
 	optional bool no_group_append = 5;
 	optional string dhchap_key = 6;
 	optional bool key_encrypted = 7;
-	optional string network_mask = 8;
+	repeated string network_mask = 8;
 	optional bool secure_listeners = 9;
 }
 
@@ -261,6 +267,16 @@ message delete_subsystem_req {
 message change_subsystem_key_req {
 	string subsystem_nqn = 1;
 	optional string dhchap_key = 2;
+}
+
+message add_subsystem_network_req {
+	string subsystem_nqn = 1;
+	string network_mask = 2;
+}
+
+message del_subsystem_network_req {
+	string subsystem_nqn = 1;
+	string network_mask = 2;
 }
 
 message list_namespaces_req {
@@ -429,6 +445,7 @@ message subsystem {
 	optional uint32 max_cntlid = 10;
 	repeated namespace namespaces = 11;
 	optional bool has_dhchap_key = 12;
+	repeated string network_mask = 13;
 }
 
 message listen_address {
@@ -471,6 +488,7 @@ message subsystem_cli {
 	optional bool has_dhchap_key = 10;
 	optional bool allow_any_host = 11;
 	optional bool created_without_key = 12;
+	repeated string network_mask = 13;
 }
 
 message gateway_info {

--- a/control/server.py
+++ b/control/server.py
@@ -1275,3 +1275,15 @@ class GatewayServer:
                                             ignore_unknown_fields=True)
                     rc = self.gateway_rpc.change_subsystem_key(req)
                     abort_server_on_update_error(rc.status, rc.error_message)
+            elif key.startswith(GatewayState.SUBSYSTEM_NETWORK_ADD_PREFIX):
+                if not is_add_req:
+                    req = json_format.Parse(val, pb2.add_subsystem_network_req(),
+                                            ignore_unknown_fields=True)
+                    rc = self.gateway_rpc.add_subsystem_network(req)
+                    abort_server_on_update_error(rc.status, rc.error_message)
+            elif key.startswith(GatewayState.SUBSYSTEM_NETWORK_DEL_PREFIX):
+                if not is_add_req:
+                    req = json_format.Parse(val, pb2.del_subsystem_network_req(),
+                                            ignore_unknown_fields=True)
+                    rc = self.gateway_rpc.del_subsystem_network(req)
+                    abort_server_on_update_error(rc.status, rc.error_message)

--- a/control/state.py
+++ b/control/state.py
@@ -35,6 +35,8 @@ class GatewayState(ABC):
     NAMESPACE_PREFIX = "namespace" + OMAP_KEY_DELIMITER
     SUBSYSTEM_PREFIX = "subsystem" + OMAP_KEY_DELIMITER
     SUBSYSTEM_NETWORK_MASK = "network-mask-subsystem" + OMAP_KEY_DELIMITER
+    SUBSYSTEM_NETWORK_ADD_PREFIX = "net-add-subsystem" + OMAP_KEY_DELIMITER
+    SUBSYSTEM_NETWORK_DEL_PREFIX = "net-del-subsystem" + OMAP_KEY_DELIMITER
     SUBSYSTEM_KEY_PREFIX = "key-subsystem" + OMAP_KEY_DELIMITER
     HOST_PREFIX = "host" + OMAP_KEY_DELIMITER
     HOST_KEY_PREFIX = "key-host" + OMAP_KEY_DELIMITER
@@ -149,6 +151,20 @@ class GatewayState(ABC):
 
     def build_subsystem_network_mask_key(subsystem_nqn: str) -> str:
         return GatewayState.SUBSYSTEM_NETWORK_MASK + subsystem_nqn
+
+    def build_subsystem_network_add_key(subsystem_nqn: str, network: str) -> str:
+        key = GatewayState.SUBSYSTEM_NETWORK_ADD_PREFIX + GatewayState.OMAP_KEY_DELIMITER + \
+            subsystem_nqn + GatewayState.OMAP_KEY_DELIMITER
+        if network is not None:
+            key += network
+        return key
+
+    def build_subsystem_network_del_key(subsystem_nqn: str, network: str) -> str:
+        key = GatewayState.SUBSYSTEM_NETWORK_DEL_PREFIX + GatewayState.OMAP_KEY_DELIMITER + \
+            subsystem_nqn + GatewayState.OMAP_KEY_DELIMITER
+        if network is not None:
+            key += network
+        return key
 
     def build_partial_listener_key(subsystem_nqn: str, host: str) -> str:
         key = GatewayState.LISTENER_PREFIX + subsystem_nqn + GatewayState.OMAP_KEY_DELIMITER
@@ -267,6 +283,10 @@ class GatewayState(ABC):
             elif key.startswith(GatewayState.build_host_key_key(subsystem_nqn, None)):
                 self._remove_key(key)
             elif key.startswith(GatewayState.build_subsystem_key_key(subsystem_nqn)):
+                self._remove_key(key)
+            elif key.startswith(GatewayState.build_subsystem_network_add_key(subsystem_nqn, None)):
+                self._remove_key(key)
+            elif key.startswith(GatewayState.build_subsystem_network_del_key(subsystem_nqn, None)):
                 self._remove_key(key)
             elif key.startswith(GatewayState.build_partial_listener_key(subsystem_nqn, None)):
                 self._remove_key(key)
@@ -1483,6 +1503,40 @@ class GatewayStateHandler:
             return (False, None, False)
         return (True, new_req.dhchap_key, new_req.key_encrypted)
 
+    def subsystem_only_network_mask_changed(self, old_val, new_val):
+        # If only the network_mask key field has changed we can use
+        # add/del_subsystem_network request instead of re-adding the subsystem
+        old_req = None
+        new_req = None
+        try:
+            old_req = json_format.Parse(old_val,
+                                        pb2.create_subsystem_req(),
+                                        ignore_unknown_fields=True)
+        except json_format.ParseError:
+            self.logger.exception(f"Got exception parsing {old_val}")
+            return (False, None, None)
+        try:
+            new_req = json_format.Parse(new_val,
+                                        pb2.create_subsystem_req(),
+                                        ignore_unknown_fields=True)
+        except json_format.ParseError:
+            self.logger.exeption(f"Got exception parsing {new_val}")
+            return (False, None, None)
+        if not old_req or not new_req:
+            self.logger.debug(f"Failed to parse requests, old: {old_val} -> {old_req}, "
+                              f"new: {new_val} -> {new_req}")
+            return (False, None, None)
+        assert old_req != new_req, f"Something was wrong we shouldn't get identical old " \
+                                   f"and new values ({old_req})"
+
+        add = list(set(new_req.network_mask) - set(old_req.network_mask))
+        delete = list(set(old_req.network_mask) - set(new_req.network_mask))
+        old_req.network_mask[:] = new_req.network_mask
+        if old_req != new_req:
+            # Something besides the network_mask is different
+            return (False, None, None)
+        return (True, add, delete)
+
     def break_namespace_attribute_key(self, prefix: str, ns_key: str):
         if not ns_key.startswith(prefix):
             self.logger.warning(f"Invalid namespace attribute key \"{ns_key}\", "
@@ -1583,6 +1637,8 @@ class GatewayStateHandler:
                 GatewayState.NAMESPACE_REFRESH_SIZE_PREFIX,
                 GatewayState.LISTENER_PREFIX,
                 GatewayState.SUBSYSTEM_NETWORK_MASK,
+                GatewayState.SUBSYSTEM_NETWORK_DEL_PREFIX,
+                GatewayState.SUBSYSTEM_NETWORK_ADD_PREFIX,
             ]
 
             if not self.omap.ioctx:
@@ -1637,6 +1693,7 @@ class GatewayStateHandler:
                 ns_auto_resize_changed = []
                 only_host_key_changed = []
                 only_subsystem_key_changed = []
+                only_subsystem_network_changed = []
                 auto_listener_add = []
                 for key in changed.keys():
                     if key.startswith(GatewayState.NAMESPACE_PREFIX):
@@ -1705,6 +1762,12 @@ class GatewayStateHandler:
                             only_subsystem_key_changed.append((key,
                                                                new_dhchap_key,
                                                                new_key_encrypted))
+                        (should_process, add_n, del_n) = self.subsystem_only_network_mask_changed(
+                            local_state_dict[key],
+                            omap_state_dict[key])
+                        if should_process:
+                            self.logger.debug(f"Found {key} where only the network has changed.")
+                            only_subsystem_network_changed.append((key, add_n, del_n))
                 for key in added.keys():
                     if key.startswith(GatewayState.SUBSYSTEM_PREFIX):
                         subsystem = self._parse_subsystem_req(omap_state_dict[key])
@@ -1894,15 +1957,49 @@ class GatewayStateHandler:
                         except Exception:
                             self.logger.exception("Exception formatting change subsystem "
                                                   "key request")
+                for subsys_key, add_n, delete_n in only_subsystem_network_changed:
+                    subsys_nqn = None
+                    try:
+                        changed.pop(subsys_key)
+                        subsys_nqn = self.break_subsystem_key(subsys_key)
+                    except Exception:
+                        self.logger.exception(f"Exception removing {subsys_key} from {changed}")
+                    if subsys_nqn:
+                        try:
+                            for network_subnet in add_n:
+                                req = pb2.add_subsystem_network_req(subsystem_nqn=subsys_nqn,
+                                                                    network_mask=network_subnet)
+                                nadd_key = GatewayState.build_subsystem_network_add_key(
+                                    subsys_nqn, network_subnet)
+                                json_req = json_format.MessageToJson(
+                                    req,
+                                    preserving_proto_field_name=True,
+                                    including_default_value_fields=True)
+                                changed[nadd_key] = json_req
+                            for network_subnet in delete_n:
+                                req = pb2.del_subsystem_network_req(subsystem_nqn=subsys_nqn,
+                                                                    network_mask=network_subnet)
+                                ndel_key = GatewayState.build_subsystem_network_del_key(
+                                    subsys_nqn, network_subnet)
+                                json_req = json_format.MessageToJson(
+                                    req,
+                                    preserving_proto_field_name=True,
+                                    including_default_value_fields=True)
+                                changed[ndel_key] = json_req
+                        except Exception:
+                            self.logger.exception("Exception formatting add/del subsystem "
+                                                  "network request")
                 for subsystem_req in auto_listener_add:
                     subsystem_nqn = subsystem_req.subsystem_nqn
                     autolistener_key = GatewayState.build_subsystem_network_mask_key(subsystem_nqn)
                     json_req = json_format.MessageToJson(subsystem_req)
                     added[autolistener_key] = json_req
+
                 if len(ns_lb_group_changed) > 0 or len(only_host_key_changed) > 0 or \
                    len(only_subsystem_key_changed) > 0 or len(ns_visibility_changed) > 0 or \
                    len(ns_location_changed) > 0 or len(ns_trash_image_changed) > 0 or \
-                   len(ns_auto_resize_changed) > 0 or len(auto_listener_add) > 0:
+                   len(ns_auto_resize_changed) > 0 or len(auto_listener_add) > 0 or \
+                   len(only_subsystem_network_changed) > 0:
                     grouped_changed = self._group_by_prefix(changed, prefix_list)
 
                     if len(only_subsystem_key_changed) > 0:

--- a/control/utils.py
+++ b/control/utils.py
@@ -627,6 +627,8 @@ class NICS:
         return False
 
     def get_ips_in_subnet(self, subnet):
+        if not subnet:
+            return []
         subnet_ = ipaddress.ip_network(subnet, strict=False)
         found_ips = []
         for dev in self.adapters:

--- a/tests/test_auto_listeners.py
+++ b/tests/test_auto_listeners.py
@@ -15,7 +15,9 @@ subsystem3 = "nqn.2016-06.io.spdk:cnode3"
 
 host_name = socket.gethostname()
 addr = "127.0.0.1"
+addr_subnet = f'{addr}/24'
 addr_ipv6 = "::1"
+addr_ipv6_subnet = f'{addr_ipv6}/120'
 config = "ceph-nvmeof.conf"
 group_name = "GROUPNAME"
 
@@ -51,15 +53,43 @@ def gateway(config):
 
 
 class TestAutoListener:
-    def test_auto_listener_ipv4(self, caplog, gateway):
+    def test_subsystem_with_networks(self, caplog, gateway):
         cli(["subsystem", "list"])
         caplog.clear()
         cli(["subsystem", "add", "--subsystem", subsystem, "--no-group-append",
-             '--network-mask', f'{addr}/24'])
+             '--network-mask', addr_subnet, addr_ipv6_subnet])
         assert f"Adding subsystem {subsystem}: Successful" in caplog.text
         assert "ipv4" in caplog.text.lower()
         assert (f"Automatically created listener at {addr}:4420 for {subsystem}"
                 in caplog.text)
+        assert "ipv6" in caplog.text.lower()
+        assert (f"Automatically created listener at [{addr_ipv6}]:4420 for {subsystem}"
+                in caplog.text)
+
+    def test_listener_list(self, caplog, gateway):
+        cli(["subsystem", "list"])
+        time.sleep(30)
+        caplog.clear()
+        listeners = cli_test(["listener", "list", "--subsystem", subsystem])
+        assert len(listeners.listeners) == 2
+        assert listeners.listeners[0].trtype == "TCP"
+        assert listeners.listeners[0].trsvcid == 4420
+        assert listeners.listeners[0].active
+        assert not listeners.listeners[0].secure
+        assert not listeners.listeners[0].manual
+        assert {listeners.listeners[0].traddr,
+                listeners.listeners[1].traddr} == {addr, addr_ipv6}
+        assert listeners.listeners[1].trtype == "TCP"
+        assert listeners.listeners[1].trsvcid == 4420
+        assert listeners.listeners[1].active
+        assert not listeners.listeners[1].secure
+        assert not listeners.listeners[1].manual
+
+    def test_subsystem_list(self, caplog, gateway):
+        subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem])
+        masks = subsystems.subsystems[0].network_mask
+        assert len(masks) == 2
+        assert set(masks) == {addr_subnet, addr_ipv6_subnet}
 
     def test_auto_listener_secure(self, caplog, gateway):
         caplog.clear()
@@ -70,28 +100,9 @@ class TestAutoListener:
         assert (f"Automatically created listener at {addr}:4420 for {subsystem2}"
                 in caplog.text)
 
-    def test_auto_listener_ipv6(self, caplog, gateway):
-        caplog.clear()
-        cli(["subsystem", "add", "--subsystem", subsystem3, "--no-group-append",
-             '--network-mask', f'{addr_ipv6}/120'])
-        assert f"Adding subsystem {subsystem3}: Successful" in caplog.text
-        assert "ipv6" in caplog.text.lower()
-        assert (f"Automatically created listener at [{addr_ipv6}]:4420 for {subsystem3}"
-                in caplog.text)
-
-    def test_auto_listener_list_ipv4(self, caplog, gateway):
+    def test_auto_listener_list_secure(self, caplog, gateway):
         cli(["subsystem", "list"])
         time.sleep(30)
-        caplog.clear()
-        listeners = cli_test(["listener", "list", "--subsystem", subsystem])
-        assert listeners.listeners[0].trtype == "TCP"
-        assert listeners.listeners[0].traddr == addr
-        assert listeners.listeners[0].trsvcid == 4420
-        assert listeners.listeners[0].active
-        assert not listeners.listeners[0].secure
-        assert not listeners.listeners[0].manual
-
-    def test_auto_listener_list_secure(self, caplog, gateway):
         caplog.clear()
         listeners = cli_test(["listener", "list", "--subsystem", subsystem2])
         assert listeners.listeners[0].trtype == "TCP"
@@ -101,12 +112,68 @@ class TestAutoListener:
         assert listeners.listeners[0].secure
         assert not listeners.listeners[0].manual
 
-    def test_auto_listener_list_ipv6(self, caplog, gateway):
+    def test_del_network_mask(self, caplog, gateway):
+        cli(["subsystem", "list"])
         caplog.clear()
-        listeners = cli_test(["listener", "list", "--subsystem", subsystem3])
+        cli(["subsystem", "del_network", "--subsystem", subsystem,
+             '--network-mask', f'{addr}/24'])
+        assert (f"Removed network {addr}/24 for subsystem {subsystem}")
+        assert (f"Automatically deleted listener at {addr}:4420 for {subsystem}"
+                in caplog.text)
+        assert (f"Automatically created listener at {addr}:4420 for {subsystem}"
+                not in caplog.text)
+
+    def test_del_network_subsystem_list(self, caplog, gateway):
+        subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem])
+        masks = subsystems.subsystems[0].network_mask
+        assert len(masks) == 1
+        assert set(masks) == {addr_ipv6_subnet}
+
+    def test_del_network_listener_list(self, caplog, gateway):
+        cli(["subsystem", "list"])
+        time.sleep(30)
+        caplog.clear()
+        listeners = cli_test(["listener", "list", "--subsystem", subsystem])
+        assert len(listeners.listeners) == 1
         assert listeners.listeners[0].trtype == "TCP"
         assert listeners.listeners[0].traddr == addr_ipv6
         assert listeners.listeners[0].trsvcid == 4420
         assert listeners.listeners[0].active
         assert not listeners.listeners[0].secure
         assert not listeners.listeners[0].manual
+
+    def test_add_network_mask(self, caplog, gateway):
+        cli(["subsystem", "list"])
+        caplog.clear()
+        cli(["subsystem", "add_network", "--subsystem", subsystem,
+             '--network-mask', f'{addr}/24'])
+        assert (f"Added network {addr}/24 for subsystem {subsystem}")
+        assert (f"Automatically created listener at {addr}:4420 for {subsystem}"
+                in caplog.text)
+        assert (f"Automatically deleted listener at {addr}:4420 for {subsystem}"
+                not in caplog.text)
+
+    def test_add_network_subsystem_list(self, caplog, gateway):
+        subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem])
+        masks = subsystems.subsystems[0].network_mask
+        assert len(masks) == 2
+        assert set(masks) == {addr_ipv6_subnet, addr_subnet}
+
+    def test_add_network_listener_list(self, caplog, gateway):
+        cli(["subsystem", "list"])
+        time.sleep(30)
+        caplog.clear()
+        listeners = cli_test(["listener", "list", "--subsystem", subsystem])
+        assert len(listeners.listeners) == 2
+        assert listeners.listeners[0].trtype == "TCP"
+        assert listeners.listeners[0].traddr == addr
+        assert listeners.listeners[0].trsvcid == 4420
+        assert listeners.listeners[0].active
+        assert not listeners.listeners[0].secure
+        assert not listeners.listeners[0].manual
+        assert listeners.listeners[1].trtype == "TCP"
+        assert listeners.listeners[1].traddr == addr_ipv6
+        assert listeners.listeners[1].trsvcid == 4420
+        assert listeners.listeners[1].active
+        assert not listeners.listeners[1].secure
+        assert not listeners.listeners[1].manual

--- a/tests/test_dhchap.py
+++ b/tests/test_dhchap.py
@@ -1006,13 +1006,13 @@ def test_encryption_disabled(caplog, gateway_encryption_disabled):
     cli(["subsystem", "add", "--subsystem", subsystem3, "--dhchap-key", hostdhchap9,
          "--no-group-append"])
     assert f"Received request to create subsystem {subsystem3}, enable_ha: True, " \
-           f"max_namespaces: 0, no group append: True, network mask: , " \
+           f"max_namespaces: 0, no group append: True, network mask: [], " \
            "secure listeners: False, context: <grpc._server" in caplog.text
     assert f"create_subsystem {subsystem3}: True" in caplog.text
     time.sleep(15)
     lookfor = f"Received request to create subsystem {subsystem3}, enable_ha: True, " \
               f"max_namespaces: {gw_encryption_disabled.MAX_NAMESPACES_PER_SUBSYSTEM_DEFAULT}" \
-              f", no group append: True, network mask: , secure listeners: False, context: None"
+              f", no group append: True, network mask: [], secure listeners: False, context: None"
     assert lookfor in caplog.text
     pos = caplog.text.find(lookfor)
     assert pos >= 0


### PR DESCRIPTION
Add 'subsystem add_network' cmd to add new subnet
of IPs as auto-listeners. And 'subsystem del_network' to remove a subnet of auto-listener IPs.

Syntax:
"subsystem add_network -n <nqn> --network-mask <subnet>" 
"subsystem del_network -n <nqn> --network-mask <subnet>"

USAGE: 

subsystem creation with 2 network_mask:
```
[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:default-listeners-edit-14 --server-address x.x.x.x subsystem add -n nqn.2016-06.io.spdk:cnode40 --network-mask x.x.x.0/24 y.y.y.0/24
Adding subsystem nqn.2016-06.io.spdk:cnode40.mygroup1: Successful
[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:default-listeners-edit-14 --server-address x.x.x.x listener list -n nqn.2016-06.io.spdk:cnode40.mygroup1
Listeners for nqn.2016-06.io.spdk:cnode40.mygroup1:
╒═══════════════════════════════╤═════════════╤══════════════════╤═══════════════════╤══════════╤══════════╤══════════╕
│ Host                          │ Transport   │ Address Family   │ Address           │ Secure   │ Active   │ Manual   │
╞═══════════════════════════════╪═════════════╪══════════════════╪═══════════════════╪══════════╪══════════╪══════════╡
│ vallari-vallari-cluster-node1 │ TCP         │ IPv4             │ x.x.x.x:4420      │ No       │ Yes      │ No       │
├───────────────────────────────┼─────────────┼──────────────────┼───────────────────┼──────────┼──────────┼──────────┤
│ vallari-vallari-cluster-node1 │ TCP         │ IPv4             │ y.y.y.y:4420      │ No       │ Yes      │ No       │
├───────────────────────────────┼─────────────┼──────────────────┼───────────────────┼──────────┼──────────┼──────────┤
│ vallari-vallari-cluster-node2 │ TCP         │ IPv4             │ x.x.x.a:4420      │ No       │ No       │ No       │
├───────────────────────────────┼─────────────┼──────────────────┼───────────────────┼──────────┼──────────┼──────────┤
│ vallari-vallari-cluster-node3 │ TCP         │ IPv4             │ x.x.x.b:4420.     │ No       │ No       │ No       │
╘═══════════════════════════════╧═════════════╧══════════════════╧═══════════════════╧══════════╧══════════╧══════════╛

[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:auto-listener-add-del-test-5 --server-address x.x.x.x  subsystem list -n nqn.2016-06.io.spdk:cnode40.mygroup1
Subsystem nqn.2016-06.io.spdk:cnode40.mygroup1:
╒═══════════╤══════════════════════════════════════╤════════════════════╤══════════════════╤═════════════╤══════════════╤════════════╤══════════╤════════════════╕
│ Subtype   │ NQN                                  │ Serial             │ Controller IDs   │   Namespace │          Max │ Allow      │ DHCHAP   │ Network        │
│           │                                      │ Number             │                  │       Count │   Namespaces │ Any Host   │ Key      │ Mask           │
╞═══════════╪══════════════════════════════════════╪════════════════════╪══════════════════╪═════════════╪══════════════╪════════════╪══════════╪════════════════╡
│ NVMe      │ nqn.2016-06.io.spdk:cnode40.mygroup1 │ Ceph47620438499947 │ 1-2040           │           0 │          512 │ No         │ No       │ x.x.x.0/24    │
│           │                                      │                    │                  │             │              │            │          │ y.y.y.0/24    │
╘═══════════╧══════════════════════════════════════╧════════════════════╧══════════════════╧═════════════╧══════════════╧════════════╧══════════╧════════════════╛

```
subsystem del_network:
```
[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:default-listeners-edit-14 --server-address x.x.x.x subsystem del_network -n nqn.2016-06.io.spdk:cnode40.mygroup1 --network-mask x.x.x.0/24
Network mask x.x.x.0/24 deleted for subsystem nqn.2016-06.io.spdk:cnode40.mygroup1: Successful
[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:default-listeners-edit-14 --server-address x.x.x.x listener list -n nqn.2016-06.io.spdk:cnode40.mygroup1
Listeners for nqn.2016-06.io.spdk:cnode40.mygroup1:
╒═══════════════════════════════╤═════════════╤══════════════════╤══════════════════╤══════════╤══════════╤══════════╕
│ Host                          │ Transport   │ Address Family   │ Address          │ Secure   │ Active   │ Manual   │
╞═══════════════════════════════╪═════════════╪══════════════════╪══════════════════╪══════════╪══════════╪══════════╡
│ vallari-vallari-cluster-node1 │ TCP         │ IPv4             │ y.y.y.y:4420     │ No       │ Yes      │ No       │
╘═══════════════════════════════╧═════════════╧══════════════════╧══════════════════╧══════════╧══════════╧══════════╛

[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:auto-listener-add-del-test-5 --server-address x.x.x.x  subsystem list -n nqn.2016-06.io.spdk:cnode40.mygroup1
Subsystem nqn.2016-06.io.spdk:cnode40.mygroup1:
╒═══════════╤═════════════════════════════════════╤════════════════════╤══════════════════╤═════════════╤══════════════╤════════════╤══════════╤════════════════╕
│ Subtype   │ NQN                                 │ Serial             │ Controller IDs   │   Namespace │          Max │ Allow      │ DHCHAP   │ Network        │
│           │                                     │ Number             │                  │       Count │   Namespaces │ Any Host   │ Key      │ Mask           │
╞═══════════╪═════════════════════════════════════╪════════════════════╪══════════════════╪═════════════╪══════════════╪════════════╪══════════╪════════════════╡
│ NVMe      │ nqn.2016-06.io.spdk:cnode40.mygroup1 │ Ceph63109618488678 │ 1-2040           │           0 │          512 │ No         │ No       │ y.y.y.0/24    │
╘═══════════╧═════════════════════════════════════╧════════════════════╧══════════════════╧═════════════╧══════════════╧════════════╧══════════╧════════════════╛

```
subsystem add_network:
```
[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:default-listeners-edit-14 --server-address x.x.x.x subsystem add_network -n nqn.2016-06.io.spdk:cnode40.mygroup1 --network-mask x.x.x.0/24
Network mask x.x.x.0/24 added to subsystem nqn.2016-06.io.spdk:cnode40.mygroup1: Successful
[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:default-listeners-edit-14 --server-address x.x.x.x listener list -n nqn.2016-06.io.spdk:cnode40.mygroup1
Listeners for nqn.2016-06.io.spdk:cnode40.mygroup1:
╒═══════════════════════════════╤═════════════╤══════════════════╤═══════════════════╤══════════╤══════════╤══════════╕
│ Host                          │ Transport   │ Address Family   │ Address           │ Secure   │ Active   │ Manual   │
╞═══════════════════════════════╪═════════════╪══════════════════╪═══════════════════╪══════════╪══════════╪══════════╡
│ vallari-vallari-cluster-node1 │ TCP         │ IPv4             │ x.x.x.x:4420      │ No       │ Yes      │ No       │
├───────────────────────────────┼─────────────┼──────────────────┼───────────────────┼──────────┼──────────┼──────────┤
│ vallari-vallari-cluster-node1 │ TCP         │ IPv4             │ y.y.y.y:4420      │ No       │ Yes      │ No       │
├───────────────────────────────┼─────────────┼──────────────────┼───────────────────┼──────────┼──────────┼──────────┤
│ vallari-vallari-cluster-node2 │ TCP         │ IPv4             │ x.x.x.a:4420      │ No       │ No       │ No       │
├───────────────────────────────┼─────────────┼──────────────────┼───────────────────┼──────────┼──────────┼──────────┤
│ vallari-vallari-cluster-node3 │ TCP         │ IPv4             │ x.x.x.b:4420      │ No       │ No       │ No       │
╘═══════════════════════════════╧═════════════╧══════════════════╧═══════════════════╧══════════╧══════════╧══════════╛

[root@vallari-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:auto-listener-add-del-test-5 --server-address x.x.x.x  subsystem list -n nqn.2016-06.io.spdk:cnode40.mygroup1
Subsystem nqn.2016-06.io.spdk:cnode40.mygroup1:
╒═══════════╤══════════════════════════════════════╤════════════════════╤══════════════════╤═════════════╤══════════════╤════════════╤══════════╤════════════════╕
│ Subtype   │ NQN                                  │ Serial             │ Controller IDs   │   Namespace │          Max │ Allow      │ DHCHAP   │ Network        │
│           │                                      │ Number             │                  │       Count │   Namespaces │ Any Host   │ Key      │ Mask           │
╞═══════════╪══════════════════════════════════════╪════════════════════╪══════════════════╪═════════════╪══════════════╪════════════╪══════════╪════════════════╡
│ NVMe      │ nqn.2016-06.io.spdk:cnode40.mygroup1 │ Ceph47620438499947 │ 1-2040           │           0 │          512 │ No         │ No       │ x.x.x.0/24    │
│           │                                      │                    │                  │             │              │            │          │ y.y.y.0/24    │
╘═══════════╧══════════════════════════════════════╧════════════════════╧══════════════════╧═════════════╧══════════════╧════════════╧══════════╧════════════════╛


```