### PR TITLE
Avoid clearing subsystem's namespace list when we don't see any. This is not thread safe

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -6076,10 +6076,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
         for s in ret:
             try:
                 if s["subtype"] == "NVMe":
-                    ns_count = len(s["namespaces"])
-                    if not ns_count:
-                        self.subsystem_nsid_bdev_and_uuid.remove_namespace(s["nqn"])
-                    s["namespace_count"] = ns_count
+                    s["namespace_count"] = len(s["namespaces"])
                     s["enable_ha"] = True
                     s["has_dhchap_key"] = self.host_info.does_subsystem_have_dhchap_key(s["nqn"])
                     s["created_without_key"] = \


### PR DESCRIPTION
We got cases in which we saw there were no namespaces on a subsystem and cleared the list while a another threads was adding a namespace and having the list cleared under its feet.

Fixes: #1694