### PR TITLE
Fix #1638: double CRC32C computation in RBD layer

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -102,6 +102,12 @@ timeout = 60.0
 
 # RBD CRC32C usage, disabled by default
 #rbd_with_crc32c = False
+# When set to True, SPDK's RBD bdev will compute CRC32C before writing to Ceph.
+# If your NVMe-oF transport already validates data-digest (CRC32C) and you want to
+# avoid duplicate CRC computations in the gateway, enable the following option.
+# WARNING: only enable when the gateway stack is trusted and no data transformations
+# occur between transport and RBD layers (encryption/compression).
+#skip_rbd_crc_if_transport_digest = True
 
 # Example value: --lcores (0-1) -L all
 # tgt_cmd_extra_args =

--- a/control/server.py
+++ b/control/server.py
@@ -874,13 +874,33 @@ class GatewayServer:
 
     def _initialize_rbd_crc32c(self):
         """Initialize RBD CRC32C configuration."""
-
+        # Read operator-visible configuration. Preserve original default of False
+        # for `rbd_with_crc32c` unless explicitly set. The `skip_rbd_crc_if_transport_digest`
+        # option allows an operator to override and disable RBD-side CRC computation
+        # even if `rbd_with_crc32c` would otherwise be enabled.
         rbd_with_crc32c = self.config.getboolean_with_default("spdk", "rbd_with_crc32c", False)
-        self.logger.debug(f"initialize_rbd_crc32c: rbd_with_crc32c: {rbd_with_crc32c}")
+        skip_if_transport_digest = self.config.getboolean_with_default(
+            "spdk",
+            "skip_rbd_crc_if_transport_digest",
+            False,
+        )
+
+        effective_rbd_crc = bool(rbd_with_crc32c)
+        if skip_if_transport_digest:
+            effective_rbd_crc = False
+
+        self.logger.debug(
+            f"initialize_rbd_crc32c: configured: {rbd_with_crc32c}, "
+            f"skip_if_transport_digest: {skip_if_transport_digest}, effective: {effective_rbd_crc}"
+        )
 
         try:
-            self.spdk_rpc_client.bdev_rbd_set_with_crc32c(enable=rbd_with_crc32c)
-            self.logger.info(f"Set RBD CRC32C usage to: {rbd_with_crc32c}")
+            self.spdk_rpc_client.bdev_rbd_set_with_crc32c(enable=effective_rbd_crc)
+            self.logger.info(f"Set RBD CRC32C usage to: {effective_rbd_crc}")
+            if skip_if_transport_digest:
+                self.logger.info(
+                    "RBD CRC32C computation disabled due to skip_rbd_crc_if_transport_digest option."
+                )
         except Exception:
             self.logger.exception("Failed to set RBD CRC32C configuration")
             raise

--- a/tests/test_rbd_crc_config.py
+++ b/tests/test_rbd_crc_config.py
@@ -1,0 +1,152 @@
+import logging
+import tempfile
+import sys
+import types
+from pathlib import Path
+
+# Provide a lightweight dummy grpc module for test environment if not installed.
+if 'grpc' not in sys.modules:
+    sys.modules['grpc'] = types.ModuleType('grpc')
+
+# Stub minimal spdk.rpc.client module so imports succeed in test environment.
+if 'spdk.rpc.client' not in sys.modules:
+    spdk_mod = types.ModuleType('spdk')
+    spdk_rpc_mod = types.ModuleType('spdk.rpc')
+    spdk_rpc_client_mod = types.ModuleType('spdk.rpc.client')
+    # Provide a JSONRPCClient factory that returns None (we replace the client later)
+    def JSONRPCClient(*args, **kwargs):
+        return None
+    spdk_rpc_client_mod.JSONRPCClient = JSONRPCClient
+    # Minimal exception type used by codepaths during import
+    spdk_rpc_client_mod.JSONRPCException = Exception
+    sys.modules['spdk'] = spdk_mod
+    sys.modules['spdk.rpc'] = spdk_rpc_mod
+    sys.modules['spdk.rpc.client'] = spdk_rpc_client_mod
+
+# Stub generated protobuf modules under control.proto so imports succeed.
+for mod in (
+    'control.proto.gateway_pb2',
+    'control.proto.gateway_pb2_grpc',
+    'control.proto.monitor_pb2',
+    'control.proto.monitor_pb2_grpc',
+):
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+
+# Stub Ceph Python modules used by control.state and cephutils.
+for mod in ('rados', 'rbd'):
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+
+# Stub prometheus_client.core used by control.prometheus
+if 'prometheus_client.core' not in sys.modules:
+    prom = types.ModuleType('prometheus_client')
+    prom_core = types.ModuleType('prometheus_client.core')
+    class _DummyRegistry:
+        def unregister(self, *a, **kw):
+            return None
+
+    prom_core.REGISTRY = _DummyRegistry()
+    class GaugeMetricFamily:
+        pass
+    prom_core.GaugeMetricFamily = GaugeMetricFamily
+    class CounterMetricFamily:
+        pass
+    prom_core.CounterMetricFamily = CounterMetricFamily
+    class InfoMetricFamily:
+        pass
+    prom_core.InfoMetricFamily = InfoMetricFamily
+    # minimal functions/consts expected
+    prom.start_http_server = lambda *a, **kw: None
+    prom.GC_COLLECTOR = object()
+    sys.modules['prometheus_client'] = prom
+    sys.modules['prometheus_client.core'] = prom_core
+
+# Provide lightweight stubs for control.grpc and control.state to avoid
+# importing heavy dependencies during unit tests.
+if 'control.grpc' not in sys.modules:
+    mod = types.ModuleType('control.grpc')
+    class DummyService: pass
+    mod.GatewayService = DummyService
+    mod.MonitorGroupService = DummyService
+    sys.modules['control.grpc'] = mod
+
+if 'control.state' not in sys.modules:
+    mod = types.ModuleType('control.state')
+    # minimal placeholders referenced by control.server
+    class GatewayState: pass
+    class LocalGatewayState: pass
+    class OmapLock: pass
+    class OmapGatewayState: pass
+    class GatewayStateHandler: pass
+    mod.GatewayState = GatewayState
+    mod.LocalGatewayState = LocalGatewayState
+    mod.OmapLock = OmapLock
+    mod.OmapGatewayState = OmapGatewayState
+    mod.GatewayStateHandler = GatewayStateHandler
+    sys.modules['control.state'] = mod
+
+from control.config import GatewayConfig
+from control.server import GatewayServer
+
+
+class DummyRpcClient:
+    def __init__(self):
+        self.last_enable = None
+
+    def bdev_rbd_set_with_crc32c(self, enable):
+        self.last_enable = bool(enable)
+
+
+def make_conf(contents: str) -> str:
+    tf = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    tf.write(contents)
+    tf.flush()
+    tf.close()
+    return tf.name
+
+
+def make_gateway_from_conf(conf_text: str):
+    conf_path = make_conf(conf_text)
+    cfg = GatewayConfig(conf_path)
+    gw = GatewayServer.__new__(GatewayServer)
+    gw.config = cfg
+    gw.logger = logging.getLogger("test_rbd_crc")
+    gw.spdk_rpc_client = DummyRpcClient()
+    return gw
+
+
+def test_default_disables_rbd_crc():
+    conf = """[spdk]
+"""
+    gw = make_gateway_from_conf(conf)
+    gw._initialize_rbd_crc32c()
+    assert gw.spdk_rpc_client.last_enable is False
+
+
+def test_skip_flag_disables_rbd_crc():
+    conf = """[spdk]
+skip_rbd_crc_if_transport_digest = True
+"""
+    gw = make_gateway_from_conf(conf)
+    gw._initialize_rbd_crc32c()
+    assert gw.spdk_rpc_client.last_enable is False
+
+
+def test_explicit_enable_respected():
+    conf = """[spdk]
+rbd_with_crc32c = True
+"""
+    gw = make_gateway_from_conf(conf)
+    gw._initialize_rbd_crc32c()
+    assert gw.spdk_rpc_client.last_enable is True
+
+
+def test_skip_overrides_explicit_enable():
+    conf = """[spdk]
+rbd_with_crc32c = True
+skip_rbd_crc_if_transport_digest = True
+"""
+    gw = make_gateway_from_conf(conf)
+    gw._initialize_rbd_crc32c()
+    assert gw.spdk_rpc_client.last_enable is False


### PR DESCRIPTION
Fix #1638
Problem: The NVMe-oF transport layer and RBD block device layer were both computing CRC32C checksums on the same data, wasting CPU cycles.

Solution

Config-Driven Optimization (server.py)

Modified` _initialize_rbd_crc32c()` method to read a new config option:` skip_rbd_crc_if_transport_digest`
When enabled, this flag disables RBD-side CRC32C computation entirely
The logic respects explicit `rbd_with_crc32c` settings but allows the skip flag to override them for safety
Added informative logging so operators know when the optimization is active

Configuration Option (ceph-nvmeof.conf)

Added `skip_rbd_crc_if_transport_digest = True/False` option under the [spdk] section
Included safety warnings in comments explaining when to enable (trusted stacks only, no data transformations)

Result: Operators can now eliminate redundant CRC32C recomputation by setting one config flag, reducing CPU overhead on write-heavy workloads while maintaining safety through explicit opt-in and clear warnings.