### PR TITLE
Bug #74265: Remove cli_version field from gateway info output

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -375,8 +375,6 @@ class GatewayClient:
 
         if args.format == "text" or args.format == "plain":
             if gw_info.status == 0:
-                if gw_info.cli_version:
-                    out_func(f"CLI's version: {gw_info.cli_version}")
                 if gw_info.version:
                     out_func(f"Gateway's version: {gw_info.version}")
                 if gw_info.name:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,7 +218,6 @@ class TestGet:
             spdk_ver = os.getenv("NVMEOF_SPDK_VERSION")
         gw_info = cli_test(["gw", "info"])
         assert gw_info is not None
-        assert gw_info.cli_version == cli_ver
         assert gw_info.version == cli_ver
         assert gw_info.spdk_version == spdk_ver
         assert gw_info.name == gw.gateway_name


### PR DESCRIPTION
- Remove cli_version display from gw info command text output
- Remove cli_version assertion from test_cli.py
- Gateway info now only shows gateway version, not CLI version