### PR TITLE
Fix secure listener logic for 'listener list'

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -6057,7 +6057,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                                  active=active,
                                                  manual=True)
                 listeners.append(one_listener)
-                listener_key = (listener.traddr, listener.trsvcid, listener.secure)
+                listener_key = (listener.traddr, listener.trsvcid)
                 omap_listeners.add(listener_key)
             except Exception:
                 self.logger.exception(f"Got exception while parsing {val}")
@@ -6069,7 +6069,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 raise RuntimeError(err_msg)
             state_subsys = state[subsys_key]
             subsystem = json.loads(state_subsys)
-            if subsystem and 'network_mask' in subsystem:
+            if subsystem and subsystem.get('network_mask'):
                 pool = self.config.get("ceph", "pool")
                 group = self.config.get("gateway", "group")
                 nvmemon_listeners = self.ceph_utils.get_gw_listeners(pool, group)
@@ -6085,8 +6085,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                             "traddr": _listener["address"],
                             "secure": secure,
                         }
-                        listener_key = (listener["traddr"], listener["trsvcid"],
-                                        secure)
+                        listener_key = (listener["traddr"], listener["trsvcid"])
                         if listener_key in omap_listeners:
                             continue
                         hostname = GatewayUtils.get_hostname(listener["traddr"], self.logger)


### PR DESCRIPTION
Currently,
Listener list has double entry for manual secure listeners (one from omap and one from "nvme-gw listeners" mon cmd). This is because mon cmd listener output does not say if listener is "secure" so it defaults to secure=False. Then later, while checking if that listener has been processed before, the condition fails `listener_key in omap_listeners` (where secure=True). Hence, it creates double entry in "listener list".

This commit fixes that by checking if listener in mon cmd is already processed in omap listeners with just (ip, port).

Fixes: https://github.com/ceph/ceph-nvmeof/issues/1728
(I checked with `gw listener_info` that only 1 listener was created, "listener list" just displayed duplicate of same entry so we saw 2 listener there.)