### PR TITLE
kmip: add kmip client api

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -604,6 +604,25 @@ jobs:
           make down
           make clean
 
+  kmip_test:
+    needs: [build, build-ceph]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Download container images
+        uses: actions/download-artifact@v4
+        with:
+          name: container_images_nvmeof
+
+      - name: Load container image
+        run: docker load < nvmeof.tar
+
+      - name: Run KMIP test inside container
+        run: |
+          make run SVC="nvmeof" OPTS="--volume=$(pwd)/tests:/src/tests --entrypoint=python3" CMD="tests/kmip/test_kmip_client.py"
+
   atom:
     needs: [build, build-ceph]
     if: github.repository == 'ceph/ceph-nvmeof' && github.event_name != 'schedule'

--- a/control/kmip_client.py
+++ b/control/kmip_client.py
@@ -1,0 +1,263 @@
+#  ############################
+#  Copyright (c) 2026 International Business Machines
+#  All rights reserved.
+#
+#  SPDX-License-Identifier: LGPL-3.0-or-later
+#
+#  Authors: gadi.didi@ibm.com
+#
+
+from typing import List, Optional, Dict, Tuple
+from kmip.pie import client
+from kmip.pie import exceptions
+
+from .utils import GatewayLogger
+from .config import GatewayConfig
+
+
+class NVMeoFKMIPClient:
+
+    """
+    NVMeoFKMIPClient for NVMe-oF gateway
+    Retrieves encryption keys and stores them in memory (volatile)
+    """
+
+    class KMIPConnection:
+        """Single KMIP connection"""
+
+        def __init__(
+            self,
+            hostname: str,
+            port: int,
+            cert: str,
+            key: str,
+            ca: str,
+            gw_logger_object: GatewayLogger,
+        ):
+            """
+            Initialize KMIP connection
+
+            Args:
+                hostname: KMIP server hostname
+                port: KMIP server port
+                cert: Client certificate path
+                key: Client key path
+                ca: CA certificate path
+                logger: Logger instance
+            """
+            self.logger = gw_logger_object.logger
+            self.hostname = hostname
+            self.port = port
+            self.cert = cert
+            self.key = key
+            self.ca = ca
+
+            self.client: Optional[client.ProxyKmipClient] = None
+            self.connected = False
+
+        def connect(self) -> None:
+            """Establish connection to KMIP server"""
+            if self.connected:
+                return
+            try:
+                self.logger.debug(f"Connecting to KMIP server {self.hostname}:{self.port}")
+
+                # Create KMIP client
+                self.client = client.ProxyKmipClient(
+                    hostname=self.hostname,
+                    port=self.port,
+                    cert=self.cert,
+                    key=self.key,
+                    ca=self.ca
+                )
+
+                # Open connection
+                self.client.open()
+
+                self.connected = True
+                self.logger.debug(f"Connected to KMIP server {self.hostname}:{self.port}")
+            except exceptions.ClientConnectionFailure:
+                self.logger.warning(f"Connection already exists to {self.hostname}:{self.port}")
+                return
+
+            except Exception:
+                self.logger.exception(
+                    f"Unexpected error connecting to {self.hostname}:{self.port}")
+                self.connected = False
+                self.client = None
+                raise
+
+        def disconnect(self) -> None:
+            """Close connection"""
+            if not self.connected or self.client is None:
+                self.logger.debug(f"Already disconnected from {self.hostname}:{self.port}")
+                return
+            try:
+                self.client.close()
+                self.logger.debug(f"Disconnected from KMIP server {self.hostname}:{self.port}")
+            except Exception:
+                self.logger.exception(f"Error disconnecting from {self.hostname}:{self.port}")
+                raise
+            finally:
+                self.connected = False
+                self.client = None
+
+        def get_key(self, key_uuid: str) -> bytes:
+            """
+            Retrieve encryption key from KMIP server
+
+            Args:
+                key_uuid: Unique identifier of the key
+
+            Returns:
+                bytes: Encryption key material
+
+            Raises:
+                RuntimeError: If not connected
+                Exception: If retrieval fails
+            """
+            if not self.connected or self.client is None:
+                raise RuntimeError("Not connected to KMIP server")
+            try:
+                self.logger.debug(f"Retrieving key {key_uuid} from KMIP server {self.hostname}")
+                result = self.client.get(key_uuid)
+                key_bytes = result.value
+                self.logger.info(f"Retrieved {len(key_bytes)}-byte key {key_uuid} "
+                                 f"from {self.hostname}:{self.port}")
+                return key_bytes
+            except Exception:
+                self.logger.exception(
+                    f"Error retrieving key {key_uuid} from {self.hostname}:{self.port}")
+                raise
+
+    def __init__(self, logger_config: GatewayConfig, cert_path: str, key_path: str, ca_path: str):
+        """
+        Initialize KMIP client
+
+        Args:
+            logger_config: Logger configuration
+            cert_path: Path to client certificate
+            key_path: Path to client key
+            ca_path: Path to CA certificate
+        """
+        self.gw_logger_object = GatewayLogger(logger_config)
+        self.logger = self.gw_logger_object.logger
+        self.cert_path = cert_path
+        self.key_path = key_path
+        self.ca_path = ca_path
+
+        # Active connections: {hostname: KMIPConnection}
+        self.active_connections: Dict[Tuple[str, int], NVMeoFKMIPClient.KMIPConnection] = {}
+
+    def get_key_for_rbd_image(self, key_uuid: str, servers: List[Tuple[str, int]]) -> bytes:
+        """
+        Get encryption key for RBD image.
+        Tries each server in order until key is found.
+
+        Args:
+            key_uuid: Key UUID string
+            servers: List of KMIP server IP and port tuples
+
+        Returns:
+            bytes: Encryption key material
+
+        Raises:
+            Exception: If failed to connect to any server or retrieve key
+            OR If key not found on any server.
+        """
+        errors = []
+        for hostname, port in servers:
+            try:
+                # Get or create connection to this specific server
+                conn = self._get_or_create_connection(hostname, port)
+                # Try to get the key from this server
+                key_bytes = conn.get_key(key_uuid)
+
+                self.logger.info(f"Successfully retrieved key {key_uuid} from {hostname}:{port}")
+                return key_bytes
+            except Exception as e:
+                # This server doesn't have the key or failed, try next
+                self.logger.warning(f"Failed to get key {key_uuid} from {hostname}:{port}: {e}")
+                errors.append(f"{hostname}:{port}: {e}")
+                continue
+
+        # All servers failed
+        error_msg = f"Key {key_uuid} not found on any KMIP server. Errors: {errors}"
+        self.logger.error(error_msg)
+        raise Exception(error_msg)
+
+    def _get_or_create_connection(
+            self,
+            hostname: str,
+            port: int) -> 'NVMeoFKMIPClient.KMIPConnection':
+        """
+        Get or create connection to a specific server
+
+        Args:
+            hostname: Server hostname
+            port: Server port
+
+        Returns:
+            KMIPConnection: Working connection to this server
+
+        Raises:
+            Exception: If connection fails
+        """
+        server_key = (hostname, port)
+
+        # Check if we already have a connection to this server
+        if server_key in self.active_connections:
+            conn = self.active_connections[server_key]
+            if conn.connected:
+                self.logger.debug(f"Reusing connection to {hostname}:{port}")
+                return conn
+
+        # Create new connection
+        self.logger.debug(f"Creating new connection to {hostname}:{port}")
+
+        conn = NVMeoFKMIPClient.KMIPConnection(
+            hostname=hostname,
+            port=port,
+            cert=self.cert_path,
+            key=self.key_path,
+            ca=self.ca_path,
+            gw_logger_object=self.gw_logger_object
+        )
+
+        # Connect
+        conn.connect()
+
+        # Store in active connections
+        self.active_connections[server_key] = conn
+
+        self.logger.info(f"Successfully connected to {hostname}:{port}")
+        return conn
+
+    def disconnect_all(self) -> None:
+        """Close all connections and clear cache"""
+        self.logger.info("Disconnecting all KMIP connections")
+
+        for server_key, conn in list(self.active_connections.items()):
+            try:
+                conn.disconnect()
+            except Exception:
+                hostname, port = server_key
+                self.logger.exception(f"Error disconnecting from {hostname}:{port}")
+
+        self.active_connections.clear()
+
+        self.logger.info("All KMIP connections closed")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        """
+        Clean up on exit
+        Returns:
+            False: Don't suppress exceptions
+        """
+        try:
+            self.disconnect_all()
+        except Exception:
+            self.logger.exception("Error during cleanup of KMIP connections")

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:10256eb04f2447b7ca6bcc9d09a8612ea82e1aca69bf77f31e27ebaebca9d3e3"
+content_hash = "sha256:944448fbc2aa50608e9484af7bebf452312b4c65683ce72277136c6944a0bb8a"
 
 [[metadata.targets]]
 requires_python = ">3.9.1"
@@ -16,7 +16,7 @@ version = "2.0.0"
 requires_python = ">=3.9"
 summary = "Foreign Function Interface for Python calling C code."
 groups = ["default"]
-marker = "python_full_version >= \"3.9\" and platform_python_implementation != \"PyPy\""
+marker = "platform_python_implementation != \"PyPy\""
 dependencies = [
     "pycparser; implementation_name != \"PyPy\"",
 ]
@@ -121,7 +121,7 @@ files = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.3"
+version = "46.0.4"
 requires_python = "!=3.9.0,!=3.9.1,>=3.8"
 summary = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 groups = ["default"]
@@ -131,60 +131,55 @@ dependencies = [
     "typing-extensions>=4.13.2; python_full_version < \"3.11\"",
 ]
 files = [
-    {file = "cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926"},
-    {file = "cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71"},
-    {file = "cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac"},
-    {file = "cryptography-46.0.3-cp311-abi3-win32.whl", hash = "sha256:f260d0d41e9b4da1ed1e0f1ce571f97fe370b152ab18778e9e8f67d6af432018"},
-    {file = "cryptography-46.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb"},
-    {file = "cryptography-46.0.3-cp311-abi3-win_arm64.whl", hash = "sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c"},
-    {file = "cryptography-46.0.3-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:00a5e7e87938e5ff9ff5447ab086a5706a957137e6e433841e9d24f38a065217"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c8daeb2d2174beb4575b77482320303f3d39b8e81153da4f0fb08eb5fe86a6c5"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:39b6755623145ad5eff1dab323f4eae2a32a77a7abef2c5089a04a3d04366715"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:db391fa7c66df6762ee3f00c95a89e6d428f4d60e7abc8328f4fe155b5ac6e54"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:78a97cf6a8839a48c49271cdcbd5cf37ca2c1d6b7fdd86cc864f302b5e9bf459"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:dfb781ff7eaa91a6f7fd41776ec37c5853c795d3b358d4896fdbb5df168af422"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6f61efb26e76c45c4a227835ddeae96d83624fb0d29eb5df5b96e14ed1a0afb7"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:23b1a8f26e43f47ceb6d6a43115f33a5a37d57df4ea0ca295b780ae8546e8044"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b419ae593c86b87014b9be7396b385491ad7f320bde96826d0dd174459e54665"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:50fc3343ac490c6b08c0cf0d704e881d0d660be923fd3076db3e932007e726e3"},
-    {file = "cryptography-46.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:22d7e97932f511d6b0b04f2bfd818d73dcd5928db509460aaf48384778eb6d20"},
-    {file = "cryptography-46.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d55f3dffadd674514ad19451161118fd010988540cee43d8bc20675e775925de"},
-    {file = "cryptography-46.0.3-cp314-cp314t-win32.whl", hash = "sha256:8a6e050cb6164d3f830453754094c086ff2d0b2f3a897a1d9820f6139a1f0914"},
-    {file = "cryptography-46.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:760f83faa07f8b64e9c33fc963d790a2edb24efb479e3520c14a45741cd9b2db"},
-    {file = "cryptography-46.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:516ea134e703e9fe26bcd1277a4b59ad30586ea90c365a87781d7887a646fe21"},
-    {file = "cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506"},
-    {file = "cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963"},
-    {file = "cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4"},
-    {file = "cryptography-46.0.3-cp38-abi3-win32.whl", hash = "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df"},
-    {file = "cryptography-46.0.3-cp38-abi3-win_amd64.whl", hash = "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f"},
-    {file = "cryptography-46.0.3-cp38-abi3-win_arm64.whl", hash = "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372"},
-    {file = "cryptography-46.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a23582810fedb8c0bc47524558fb6c56aac3fc252cb306072fd2815da2a47c32"},
-    {file = "cryptography-46.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e7aec276d68421f9574040c26e2a7c3771060bc0cff408bae1dcb19d3ab1e63c"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7ce938a99998ed3c8aa7e7272dca1a610401ede816d36d0693907d863b10d9ea"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:191bb60a7be5e6f54e30ba16fdfae78ad3a342a0599eb4193ba88e3f3d6e185b"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c70cc23f12726be8f8bc72e41d5065d77e4515efae3690326764ea1b07845cfb"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:9394673a9f4de09e28b5356e7fff97d778f8abad85c9d5ac4a4b7e25a0de7717"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94cd0549accc38d1494e1f8de71eca837d0509d0d44bf11d158524b0e12cebf9"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6b5063083824e5509fdba180721d55909ffacccc8adbec85268b48439423d78c"},
-    {file = "cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1"},
+    {file = "cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47bcd19517e6389132f76e2d5303ded6cf3f78903da2158a671be8de024f4cd0"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:01df4f50f314fbe7009f54046e908d1754f19d0c6d3070df1e6268c5a4af09fa"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5aa3e463596b0087b3da0dbe2b2487e9fc261d25da85754e30e3b40637d61f81"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0a9ad24359fee86f131836a9ac3bffc9329e956624a2d379b613f8f8abaf5255"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:dc1272e25ef673efe72f2096e92ae39dea1a1a450dd44918b15351f72c5a168e"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:de0f5f4ec8711ebc555f54735d4c673fc34b65c44283895f1a08c2b49d2fd99c"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:eeeb2e33d8dbcccc34d64651f00a98cb41b2dc69cef866771a5717e6734dfa32"},
+    {file = "cryptography-46.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3d425eacbc9aceafd2cb429e42f4e5d5633c6f873f5e567077043ef1b9bbf616"},
+    {file = "cryptography-46.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91627ebf691d1ea3976a031b61fb7bac1ccd745afa03602275dda443e11c8de0"},
+    {file = "cryptography-46.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2d08bc22efd73e8854b0b7caff402d735b354862f1145d7be3b9c0f740fef6a0"},
+    {file = "cryptography-46.0.4-cp311-abi3-win32.whl", hash = "sha256:82a62483daf20b8134f6e92898da70d04d0ef9a75829d732ea1018678185f4f5"},
+    {file = "cryptography-46.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:6225d3ebe26a55dbc8ead5ad1265c0403552a63336499564675b29eb3184c09b"},
+    {file = "cryptography-46.0.4-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:485e2b65d25ec0d901bca7bcae0f53b00133bf3173916d8e421f6fddde103908"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:078e5f06bd2fa5aea5a324f2a09f914b1484f1d0c2a4d6a8a28c74e72f65f2da"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dce1e4f068f03008da7fa51cc7abc6ddc5e5de3e3d1550334eaf8393982a5829"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2067461c80271f422ee7bdbe79b9b4be54a5162e90345f86a23445a0cf3fd8a2"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:c92010b58a51196a5f41c3795190203ac52edfd5dc3ff99149b4659eba9d2085"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:829c2b12bbc5428ab02d6b7f7e9bbfd53e33efd6672d21341f2177470171ad8b"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:62217ba44bf81b30abaeda1488686a04a702a261e26f87db51ff61d9d3510abd"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:9c2da296c8d3415b93e6053f5a728649a87a48ce084a9aaf51d6e46c87c7f2d2"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9b34d8ba84454641a6bf4d6762d15847ecbd85c1316c0a7984e6e4e9f748ec2e"},
+    {file = "cryptography-46.0.4-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:df4a817fa7138dd0c96c8c8c20f04b8aaa1fac3bbf610913dcad8ea82e1bfd3f"},
+    {file = "cryptography-46.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b1de0ebf7587f28f9190b9cb526e901bf448c9e6a99655d2b07fff60e8212a82"},
+    {file = "cryptography-46.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9b4d17bc7bd7cdd98e3af40b441feaea4c68225e2eb2341026c84511ad246c0c"},
+    {file = "cryptography-46.0.4-cp314-cp314t-win32.whl", hash = "sha256:c411f16275b0dea722d76544a61d6421e2cc829ad76eec79280dbdc9ddf50061"},
+    {file = "cryptography-46.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:728fedc529efc1439eb6107b677f7f7558adab4553ef8669f0d02d42d7b959a7"},
+    {file = "cryptography-46.0.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a9556ba711f7c23f77b151d5798f3ac44a13455cc68db7697a1096e6d0563cab"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bf75b0259e87fa70bddc0b8b4078b76e7fd512fd9afae6c1193bcf440a4dbef"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c268a3490df22270955966ba236d6bc4a8f9b6e4ffddb78aac535f1a5ea471d"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:812815182f6a0c1d49a37893a303b44eaac827d7f0d582cecfc81b6427f22973"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:a90e43e3ef65e6dcf969dfe3bb40cbf5aef0d523dff95bfa24256be172a845f4"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a05177ff6296644ef2876fce50518dffb5bcdf903c85250974fc8bc85d54c0af"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:daa392191f626d50f1b136c9b4cf08af69ca8279d110ea24f5c2700054d2e263"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e07ea39c5b048e085f15923511d8121e4a9dc45cee4e3b970ca4f0d338f23095"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d5a45ddc256f492ce42a4e35879c5e5528c09cd9ad12420828c972951d8e016b"},
+    {file = "cryptography-46.0.4-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:6bb5157bf6a350e5b28aee23beb2d84ae6f5be390b2f8ee7ea179cda077e1019"},
+    {file = "cryptography-46.0.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd5aba870a2c40f87a3af043e0dee7d9eb02d4aff88a797b48f2b43eff8c3ab4"},
+    {file = "cryptography-46.0.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:93d8291da8d71024379ab2cb0b5c57915300155ad42e07f76bea6ad838d7e59b"},
+    {file = "cryptography-46.0.4-cp38-abi3-win32.whl", hash = "sha256:0563655cb3c6d05fb2afe693340bc050c30f9f34e15763361cf08e94749401fc"},
+    {file = "cryptography-46.0.4-cp38-abi3-win_amd64.whl", hash = "sha256:fa0900b9ef9c49728887d1576fd8d9e7e3ea872fa9b25ef9b64888adc434e976"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:766330cce7416c92b5e90c3bb71b1b79521760cdcfc3a6a1a182d4c9fab23d2b"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c236a44acfb610e70f6b3e1c3ca20ff24459659231ef2f8c48e879e2d32b73da"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:8a15fb869670efa8f83cbffbc8753c1abf236883225aed74cd179b720ac9ec80"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:fdc3daab53b212472f1524d070735b2f0c214239df131903bae1d598016fa822"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:44cc0675b27cadb71bdbb96099cca1fa051cd11d2ade09e5cd3a2edb929ed947"},
+    {file = "cryptography-46.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be8c01a7d5a55f9a47d1888162b76c8f49d62b234d88f0ff91a9fbebe32ffbc3"},
+    {file = "cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59"},
 ]
 
 [[package]]
@@ -200,6 +195,82 @@ dependencies = [
 files = [
     {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
     {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
+]
+
+[[package]]
+name = "greenlet"
+version = "3.2.4"
+requires_python = ">=3.9"
+summary = "Lightweight in-process concurrent programming"
+groups = ["default"]
+marker = "platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\""
+files = [
+    {file = "greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c"},
+    {file = "greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590"},
+    {file = "greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c"},
+    {file = "greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b"},
+    {file = "greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31"},
+    {file = "greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8854167e06950ca75b898b104b63cc646573aa5fef1353d4508ecdd1ee76254f"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f47617f698838ba98f4ff4189aef02e7343952df3a615f847bb575c3feb177a7"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af41be48a4f60429d5cad9d22175217805098a9ef7c40bfef44f7669fb9d74d8"},
+    {file = "greenlet-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:73f49b5368b5359d04e18d15828eecc1806033db5233397748f4ca813ff1056c"},
+    {file = "greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2"},
+    {file = "greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246"},
+    {file = "greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3"},
+    {file = "greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633"},
+    {file = "greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079"},
+    {file = "greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5"},
+    {file = "greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9"},
+    {file = "greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd"},
+    {file = "greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb"},
+    {file = "greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968"},
+    {file = "greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9"},
+    {file = "greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6"},
+    {file = "greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d"},
+    {file = "greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02"},
+    {file = "greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31"},
+    {file = "greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945"},
+    {file = "greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc"},
+    {file = "greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a"},
+    {file = "greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504"},
+    {file = "greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929"},
+    {file = "greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b"},
+    {file = "greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0"},
+    {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f"},
+    {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5"},
+    {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1"},
+    {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735"},
+    {file = "greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337"},
+    {file = "greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269"},
+    {file = "greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681"},
+    {file = "greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01"},
+    {file = "greenlet-3.2.4-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:b6a7c19cf0d2742d0809a4c05975db036fdff50cd294a93632d6a310bf9ac02c"},
+    {file = "greenlet-3.2.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:27890167f55d2387576d1f41d9487ef171849ea0359ce1510ca6e06c8bece11d"},
+    {file = "greenlet-3.2.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:18d9260df2b5fbf41ae5139e1be4e796d99655f023a636cd0e11e6406cca7d58"},
+    {file = "greenlet-3.2.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:671df96c1f23c4a0d4077a325483c1503c96a1b7d9db26592ae770daa41233d4"},
+    {file = "greenlet-3.2.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:16458c245a38991aa19676900d48bd1a6f2ce3e16595051a4db9d012154e8433"},
+    {file = "greenlet-3.2.4-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9913f1a30e4526f432991f89ae263459b1c64d1608c0d22a5c79c287b3c70df"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b90654e092f928f110e0007f572007c9727b5265f7632c2fa7415b4689351594"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:81701fd84f26330f0d5f4944d4e92e61afe6319dcd9775e39396e39d7c3e5f98"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:28a3c6b7cd72a96f61b0e4b2a36f681025b60ae4779cc73c1535eb5f29560b10"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:52206cd642670b0b320a1fd1cbfd95bca0e043179c1d8a045f2c6109dfe973be"},
+    {file = "greenlet-3.2.4-cp39-cp39-win32.whl", hash = "sha256:65458b409c1ed459ea899e939f0e1cdb14f58dbc803f2f93c5eab5694d32671b"},
+    {file = "greenlet-3.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:d2e685ade4dafd447ede19c31277a224a239a0a1a4eca4e6390efedf20260cfb"},
+    {file = "greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d"},
 ]
 
 [[package]]
@@ -362,7 +433,7 @@ version = "2.23"
 requires_python = ">=3.8"
 summary = "C parser in Python"
 groups = ["default"]
-marker = "python_full_version >= \"3.9\" and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
+marker = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
     {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
@@ -377,6 +448,22 @@ groups = ["test"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+]
+
+[[package]]
+name = "pykmip"
+version = "0.8.0"
+summary = "KMIP v1.1 library"
+groups = ["default"]
+dependencies = [
+    "cryptography",
+    "enum34",
+    "six",
+    "sqlalchemy",
+]
+files = [
+    {file = "PyKMIP-0.8.0-py2.py3-none-any.whl", hash = "sha256:8703e5a6fdc9f9c8c4a7f8c01e69a6f6ce57ce403961211651739716e5c46095"},
+    {file = "PyKMIP-0.8.0.tar.gz", hash = "sha256:1ba25e01d3a4c5a5cfa676bf6c28499f9f15c9d4879c4f7759b7595f0352fc27"},
 ]
 
 [[package]]
@@ -486,6 +573,83 @@ files = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+summary = "Python 2 and 3 compatibility utilities"
+groups = ["default"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.46"
+requires_python = ">=3.7"
+summary = "Database Abstraction Library"
+groups = ["default"]
+dependencies = [
+    "greenlet>=1; platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\"",
+    "importlib-metadata; python_version < \"3.8\"",
+    "typing-extensions>=4.6.0",
+]
+files = [
+    {file = "sqlalchemy-2.0.46-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:895296687ad06dc9b11a024cf68e8d9d3943aa0b4964278d2553b86f1b267735"},
+    {file = "sqlalchemy-2.0.46-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab65cb2885a9f80f979b85aa4e9c9165a31381ca322cbde7c638fe6eefd1ec39"},
+    {file = "sqlalchemy-2.0.46-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52fe29b3817bd191cc20bad564237c808967972c97fa683c04b28ec8979ae36f"},
+    {file = "sqlalchemy-2.0.46-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:09168817d6c19954d3b7655da6ba87fcb3a62bb575fb396a81a8b6a9fadfe8b5"},
+    {file = "sqlalchemy-2.0.46-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:be6c0466b4c25b44c5d82b0426b5501de3c424d7a3220e86cd32f319ba56798e"},
+    {file = "sqlalchemy-2.0.46-cp310-cp310-win32.whl", hash = "sha256:1bc3f601f0a818d27bfe139f6766487d9c88502062a2cd3a7ee6c342e81d5047"},
+    {file = "sqlalchemy-2.0.46-cp310-cp310-win_amd64.whl", hash = "sha256:e0c05aff5c6b1bb5fb46a87e0f9d2f733f83ef6cbbbcd5c642b6c01678268061"},
+    {file = "sqlalchemy-2.0.46-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:261c4b1f101b4a411154f1da2b76497d73abbfc42740029205d4d01fa1052684"},
+    {file = "sqlalchemy-2.0.46-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:181903fe8c1b9082995325f1b2e84ac078b1189e2819380c2303a5f90e114a62"},
+    {file = "sqlalchemy-2.0.46-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:590be24e20e2424a4c3c1b0835e9405fa3d0af5823a1a9fc02e5dff56471515f"},
+    {file = "sqlalchemy-2.0.46-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7568fe771f974abadce52669ef3a03150ff03186d8eb82613bc8adc435a03f01"},
+    {file = "sqlalchemy-2.0.46-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf7e1e78af38047e08836d33502c7a278915698b7c2145d045f780201679999"},
+    {file = "sqlalchemy-2.0.46-cp311-cp311-win32.whl", hash = "sha256:9d80ea2ac519c364a7286e8d765d6cd08648f5b21ca855a8017d9871f075542d"},
+    {file = "sqlalchemy-2.0.46-cp311-cp311-win_amd64.whl", hash = "sha256:585af6afe518732d9ccd3aea33af2edaae4a7aa881af5d8f6f4fe3a368699597"},
+    {file = "sqlalchemy-2.0.46-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3a9a72b0da8387f15d5810f1facca8f879de9b85af8c645138cba61ea147968c"},
+    {file = "sqlalchemy-2.0.46-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2347c3f0efc4de367ba00218e0ae5c4ba2306e47216ef80d6e31761ac97cb0b9"},
+    {file = "sqlalchemy-2.0.46-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9094c8b3197db12aa6f05c51c05daaad0a92b8c9af5388569847b03b1007fb1b"},
+    {file = "sqlalchemy-2.0.46-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37fee2164cf21417478b6a906adc1a91d69ae9aba8f9533e67ce882f4bb1de53"},
+    {file = "sqlalchemy-2.0.46-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b1e14b2f6965a685c7128bd315e27387205429c2e339eeec55cb75ca4ab0ea2e"},
+    {file = "sqlalchemy-2.0.46-cp312-cp312-win32.whl", hash = "sha256:412f26bb4ba942d52016edc8d12fb15d91d3cd46b0047ba46e424213ad407bcb"},
+    {file = "sqlalchemy-2.0.46-cp312-cp312-win_amd64.whl", hash = "sha256:ea3cd46b6713a10216323cda3333514944e510aa691c945334713fca6b5279ff"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:93a12da97cca70cea10d4b4fc602589c4511f96c1f8f6c11817620c021d21d00"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af865c18752d416798dae13f83f38927c52f085c52e2f32b8ab0fef46fdd02c2"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8d679b5f318423eacb61f933a9a0f75535bfca7056daeadbf6bd5bcee6183aee"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64901e08c33462acc9ec3bad27fc7a5c2b6491665f2aa57564e57a4f5d7c52ad"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8ac45e8f4eaac0f9f8043ea0e224158855c6a4329fd4ee37c45c61e3beb518e"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313-win32.whl", hash = "sha256:8d3b44b3d0ab2f1319d71d9863d76eeb46766f8cf9e921ac293511804d39813f"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313-win_amd64.whl", hash = "sha256:77f8071d8fbcbb2dd11b7fd40dedd04e8ebe2eb80497916efedba844298065ef"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1e8cc6cc01da346dc92d9509a63033b9b1bda4fed7a7a7807ed385c7dccdc10"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:96c7cca1a4babaaf3bfff3e4e606e38578856917e52f0384635a95b226c87764"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b2a9f9aee38039cf4755891a1e50e1effcc42ea6ba053743f452c372c3152b1b"},
+    {file = "sqlalchemy-2.0.46-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:db23b1bf8cfe1f7fda19018e7207b20cdb5168f83c437ff7e95d19e39289c447"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56bdd261bfd0895452006d5316cbf35739c53b9bb71a170a331fa0ea560b2ada"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33e462154edb9493f6c3ad2125931e273bbd0be8ae53f3ecd1c161ea9a1dd366"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcdce05f056622a632f1d44bb47dbdb677f58cad393612280406ce37530eb6d"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e84b09a9b0f19accedcbeff5c2caf36e0dd537341a33aad8d680336152dc34e"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4f52f7291a92381e9b4de9050b0a65ce5d6a763333406861e33906b8aa4906bf"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314-win32.whl", hash = "sha256:70ed2830b169a9960193f4d4322d22be5c0925357d82cbf485b3369893350908"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314-win_amd64.whl", hash = "sha256:3c32e993bc57be6d177f7d5d31edb93f30726d798ad86ff9066d75d9bf2e0b6b"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4dafb537740eef640c4d6a7c254611dca2df87eaf6d14d6a5fca9d1f4c3fc0fa"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42a1643dc5427b69aca967dae540a90b0fbf57eaf248f13a90ea5930e0966863"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ff33c6e6ad006bbc0f34f5faf941cfc62c45841c64c0a058ac38c799f15b5ede"},
+    {file = "sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:82ec52100ec1e6ec671563bbd02d7c7c8d0b9e71a0723c72f22ecf52d1755330"},
+    {file = "sqlalchemy-2.0.46-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:90bde6c6b1827565a95fde597da001212ab436f1b2e0c2dcc7246e14db26e2a3"},
+    {file = "sqlalchemy-2.0.46-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b1e5f3a5f1ff4f42d5daab047428cd45a3380e51e191360a35cef71c9a7a2a"},
+    {file = "sqlalchemy-2.0.46-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93bb0aae40b52c57fd74ef9c6933c08c040ba98daf23ad33c3f9893494b8d3ce"},
+    {file = "sqlalchemy-2.0.46-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c4e2cc868b7b5208aec6c960950b7bb821f82c2fe66446c92ee0a571765e91a5"},
+    {file = "sqlalchemy-2.0.46-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:965c62be8256d10c11f8907e7a8d3e18127a4c527a5919d85fa87fd9ecc2cfdc"},
+    {file = "sqlalchemy-2.0.46-cp39-cp39-win32.whl", hash = "sha256:9397b381dcee8a2d6b99447ae85ea2530dcac82ca494d1db877087a13e38926d"},
+    {file = "sqlalchemy-2.0.46-cp39-cp39-win_amd64.whl", hash = "sha256:4396c948d8217e83e2c202fbdcc0389cf8c93d2c1c5e60fa5c5a955eae0e64be"},
+    {file = "sqlalchemy-2.0.46-py3-none-any.whl", hash = "sha256:f9c11766e7e7c0a2767dda5acb006a118640c9fc0a4104214b96269bfb78399e"},
+    {file = "sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7"},
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 requires_python = ">=3.7"
@@ -559,7 +723,6 @@ version = "4.15.0"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
 groups = ["default", "test"]
-marker = "python_version < \"3.11\""
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,12 @@ dependencies = [
     "pyyaml>=6.0.1",
     "prometheus_client ~= 0.19.0",
     "netifaces ~= 0.11.0",
-    "cryptography>=43.0.3"
+    "cryptography>=43.0.3",
+    "PyKMIP"
 ]
+
+[tool.pdm.resolution]
+excludes = ["enum34"]
 
 [tool.pdm.scripts]
 protoc = {call = "grpc_tools.command:build_package_protos('.')"}

--- a/tests/kmip/dummy_kmip_server.py
+++ b/tests/kmip/dummy_kmip_server.py
@@ -1,0 +1,187 @@
+#  ############################
+#  Copyright (c) 2026 International Business Machines
+#  All rights reserved.
+#
+#  SPDX-License-Identifier: LGPL-3.0-or-later
+#
+#  Authors: gadi.didi@ibm.com
+#
+
+"""
+KMIP Mock Server
+
+Usage:
+    # Use defaults (127.0.0.1:5696)
+    python3 dummy_kmip_server.py
+    
+    # Custom port
+    python3 dummy_kmip_server.py --port 5697
+    
+    # Custom address and port
+    python3 dummy_kmip_server.py --address 127.0.0.1 --port 5697
+    
+    # Custom config file
+    python3 dummy_kmip_server.py --config my_server.conf
+    
+    # Custom base directory
+    python3 dummy_kmip_server.py --base-dir /tmp/kmip_test
+"""
+
+import argparse
+from kmip.services.server import KmipServer
+import os
+import sys
+
+def print_separator():
+    print("=" * 70)
+
+
+def create_default_config(address: str, port: int, base_dir: str) -> str:
+    """Create default server config if it doesn't exist"""
+    
+    config_path = os.path.join(base_dir, f'server_{port}.conf')
+    
+    # Don't overwrite existing config
+    if os.path.exists(config_path):
+        return config_path
+    
+    # Ensure directories exist
+    os.makedirs(os.path.join(base_dir, 'certs'), exist_ok=True)
+    os.makedirs(os.path.join(base_dir, 'policies'), exist_ok=True)
+    os.makedirs(os.path.join(base_dir, 'logs'), exist_ok=True)
+    
+    config_content = f"""[server]
+hostname={address}
+port={port}
+certificate_path={base_dir}/certs/server_cert.pem
+key_path={base_dir}/certs/server_key.pem
+ca_path={base_dir}/certs/ca_cert.pem
+auth_suite=TLS1.2
+policy_path={base_dir}/policies
+logging_level=INFO
+database_path={base_dir}/kmip_server_{port}.db
+"""
+    
+    with open(config_path, 'w') as f:
+        f.write(config_content)
+    
+    print(f"Created default config: {config_path}")
+    
+    return config_path
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='KMIP Mock Server',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    
+    parser.add_argument(
+        '--address', '-a',
+        default='127.0.0.1',
+        help='Server address (default: 127.0.0.1)'
+    )
+    
+    parser.add_argument(
+        '--port', '-p',
+        type=int,
+        default=5696,
+        help='Server port (default: 5696)'
+    )
+    
+    parser.add_argument(
+        '--config', '-c',
+        default=None,
+        help='Path to server config file (default: auto-generated)'
+    )
+    
+    parser.add_argument(
+        '--base-dir', '-d',
+        default='.',
+        help='Base directory for config, logs, certs (default: current directory)'
+    )
+    
+    parser.add_argument(
+        '--log-level',
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+        default='DEBUG',
+        help='Logging level (default: DEBUG)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Resolve paths
+    base_dir = os.path.abspath(args.base_dir)
+    
+    # Create directories
+    os.makedirs(os.path.join(base_dir, 'logs'), exist_ok=True)
+    os.makedirs(os.path.join(base_dir, 'policies'), exist_ok=True)
+    
+    # Determine config file
+    if args.config:
+        config_path = args.config
+    else:
+        config_path = create_default_config(args.address, args.port, base_dir)
+    
+    # Log path
+    log_path = os.path.join(base_dir, 'logs', f'kmip_server_{args.port}.log')
+    
+    # Print startup info
+    print_separator()
+    print("KMIP Mock Server")
+    print_separator()
+    print(f"Address:    {args.address}:{args.port}")
+    print(f"Config:     {config_path}")
+    print(f"Logs:       {log_path}")
+    print(f"Base dir:   {base_dir}")
+    print(f"Log level:  {args.log_level}")
+    print("\nPress Ctrl+C to stop")
+    print_separator()
+    
+    # Check if certificates exist
+    cert_path = os.path.join(base_dir, 'certs', 'server_cert.pem')
+    if not os.path.exists(cert_path):
+        print("\nWARNING: Certificates not found!")
+        print(f"   Expected: {os.path.join(base_dir, 'certs')}/*.pem")
+        print("\n   Generate certificates first using setup_kmip_test.sh")
+        print_separator()
+        sys.exit(1)
+    
+    # Create and start server
+    server = KmipServer(
+        config_path=config_path,
+        log_path=log_path
+    )
+    
+    try:
+        # Bind socket
+        server.start()
+        print(f"\n✓ Server socket bound to {args.address}:{args.port}")
+        
+        # Start listening
+        print("Server is now listening for connections...\n")
+        server.serve()
+        
+    except KeyboardInterrupt:
+        print("\n\nShutting down server...")
+        server.stop()
+        print("Server stopped cleanly")
+        
+    except OSError as e:
+        if "Address already in use" in str(e):
+            print(f"\nError: Port {args.port} is already in use")
+            print(f"   Try a different port with: --port <PORT>")
+        else:
+            print(f"\nError: {e}")
+        sys.exit(1)
+        
+    except Exception as e:
+        print(f"\nError: {e}")
+        import traceback
+        traceback.print_exc()
+        server.stop()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/kmip/setup_kmip_test.sh
+++ b/tests/kmip/setup_kmip_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Setup script for KMIP test environment
+
+BASE_DIR=${1:-/tmp/kmip_test}
+CERTS_DIR="$BASE_DIR/certs"
+
+echo "Setting up KMIP test environment in $BASE_DIR"
+
+# Create directories
+mkdir -p "$CERTS_DIR"
+mkdir -p "$BASE_DIR/policies"
+mkdir -p "$BASE_DIR/logs"
+
+cd "$CERTS_DIR"
+
+# Generate CA
+echo "Generating CA certificate..."
+openssl req -x509 -newkey rsa:4096 -sha256 -days 365 \
+  -nodes -keyout ca_key.pem -out ca_cert.pem \
+  -subj "/CN=KMIP Test CA" 2>/dev/null
+
+# Generate server certificate
+echo "Generating server certificate..."
+openssl req -newkey rsa:4096 -nodes \
+  -keyout server_key.pem \
+  -out server_req.pem \
+  -subj "/CN=localhost" 2>/dev/null
+
+cat > server_ext.cnf << EOF
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = DNS:localhost,IP:127.0.0.1
+EOF
+
+openssl x509 -req -in server_req.pem \
+  -CA ca_cert.pem -CAkey ca_key.pem \
+  -CAcreateserial -out server_cert.pem \
+  -days 365 -sha256 \
+  -extfile server_ext.cnf 2>/dev/null
+
+# Generate client certificate
+echo "Generating client certificate..."
+openssl req -newkey rsa:4096 -nodes \
+  -keyout client_key.pem \
+  -out client_req.pem \
+  -subj "/CN=test_client" 2>/dev/null
+
+cat > client_ext.cnf << EOF
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+EOF
+
+openssl x509 -req -in client_req.pem \
+  -CA ca_cert.pem -CAkey ca_key.pem \
+  -CAcreateserial -out client_cert.pem \
+  -days 365 -sha256 \
+  -extfile client_ext.cnf 2>/dev/null
+
+# Verify
+echo ""
+echo "Verifying certificates..."
+openssl verify -CAfile ca_cert.pem server_cert.pem
+openssl verify -CAfile ca_cert.pem client_cert.pem
+
+echo ""
+echo "Setup complete!"
+echo ""
+echo "Run tests with:"
+echo "python3 test_kmip_client.py"

--- a/tests/kmip/test_kmip_client.py
+++ b/tests/kmip/test_kmip_client.py
@@ -1,0 +1,445 @@
+#  ############################
+#  Copyright (c) 2026 International Business Machines
+#  All rights reserved.
+#
+#  SPDX-License-Identifier: LGPL-3.0-or-later
+#
+#  Authors: gadi.didi@ibm.com
+#
+
+"""
+Test script for NVMeoFKMIPClient
+
+Prerequisites:
+1. PyKMIP mock server installed: pip install pykmip
+2. Generate test certificates (see setup_certificates.sh below)
+3. Run this script: python3 test_kmip_client.py
+"""
+
+import subprocess
+import threading
+import time
+import sys
+import os
+from typing import List, Tuple
+
+
+# Get the project root (2 levels up from tests/kmip/)
+project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, project_root)
+
+print(f"Python path: {project_root}")
+
+from control.kmip_client import NVMeoFKMIPClient
+from control.config import GatewayConfig
+from kmip.pie import client
+from kmip.services.server import KmipServer
+from kmip import enums
+
+def print_separator():
+    print("=" * 70)
+
+class KMIPServerManager:
+    """Manages multiple KMIP mock servers for testing"""
+    
+    def __init__(self, base_dir: str):
+        self.base_dir = base_dir
+        self.servers = []  # List of (hostname, port, process)
+    
+    def start_server(self, hostname: str, port: int) -> subprocess.Popen:
+        """Start a KMIP mock server subprocess"""
+
+        # Get path to dummy server script
+        server_script = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            'dummy_kmip_server.py'
+        )
+        # Start server process
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                server_script,
+                '--address', hostname,
+                '--port', str(port),
+                '--base-dir', self.base_dir
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1
+        )
+        self.servers.append((hostname, port, process))
+        
+        # Wait for server to be ready and print output
+        time.sleep(2)
+        
+        # Check if process is still running
+        if process.poll() is not None:
+            # Process died
+            output = process.stdout.read()
+            print(f"Server {hostname}:{port} failed to start:")
+            print(output)
+            raise RuntimeError(f"Server {hostname}:{port} failed to start")
+        
+        print(f"Started KMIP server {hostname}:{port} (PID: {process.pid})")
+
+
+    def stop_all(self):
+        """Stop all running servers"""
+        for hostname, port, process in self.servers:
+            if process.poll() is None:  # Still running
+                print(f"Stopping server {hostname}:{port} (PID: {process.pid})")
+                try:
+                    process.terminate()
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+        
+        # remove the database files (for next test run)
+        for hostname, port, _ in self.servers:
+            db_path = os.path.join(self.base_dir, f'kmip_server_{port}.db')
+            if os.path.exists(db_path):
+                os.remove(db_path)
+
+        self.servers.clear()
+
+ 
+def setup_test_keys(servers: List[Tuple[str, int]], base_dir: str):
+    """
+    Populate KMIP servers with test keys in non-overlapping ranges
+    
+    Server 1: key-1, key-2, key-3 -> UUIDs 1,2,3
+    Server 2: key-1, key-2, key-3, key-4, key-5  -> UUIDs 1,2,3,4,5
+    Server 3: key-1, key-2, key-3, key-4, key-5, key-6, key-7 -> UUIDs 1,2,3,4,5,6,7
+    
+    This way:
+    - key-1, key-2, key-3 exist on ALL servers (UUIDs 1,2,3)
+    - key-4, key-5 exist ONLY on servers 2&3 (UUIDs 4,5)
+    - key-6, key-7 exist ONLY on server 3 (UUIDs 6,7)
+    """
+
+    
+    keys_per_server = [
+        (['key-1', 'key-2', 'key-3'], servers[0]),                              # Server 1: 3 keys
+        (['key-1', 'key-2', 'key-3', 'key-4', 'key-5'], servers[1]),           # Server 2: 5 keys
+        (['key-1', 'key-2', 'key-3', 'key-4', 'key-5', 'key-6', 'key-7'], servers[2])  # Server 3: 7 keys
+    ]
+
+    # Store mapping: {key_name: {(hostname, port): uuid}}
+    key_map = {}
+
+    for key_names, (hostname, port) in keys_per_server:
+        server_num = keys_per_server.index((key_names, (hostname, port))) + 1
+        print(f"\nPopulating Server {server_num} - ({hostname}:{port}) with keys: {key_names}")
+        
+        c = client.ProxyKmipClient(
+            hostname=hostname,
+            port=port,
+            cert=f'{base_dir}/certs/client_cert.pem',
+            key=f'{base_dir}/certs/client_key.pem',
+            ca=f'{base_dir}/certs/ca_cert.pem'
+        )
+        
+        c.open()
+        
+        for key_name in key_names:
+            try:
+                # Create AES-256 key
+                key_uuid = c.create(
+                    algorithm=enums.CryptographicAlgorithm.AES,
+                    length=256,
+                    name=key_name
+                )
+                
+                # Activate it
+                c.activate(key_uuid)
+                
+                # Store mapping
+                if key_name not in key_map:
+                    key_map[key_name] = {}
+                key_map[key_name][(hostname, port)] = key_uuid    
+
+                print(f"  Created key '{key_name}' with UUID: {key_uuid}")
+            except Exception as e:
+                print(f"  Error creating key '{key_name}': {e}")
+        
+        c.close()
+    return key_map
+
+def create_test_config(base_dir: str) -> GatewayConfig:
+    """Create a minimal test config"""
+    config_path = f"{base_dir}/test_gateway.conf"
+    
+    with open(config_path, 'w') as f:
+        f.write("""[gateway]
+name=test-gateway
+
+[gateway-logs]
+log_directory=/tmp/kmip_test_logs
+log_files_enabled=false
+log_level=DEBUG
+""")
+    
+    return GatewayConfig(config_path)
+
+
+def run_tests(base_dir: str, key_map: dict):
+    """Run test scenarios"""
+    
+    print_separator()
+    print("KMIP CLIENT TEST SUITE")
+    print_separator()
+    
+    # Create config
+    config = create_test_config(base_dir)
+    
+    # Initialize KMIP client
+    kmip_client = NVMeoFKMIPClient(
+        logger_config=config,
+        cert_path=f'{base_dir}/certs/client_cert.pem',
+        key_path=f'{base_dir}/certs/client_key.pem',
+        ca_path=f'{base_dir}/certs/ca_cert.pem'
+    )
+    
+    servers = [
+        ('127.0.0.1', 5696),
+        ('127.0.0.1', 5697),
+        ('127.0.0.1', 5698)
+    ]
+
+    # Track test results
+    total_tests = 9
+    passed_tests = 0
+
+
+    print("\nKey Distribution:")
+    print("  Server 1 (5696): key-1, key-2, key-3              (UUIDs: 1,2,3)")
+    print("  Server 2 (5697): key-1, key-2, key-3, key-4, key-5    (UUIDs: 1,2,3,4,5)")
+    print("  Server 3 (5698): key-1, key-2, key-3, key-4, key-5, key-6, key-7 (UUIDs: 1,2,3,4,5,6,7)")
+    print()
+
+    # Test Case 1: Key exists on first server
+    print_separator()
+    print(f"TEST 1: Key exists on first server (GREEN CASE)")
+    print_separator()
+    try:
+        key1_uuid = key_map['key-1'][servers[0]]
+        key = kmip_client.get_key_for_rbd_image(key1_uuid, servers)
+        print(f"SUCCESS: Retrieved key-1 ({len(key)} bytes)")
+        print(f"  First 8 bytes: {key[:8].hex()}")
+        passed_tests += 1
+    except Exception as e:
+        print(f"FAILED: {e}")
+    
+    # Test Case 2: Key-4 NOT on server 1, exists on servers 2&3
+    print_separator()
+    print("TEST 2: Key-4 missing on server 1, exists on servers 2&3")
+    print_separator()
+    try:
+        # key-4 only exists on server 2
+        key4_uuid = key_map['key-4'][servers[1]]
+        key = kmip_client.get_key_for_rbd_image(key4_uuid, servers)
+        print(f"SUCCESS: Retrieved key-4 from server 2 ({len(key)} bytes)")
+        print(f"  First 8 bytes: {key[:8].hex()}")
+        passed_tests += 1
+    except Exception as e:
+        print(f"FAILED: {e}")
+    
+    # Test Case 3: Key exists on multiple servers (should get from first available)
+    print_separator()
+    print("TEST 3: Key exists on multiple servers")
+    print_separator()
+    try:
+        # key-2 exists on both server 1 and server 2
+        key2_uuid = key_map['key-2'][servers[0]]
+        key = kmip_client.get_key_for_rbd_image(key2_uuid, servers)
+        print(f"SUCCESS: Retrieved key-2 (should be from server 1) ({len(key)} bytes)")
+        passed_tests += 1
+    except Exception as e:
+        print(f"FAILED: {e}")
+    
+    # Test Case 4: Connection reuse
+    print_separator()
+    print("TEST 4: Connection reuse (fetch key-1 again)")
+    print_separator()
+    try:
+        key1_uuid = key_map['key-1'][servers[0]]
+        key = kmip_client.get_key_for_rbd_image(key1_uuid, servers)
+        print(f"SUCCESS: Retrieved key-1 using cached connection ({len(key)} bytes)")
+        print(f"  Active connections: {len(kmip_client.active_connections)}")
+        passed_tests += 1
+    except Exception as e:
+        print(f"FAILED: {e}")
+    
+    # Test Case 5: Key doesn't exist on any server
+    print_separator()
+    print("TEST 5: Key doesn't exist on any server")
+    print_separator()
+    try:
+        junk_uuid = '99999' # FYI - the dummy kmip server use simple integer strings as UUIDs..
+        key = kmip_client.get_key_for_rbd_image(junk_uuid, servers)
+        print(f"UNEXPECTED: Should have failed but got key ({len(key)} bytes)")
+    except Exception as e:
+        print(f"SUCCESS: Correctly failed with error")
+        print(f"  Error: {e}")
+        passed_tests += 1
+    
+    # Test Case 6: Wrong server address
+    print_separator()
+    print("TEST 6: Cannot connect to server (wrong address)")
+    print_separator()
+    bad_servers = [
+        ('192.0.2.1', 5696),  # Non-routable address
+        ('127.0.0.1', 5697)   # Good server
+    ]
+    try:
+        # key-4 exists on server 2
+        key4_uuid = key_map['key-4'][servers[1]]
+        key = kmip_client.get_key_for_rbd_image(key4_uuid, bad_servers)
+        print(f"SUCCESS: Failover worked, got key from server 2 ({len(key)} bytes)")
+        passed_tests += 1
+    except Exception as e:
+        print(f"FAILED: {e}")
+    
+    # Test Case 7: All servers unreachable
+    print_separator()
+    print("TEST 7: All servers unreachable")
+    print_separator()
+    bad_servers_all = [
+        ('192.0.2.1', 5696),
+        ('192.0.2.2', 5697),
+    ]
+    try:
+        key1_uuid = key_map['key-1'][servers[0]]
+        key = kmip_client.get_key_for_rbd_image(key1_uuid, bad_servers_all)
+        print(f"UNEXPECTED: Should have failed but got key")
+    except Exception as e:
+        print(f"SUCCESS: Correctly failed")
+        print(f"  Error: {str(e)[:100]}...")
+        passed_tests += 1
+    
+    # Test Case 8: Different key from different server
+    print_separator()
+    print("TEST 8: Fetch key-6 (only on server 3)")
+    print_separator()
+    try:
+        key6_uuid = key_map['key-6'][servers[2]]
+        key = kmip_client.get_key_for_rbd_image(key6_uuid, servers)
+        print(f"SUCCESS: Retrieved key-6 from server 3 ({len(key)} bytes)")
+        print(f"  Active connections: {len(kmip_client.active_connections)}")
+        for server_key in kmip_client.active_connections:
+            print(f"    - {server_key[0]}:{server_key[1]}")
+        passed_tests += 1
+    except Exception as e:
+        print(f"FAILED: {e}")
+    
+    # Test Case 9: Fetch from subset of servers
+    print_separator()
+    print("TEST 9: Fetch key using only servers 2 and 3")
+    print_separator()
+    subset_servers = [
+        ('127.0.0.1', 5697),
+        ('127.0.0.1', 5698)
+    ]
+    try:
+        # key-5 exists on both server 2 and 3
+        key5_uuid = key_map['key-5'][servers[1]]
+        key = kmip_client.get_key_for_rbd_image(key5_uuid, subset_servers)
+        print(f"SUCCESS: Retrieved key-5 from subset ({len(key)} bytes)")
+        passed_tests += 1
+    except Exception as e:
+        print(f"FAILED: {e}")
+    
+    print_separator()
+    print("TEST RESULTS")
+    print_separator()
+    print(f"Total tests: {total_tests}")
+    print(f"Passed:      {passed_tests}")
+    print(f"Failed:      {total_tests - passed_tests}")
+    print_separator()
+
+    # Cleanup
+    print_separator()
+    print("Cleanup: Disconnecting all connections")
+    print_separator()
+    kmip_client.disconnect_all()
+    print(f"Disconnected. Active connections: {len(kmip_client.active_connections)}")
+
+
+def main():
+    """Main test runner"""
+    
+    # first call to setup_kmip_test.sh for initial setup (generate certs, create config, etc)
+
+    try:
+        setup_script = os.path.join(project_root, "tests", "kmip", "setup_kmip_test.sh")
+        result = subprocess.run([setup_script, "/tmp/kmip_test"], check=True, capture_output=True, text=True)
+        print("Setup script output:")
+        print(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Setup script failed: {e}")
+        sys.exit(1)
+
+    base_dir = "/tmp/kmip_test"
+    
+    # Create directory structure
+    os.makedirs(f"{base_dir}/certs", exist_ok=True)
+    os.makedirs(f"{base_dir}/policies", exist_ok=True)
+    os.makedirs(f"{base_dir}/logs", exist_ok=True)
+    
+    print("KMIP Client Test Setup")
+    print("="*70)
+    
+    # Check if certificates exist
+    if not os.path.exists(f"{base_dir}/certs/ca_cert.pem"):
+        print("\nCertificates not found!")
+        print("\nPlease run the setup script first:")
+        print(f"  ./setup_kmip_test.sh {base_dir}")
+        sys.exit(1)
+    
+    print("Certificates found")
+    
+    # Start servers
+    print("\nStarting KMIP mock servers...")
+    server_manager = KMIPServerManager(base_dir)
+    
+    try:
+        # Start 3 servers on different ports
+        servers = [
+            ('127.0.0.1', 5696),
+            ('127.0.0.1', 5697),
+            ('127.0.0.1', 5698)
+        ]
+        
+        for hostname, port in servers:
+            server_manager.start_server(hostname, port)
+        
+        print("All servers started")
+        
+        # Populate servers with keys
+        print("\nPopulating servers with test keys...")
+        key_map = setup_test_keys(servers, base_dir)
+        print("Keys created")
+        
+        # Run tests
+        run_tests(base_dir, key_map)
+        
+        print_separator()
+        print("TEST SUITE COMPLETE")
+        print_separator()
+        
+    except KeyboardInterrupt:
+        print("\n\nTest interrupted by user")
+    except Exception as e:
+        print(f"\nTest setup failed: {e}")
+        import traceback
+        traceback.print_exc()
+    finally:
+        print("\nStopping all servers...")
+        server_manager.stop_all()
+        print("All servers stopped")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Add KMIP integration for secure key management.

Implemented KMIP client for NVMe-oF gateway to retrieve encryption keys from external key management servers.
### Implementation:

`control/kmip_client.py`: Multi-server KMIP client with connection pooling.

### Testing:

`tests/kmip/test_kmip_client.py`: Comprehensive test suite with 9 test cases
`tests/kmip/dummy_kmip_server.py`: Mock KMIP server for testing
`tests/kmip/setup_kmip_test.sh`: Automated cert generation and environment setup
Tests cover: connection reuse, multi-server failover, error handling, key distribution scenarios

### Dependencies:

- Added PyKMIP library for KMIP protocol support
- Excluded enum34 to prevent Python 3.9 stdlib conflicts (enum34 shadows built-in enum module causing AttributeError: module 'enum' has no attribute 'IntFlag')

### CI Integration:

Added kmip_test job to GitHub Actions workflow