### PR TITLE
Add 'list_namespaces_io_stats' grpc call

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -2922,95 +2922,84 @@ class GatewayClient:
         return namespaces_info.status
 
     def ns_get_io_stats(self, args):
-        """Get namespace IO statistics."""
+        """Get namespaces IO statistics."""
 
         out_func, err_func, _ = self.get_output_functions(args)
-        if args.nsid <= 0:
+        if args.nsid and args.nsid <= 0:
             self.cli.parser.error("nsid value must be positive")
 
         try:
-            get_stats_req = pb2.namespace_get_io_stats_req(subsystem_nqn=args.subsystem,
-                                                           nsid=args.nsid)
-            ns_io_stats = self.stub.namespace_get_io_stats(get_stats_req)
+            ns_list_io_stats_req = pb2.list_namespaces_io_stats_req(subsystem_nqn=args.subsystem,
+                                                                    nsid=args.nsid)
+            ns_io_stats = self.stub.list_namespaces_io_stats(ns_list_io_stats_req)
         except Exception as ex:
-            ns_io_stats = pb2.namespace_io_stats_info(
+            ns_io_stats = pb2.list_namespaces_io_stats_info(
                 status=errno.EINVAL,
-                error_message=f"Failure getting namespace's IO stats:\n{ex}")
-
-        if ns_io_stats.status == 0:
-            if ns_io_stats.subsystem_nqn != args.subsystem:
-                ns_io_stats.status = errno.ENODEV
-                ns_io_stats.error_message = f"Failure getting namespace's IO stats: Returned " \
-                                            f"subsystem {ns_io_stats.subsystem_nqn} differs " \
-                                            f"from requested one {args.subsystem}"
-            elif args.nsid and args.nsid != ns_io_stats.nsid:
-                ns_io_stats.status = errno.ENODEV
-                ns_io_stats.error_message = f"Failure getting namespace's IO stats: Returned " \
-                                            f"namespace NSID {ns_io_stats.nsid} differs from " \
-                                            f"requested one {args.nsid}"
-
-        # only show IO errors in verbose mode
-        if not args.verbose:
-            io_stats = pb2.namespace_io_stats_info(
-                status=ns_io_stats.status,
-                error_message=ns_io_stats.error_message,
-                subsystem_nqn=ns_io_stats.subsystem_nqn,
-                nsid=ns_io_stats.nsid,
-                uuid=ns_io_stats.uuid,
-                bdev_name=ns_io_stats.bdev_name,
-                tick_rate=ns_io_stats.tick_rate,
-                ticks=ns_io_stats.ticks,
-                bytes_read=ns_io_stats.bytes_read,
-                num_read_ops=ns_io_stats.num_read_ops,
-                bytes_written=ns_io_stats.bytes_written,
-                num_write_ops=ns_io_stats.num_write_ops,
-                bytes_unmapped=ns_io_stats.bytes_unmapped,
-                num_unmap_ops=ns_io_stats.num_unmap_ops,
-                read_latency_ticks=ns_io_stats.read_latency_ticks,
-                max_read_latency_ticks=ns_io_stats.max_read_latency_ticks,
-                min_read_latency_ticks=ns_io_stats.min_read_latency_ticks,
-                write_latency_ticks=ns_io_stats.write_latency_ticks,
-                max_write_latency_ticks=ns_io_stats.max_write_latency_ticks,
-                min_write_latency_ticks=ns_io_stats.min_write_latency_ticks,
-                unmap_latency_ticks=ns_io_stats.unmap_latency_ticks,
-                max_unmap_latency_ticks=ns_io_stats.max_unmap_latency_ticks,
-                min_unmap_latency_ticks=ns_io_stats.min_unmap_latency_ticks,
-                copy_latency_ticks=ns_io_stats.copy_latency_ticks,
-                max_copy_latency_ticks=ns_io_stats.max_copy_latency_ticks,
-                min_copy_latency_ticks=ns_io_stats.min_copy_latency_ticks)
-            ns_io_stats = io_stats
+                error_message=f"Failure getting namespaces IO stats:\n{ex}")
 
         if args.format == "text" or args.format == "plain":
             if ns_io_stats.status == 0:
-                stats_list = []
-                stats_list.append(["Tick Rate", ns_io_stats.tick_rate])
-                stats_list.append(["Ticks", ns_io_stats.ticks])
-                stats_list.append(["Bytes Read", ns_io_stats.bytes_read])
-                stats_list.append(["Num Read Ops", ns_io_stats.num_read_ops])
-                stats_list.append(["Bytes Written", ns_io_stats.bytes_written])
-                stats_list.append(["Num Write Ops", ns_io_stats.num_write_ops])
-                stats_list.append(["Bytes Unmapped", ns_io_stats.bytes_unmapped])
-                stats_list.append(["Num Unmap Ops", ns_io_stats.num_unmap_ops])
-                stats_list.append(["Read Latency Ticks", ns_io_stats.read_latency_ticks])
-                stats_list.append(["Max Read Latency Ticks", ns_io_stats.max_read_latency_ticks])
-                stats_list.append(["Min Read Latency Ticks", ns_io_stats.min_read_latency_ticks])
-                stats_list.append(["Write Latency Ticks", ns_io_stats.write_latency_ticks])
-                stats_list.append(["Max Write Latency Ticks", ns_io_stats.max_write_latency_ticks])
-                stats_list.append(["Min Write Latency Ticks", ns_io_stats.min_write_latency_ticks])
-                stats_list.append(["Unmap Latency Ticks", ns_io_stats.unmap_latency_ticks])
-                stats_list.append(["Max Unmap Latency Ticks", ns_io_stats.max_unmap_latency_ticks])
-                stats_list.append(["Min Unmap Latency Ticks", ns_io_stats.min_unmap_latency_ticks])
-                stats_list.append(["Copy Latency Ticks", ns_io_stats.copy_latency_ticks])
-                stats_list.append(["Max Copy Latency Ticks", ns_io_stats.max_copy_latency_ticks])
-                stats_list.append(["Min Copy Latency Ticks", ns_io_stats.min_copy_latency_ticks])
-                for e in ns_io_stats.io_error:
-                    if e.value:
-                        stats_list.append([f"IO Error - {e.name}", e.value])
-
-                table_format = "fancy_grid" if args.format == "text" else "plain"
-                stats_out = tabulate(stats_list, headers=["Stat", "Value"], tablefmt=table_format)
-                out_func(f"IO statistics for namespace {args.nsid} in {args.subsystem}, "
-                         f"bdev {ns_io_stats.bdev_name}:\n{stats_out}")
+                ns_iostat_list = []
+                for ns_iostat in ns_io_stats.namespaces:
+                    ns_iostat_list.append([
+                        ns_iostat.bdev_name,
+                        ns_iostat.bytes_read,
+                        ns_iostat.num_read_ops,
+                        ns_iostat.bytes_written,
+                        ns_iostat.num_write_ops,
+                        ns_iostat.bytes_unmapped,
+                        ns_iostat.num_unmap_ops,
+                        ns_iostat.bytes_copied,
+                        ns_iostat.num_copy_ops,
+                        ns_iostat.read_latency_ticks,
+                        ns_iostat.max_read_latency_ticks,
+                        ns_iostat.min_read_latency_ticks,
+                        ns_iostat.write_latency_ticks,
+                        ns_iostat.max_write_latency_ticks,
+                        ns_iostat.min_write_latency_ticks,
+                        ns_iostat.unmap_latency_ticks,
+                        ns_iostat.max_unmap_latency_ticks,
+                        ns_iostat.min_unmap_latency_ticks,
+                        ns_iostat.copy_latency_ticks,
+                        ns_iostat.max_copy_latency_ticks,
+                        ns_iostat.min_copy_latency_ticks,
+                    ])
+                if len(ns_iostat_list) > 0:
+                    table_format = "fancy_grid" if args.format == "text" else "plain"
+                    ns_iostat_out = tabulate(ns_iostat_list,
+                                             headers=[
+                                                 "Name",
+                                                 "Bytes Read",
+                                                 "Num Read Ops",
+                                                 "Bytes Written",
+                                                 "Num Write Ops",
+                                                 "Bytes Unmapped",
+                                                 "Num Unmap Ops",
+                                                 "Bytes Copied",
+                                                 "Num Copy Ops",
+                                                 "Read Latency Ticks",
+                                                 "Max Read Latency Ticks",
+                                                 "Min Read Latency Ticks",
+                                                 "Write Latency Ticks",
+                                                 "Max Write Latency Ticks",
+                                                 "Min Write Latency Ticks",
+                                                 "Unmap Latency Ticks",
+                                                 "Max Unmap Latency Ticks",
+                                                 "Min Unmap Latency Ticks",
+                                                 "Copy Latency Ticks",
+                                                 "Max Copy Latency Ticks",
+                                                 "Min Copy Latency Ticks",
+                                             ],
+                                             tablefmt=table_format)
+                    tick_rate = ns_io_stats.tick_rate
+                    ticks = ns_io_stats.ticks
+                    if args.nsid and args.subsystem:
+                        ns_str = f"IO statistics for namespace {args.nsid} in {args.subsystem}"
+                    else:
+                        ns_str = "IO statistics for all namespaces"
+                    out_func(f"{ns_str}; tick rate={tick_rate} and ticks={ticks}:\n{ns_iostat_out}")
+                else:
+                    out_func("No namespaces found")
             else:
                 err_func(f"{ns_io_stats.error_message}")
         elif args.format == "json" or args.format == "yaml":
@@ -3579,11 +3568,15 @@ class GatewayClient:
                  "-u",
                  help="UUID"),
     ]
-    ns_get_io_stats_args_list = ns_common_args + [
+    ns_get_io_stats_args_list = [
+        argument("--subsystem",
+                 "-n",
+                 help="Subsystem NQN",
+                 required=False),
         argument("--nsid",
                  help="Namespace ID",
                  type=int,
-                 required=True),
+                 required=False),
     ]
     ns_change_load_balancing_group_args_list = ns_common_args + [
         argument("--nsid",
@@ -3709,7 +3702,7 @@ class GatewayClient:
                        "help": "List namespaces"})
     ns_actions.append({"name": "get_io_stats",
                        "args": ns_get_io_stats_args_list,
-                       "help": "Get I/O stats for a namespace"})
+                       "help": "Get I/O stats for namespaces"})
     ns_actions.append({"name": "change_load_balancing_group",
                        "args": ns_change_load_balancing_group_args_list,
                        "help": "Change load balancing group for a namespace"})

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -3919,49 +3919,56 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                    subsystem_nqn=request.subsystem,
                                    namespaces=namespaces)
 
-    def namespace_get_io_stats(self, request, context=None):
-        """Get namespace's IO stats."""
-
-        failure_prefix = f"Failure getting IO stats for namespace {request.nsid} " \
-                         f"on {request.subsystem_nqn}"
+    def list_namespaces_io_stats(self, request, context=None):
+        """Get namespaces IO stats."""
         peer_msg = self.get_peer_message(context)
-        self.logger.info(f"Received request to get IO stats for namespace {request.nsid} on "
-                         f"{request.subsystem_nqn}, context: {context}{peer_msg}")
-        if not request.nsid:
+        self.logger.info(f"Received request to list IO stats for namespaces with "
+                         f"nsid: {request.nsid}, subsystem: {request.subsystem_nqn}, "
+                         f"context: {context}{peer_msg}")
+        failure_prefix = "Failure listing IO stats for namespaces"
+        if (request.nsid):
+            failure_prefix += f" with ID {request.nsid}"
+        if (request.subsystem_nqn):
+            failure_prefix += f" on subsystem {request.subsystem_nqn}"
+
+        if (request.subsystem_nqn and not request.nsid):
             errmsg = "Failure getting IO stats for namespace, missing ID"
             self.logger.error(errmsg)
-            return pb2.namespace_io_stats_info(status=errno.EINVAL, error_message=errmsg)
+            return pb2.list_namespaces_io_stats_info(status=errno.EINVAL, error_message=errmsg)
 
-        if not request.subsystem_nqn:
-            errmsg = f"Failure getting IO stats for namespace {request.nsid}, \
-                missing subsystem NQN"
+        if (request.nsid and not request.subsystem_nqn):
+            errmsg = f"Failure getting IO stats for namespace {request.nsid}, " \
+                     "missing subsystem NQN"
             self.logger.error(errmsg)
-            return pb2.namespace_io_stats_info(status=errno.EINVAL, error_message=errmsg)
+            return pb2.list_namespaces_io_stats_info(status=errno.EINVAL, error_message=errmsg)
 
         # If this is not set the subsystem was not created yet
-        if request.subsystem_nqn not in self.subsys_serial:
+        if request.subsystem_nqn and (request.subsystem_nqn not in self.subsys_serial):
             errmsg = f"Failure getting IO stats for namespace {request.nsid}, can't find " \
                      f"subsystem \"{request.subsystem_nqn}\""
             self.logger.error(errmsg)
-            return pb2.namespace_io_stats_info(status=errno.ENOENT, error_message=errmsg)
+            return pb2.list_namespaces_io_stats_info(status=errno.ENOENT, error_message=errmsg)
 
+        target_bdev_name = None
         with self.rpc_lock:
-            find_ret = self.subsystem_nsid_bdev_and_uuid.find_namespace(
-                request.subsystem_nqn, request.nsid)
-            if find_ret.empty():
-                errmsg = f"{failure_prefix}: Can't find namespace"
-                self.logger.error(errmsg)
-                return pb2.namespace_io_stats_info(status=errno.ENODEV, error_message=errmsg)
-            uuid = find_ret.uuid
-            bdev_name = find_ret.bdev
-            if not bdev_name:
-                errmsg = f"{failure_prefix}: Can't find associated block device"
-                self.logger.error(errmsg)
-                return pb2.namespace_io_stats_info(status=errno.ENODEV, error_message=errmsg)
+            if request.nsid:
+                find_ret = self.subsystem_nsid_bdev_and_uuid.find_namespace(
+                    request.subsystem_nqn, request.nsid)
+                if find_ret.empty():
+                    errmsg = f"{failure_prefix}: Can't find namespace"
+                    self.logger.error(errmsg)
+                    return pb2.list_namespaces_io_stats_info(status=errno.ENODEV,
+                                                             error_message=errmsg)
+                target_bdev_name = find_ret.bdev
+                if not target_bdev_name:
+                    errmsg = f"{failure_prefix}: Can't find associated block device"
+                    self.logger.error(errmsg)
+                    return pb2.list_namespaces_io_stats_info(status=errno.ENODEV,
+                                                             error_message=errmsg)
 
             try:
-                ret = self.spdk_rpc_client.bdev_get_iostat(name=bdev_name)
-                self.logger.debug(f"get_bdev_iostat {bdev_name}: {ret}")
+                ret = self.spdk_rpc_client.bdev_get_iostat(name=target_bdev_name)
+                self.logger.debug(f"get_bdev_iostat: {ret}")
             except Exception as ex:
                 self.logger.exception(failure_prefix)
                 errmsg = f"{failure_prefix}:\n{ex}"
@@ -3970,69 +3977,145 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 if resp:
                     status = resp["code"]
                     errmsg = f"{failure_prefix}: {resp['message']}"
-                return pb2.namespace_io_stats_info(status=status, error_message=errmsg)
+                return pb2.list_namespaces_io_stats_info(status=status, error_message=errmsg)
 
         # Just in case SPDK failed with no exception
         if not ret:
             self.logger.error(failure_prefix)
-            return pb2.namespace_io_stats_info(status=errno.EINVAL, error_message=failure_prefix)
+            return pb2.list_namespaces_io_stats_info(status=errno.EINVAL,
+                                                     error_message=failure_prefix)
 
         exmsg = ""
         try:
             bdevs = ret["bdevs"]
             if not bdevs:
-                return pb2.namespace_io_stats_info(
+                return pb2.list_namespaces_io_stats_info(
                     status=errno.ENODEV,
                     error_message=f"{failure_prefix}: No associated block device found")
-            if len(bdevs) > 1:
-                self.logger.warning("More than one associated block device found for namespace, "
-                                    "will use the first one")
-            bdev = bdevs[0]
-            io_errs = []
-            try:
-                io_error = bdev["io_error"]
-                for err_name in io_error.keys():
-                    one_error = pb2.namespace_io_error(name=err_name, value=io_error[err_name])
-                    io_errs.append(one_error)
-            except Exception:
-                self.logger.exception("failure getting io errors")
-            io_stats = pb2.namespace_io_stats_info(
+
+            if target_bdev_name and len(bdevs) > 1:
+                self.logger.warning("More than one associated block device found for namespace")
+
+            bdev_iostats = []
+            for bdev in bdevs:
+                io_errs = []
+                try:
+                    io_error = bdev["io_error"]
+                    for err_name in io_error.keys():
+                        one_error = pb2.namespace_io_error(name=err_name, value=io_error[err_name])
+                        io_errs.append(one_error)
+                except Exception:
+                    self.logger.exception("failure getting io errors")
+                io_stats = pb2.bdev_io_stats_info(
+                    bdev_name=bdev["name"],
+                    bytes_read=bdev["bytes_read"],
+                    num_read_ops=bdev["num_read_ops"],
+                    bytes_written=bdev["bytes_written"],
+                    num_write_ops=bdev["num_write_ops"],
+                    bytes_unmapped=bdev["bytes_unmapped"],
+                    num_unmap_ops=bdev["num_unmap_ops"],
+                    bytes_copied=bdev["bytes_copied"],
+                    num_copy_ops=bdev["num_copy_ops"],
+                    read_latency_ticks=bdev["read_latency_ticks"],
+                    max_read_latency_ticks=bdev["max_read_latency_ticks"],
+                    min_read_latency_ticks=bdev["min_read_latency_ticks"],
+                    write_latency_ticks=bdev["write_latency_ticks"],
+                    max_write_latency_ticks=bdev["max_write_latency_ticks"],
+                    min_write_latency_ticks=bdev["min_write_latency_ticks"],
+                    unmap_latency_ticks=bdev["unmap_latency_ticks"],
+                    max_unmap_latency_ticks=bdev["max_unmap_latency_ticks"],
+                    min_unmap_latency_ticks=bdev["min_unmap_latency_ticks"],
+                    copy_latency_ticks=bdev["copy_latency_ticks"],
+                    max_copy_latency_ticks=bdev["max_copy_latency_ticks"],
+                    min_copy_latency_ticks=bdev["min_copy_latency_ticks"],
+                    io_error=io_errs)
+                bdev_iostats.append(io_stats)
+            return pb2.list_namespaces_io_stats_info(
                 status=0,
                 error_message=os.strerror(0),
-                subsystem_nqn=request.subsystem_nqn,
-                nsid=request.nsid,
-                uuid=uuid,
-                bdev_name=bdev_name,
                 tick_rate=ret["tick_rate"],
                 ticks=ret["ticks"],
-                bytes_read=bdev["bytes_read"],
-                num_read_ops=bdev["num_read_ops"],
-                bytes_written=bdev["bytes_written"],
-                num_write_ops=bdev["num_write_ops"],
-                bytes_unmapped=bdev["bytes_unmapped"],
-                num_unmap_ops=bdev["num_unmap_ops"],
-                read_latency_ticks=bdev["read_latency_ticks"],
-                max_read_latency_ticks=bdev["max_read_latency_ticks"],
-                min_read_latency_ticks=bdev["min_read_latency_ticks"],
-                write_latency_ticks=bdev["write_latency_ticks"],
-                max_write_latency_ticks=bdev["max_write_latency_ticks"],
-                min_write_latency_ticks=bdev["min_write_latency_ticks"],
-                unmap_latency_ticks=bdev["unmap_latency_ticks"],
-                max_unmap_latency_ticks=bdev["max_unmap_latency_ticks"],
-                min_unmap_latency_ticks=bdev["min_unmap_latency_ticks"],
-                copy_latency_ticks=bdev["copy_latency_ticks"],
-                max_copy_latency_ticks=bdev["max_copy_latency_ticks"],
-                min_copy_latency_ticks=bdev["min_copy_latency_ticks"],
-                io_error=io_errs)
-            return io_stats
+                namespaces=bdev_iostats
+            )
         except Exception as ex:
             self.logger.exception("parse error")
             exmsg = str(ex)
             pass
+        return pb2.list_namespaces_io_stats_info(status=errno.EINVAL,
+                                                 error_message=f"{failure_prefix}: Error "
+                                                 f"parsing returned stats:\n{exmsg}")
 
-        return pb2.namespace_io_stats_info(status=errno.EINVAL,
-                                           error_message=f"{failure_prefix}: Error "
-                                                         f"parsing returned stats:\n{exmsg}")
+    def namespace_get_io_stats(self, request, context=None):
+        """Get namespace's IO stats."""
+
+        failure_prefix = f"Failure getting IO stats for namespace {request.nsid} " \
+                         f"on {request.subsystem_nqn}"
+        peer_msg = self.get_peer_message(context)
+        self.logger.info(f"Received request to get IO stats for namespace {request.nsid} on "
+                         f"{request.subsystem_nqn}, context: {context}{peer_msg}")
+
+        list_req = pb2.list_namespaces_io_stats_req(
+            subsystem_nqn=request.subsystem_nqn,
+            nsid=request.nsid
+        )
+        list_ret = self.list_namespaces_io_stats(list_req, context)
+
+        if list_ret.status != 0:
+            return pb2.namespace_io_stats_info(
+                status=list_ret.status,
+                error_message=list_ret.error_message
+            )
+
+        if not list_ret.namespaces:
+            return pb2.namespace_io_stats_info(
+                status=errno.ENODEV,
+                error_message=f"{failure_prefix}: No namespace found"
+            )
+
+        if len(list_ret.namespaces) > 1:
+            self.logger.warning("Found multiple devices for same ID, will use first one")
+        bdev_stats = list_ret.namespaces[0]
+
+        # get uuid
+        with self.rpc_lock:
+            find_ret = self.subsystem_nsid_bdev_and_uuid.find_namespace(
+                request.subsystem_nqn, request.nsid)
+            if find_ret.empty():
+                return pb2.namespace_io_stats_info(
+                    status=errno.ENODEV,
+                    error_message=f"{failure_prefix}: Can't find namespace"
+                )
+            uuid = find_ret.uuid
+
+        return pb2.namespace_io_stats_info(
+            status=0,
+            error_message=os.strerror(0),
+            subsystem_nqn=request.subsystem_nqn,
+            nsid=request.nsid,
+            uuid=uuid,
+            bdev_name=bdev_stats.bdev_name,
+            tick_rate=list_ret.tick_rate,
+            ticks=list_ret.ticks,
+            bytes_read=bdev_stats.bytes_read,
+            num_read_ops=bdev_stats.num_read_ops,
+            bytes_written=bdev_stats.bytes_written,
+            num_write_ops=bdev_stats.num_write_ops,
+            bytes_unmapped=bdev_stats.bytes_unmapped,
+            num_unmap_ops=bdev_stats.num_unmap_ops,
+            read_latency_ticks=bdev_stats.read_latency_ticks,
+            max_read_latency_ticks=bdev_stats.max_read_latency_ticks,
+            min_read_latency_ticks=bdev_stats.min_read_latency_ticks,
+            write_latency_ticks=bdev_stats.write_latency_ticks,
+            max_write_latency_ticks=bdev_stats.max_write_latency_ticks,
+            min_write_latency_ticks=bdev_stats.min_write_latency_ticks,
+            unmap_latency_ticks=bdev_stats.unmap_latency_ticks,
+            max_unmap_latency_ticks=bdev_stats.max_unmap_latency_ticks,
+            min_unmap_latency_ticks=bdev_stats.min_unmap_latency_ticks,
+            copy_latency_ticks=bdev_stats.copy_latency_ticks,
+            max_copy_latency_ticks=bdev_stats.max_copy_latency_ticks,
+            min_copy_latency_ticks=bdev_stats.min_copy_latency_ticks,
+            io_error=bdev_stats.io_error
+        )
 
     @staticmethod
     def is_optional_field_in_message(request, fld):

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -74,6 +74,9 @@ service Gateway {
 	// Gets namespace's IO stats
 	rpc namespace_get_io_stats(namespace_get_io_stats_req) returns (namespace_io_stats_info) {}
 
+	// List namespaces IO stats
+	rpc list_namespaces_io_stats(list_namespaces_io_stats_req) returns (list_namespaces_io_stats_info) {}
+
 	// Sets namespace's qos limits
 	rpc namespace_set_qos_limits(namespace_set_qos_req) returns (req_status) {}
 
@@ -203,6 +206,11 @@ message namespace_get_io_stats_req {
 	string subsystem_nqn = 1;
 	uint32 nsid = 2;
 	optional string OBSOLETE_uuid = 3;
+}
+
+message list_namespaces_io_stats_req {
+	optional string subsystem_nqn = 1;
+	optional uint32 nsid = 2;
 }
 
 message namespace_set_qos_req {
@@ -736,6 +744,39 @@ message namespaces_info {
 message namespace_io_error {
 	string name = 1;
 	uint32 value = 2;
+}
+
+message list_namespaces_io_stats_info {
+	int32 status = 1;
+	string error_message = 2;
+	uint64 tick_rate = 3;
+	uint64 ticks = 4;
+	repeated bdev_io_stats_info namespaces = 5;
+}
+
+message bdev_io_stats_info {
+	string bdev_name = 1;
+	uint64 bytes_read = 2;
+	uint64 num_read_ops = 3;
+	uint64 bytes_written = 4;
+	uint64 num_write_ops = 5;
+	uint64 bytes_unmapped = 6;
+	uint64 num_unmap_ops = 7;
+	uint64 bytes_copied = 8;
+	uint64 num_copy_ops = 9;
+	uint64 read_latency_ticks = 10;
+	uint64 max_read_latency_ticks = 11;
+	uint64 min_read_latency_ticks = 12;
+	uint64 write_latency_ticks = 13;
+	uint64 max_write_latency_ticks = 14;
+	uint64 min_write_latency_ticks = 15;
+	uint64 unmap_latency_ticks = 16;
+	uint64 max_unmap_latency_ticks = 17;
+	uint64 min_unmap_latency_ticks = 18;
+	uint64 copy_latency_ticks = 19;
+	uint64 max_copy_latency_ticks = 20;
+	uint64 min_copy_latency_ticks = 21;
+	repeated namespace_io_error io_error = 22;
 }
 
 message namespace_io_stats_info {

--- a/tests/ha/ns_lb_change.sh
+++ b/tests/ha/ns_lb_change.sh
@@ -13,10 +13,10 @@ ip2="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end
 calc_written_bytes_in_sec()
 {
    IP=$1
-   num_bytes=$(docker compose run --rm nvmeof-cli --server-address $IP --server-port 5500 --output stdio --format json namespace get_io_stats -n nqn.2016-06.io.spdk:cnode1 --nsid 1 | jq '.bytes_written'| sed 's/[^0-9]*//g');
+   num_bytes=$(docker compose run --rm nvmeof-cli --server-address $IP --server-port 5500 --output stdio --format json namespace get_io_stats -n nqn.2016-06.io.spdk:cnode1 --nsid 1 | jq '.namespaces[0].bytes_written'| sed 's/[^0-9]*//g');
 
   sleep 1;
-  num_bytes1=$(docker compose run --rm nvmeof-cli --server-address $IP --server-port 5500 --output stdio --format json namespace get_io_stats -n nqn.2016-06.io.spdk:cnode1 --nsid 1 | jq '.bytes_written'| sed 's/[^0-9]*//g');
+  num_bytes1=$(docker compose run --rm nvmeof-cli --server-address $IP --server-port 5500 --output stdio --format json namespace get_io_stats -n nqn.2016-06.io.spdk:cnode1 --nsid 1 | jq '.namespaces[0].bytes_written'| sed 's/[^0-9]*//g');
    
   res=$(expr $num_bytes1 - $num_bytes );
   #echo "Bytes written in sec: $res";

--- a/tests/ha/ns_read_only.sh
+++ b/tests/ha/ns_read_only.sh
@@ -15,10 +15,10 @@ function cephnvmf()
 
 calc_written_bytes_in_sec()
 {
-  num_bytes=$(docker compose run --rm nvmeof-cli --server-address $GW_IP --server-port 5500 --output stdio --format json namespace get_io_stats -n $NQN --nsid 1 | jq '.bytes_written'| sed 's/[^0-9]*//g')
+  num_bytes=$(docker compose run --rm nvmeof-cli --server-address $GW_IP --server-port 5500 --output stdio --format json namespace get_io_stats -n $NQN --nsid 1 | jq '.namespaces[0].bytes_written'| sed 's/[^0-9]*//g')
 
   sleep 1
-  num_bytes1=$(docker compose run --rm nvmeof-cli --server-address $GW_IP --server-port 5500 --output stdio --format json namespace get_io_stats -n $NQN --nsid 1 | jq '.bytes_written'| sed 's/[^0-9]*//g')
+  num_bytes1=$(docker compose run --rm nvmeof-cli --server-address $GW_IP --server-port 5500 --output stdio --format json namespace get_io_stats -n $NQN --nsid 1 | jq '.namespaces[0].bytes_written'| sed 's/[^0-9]*//g')
 
   res=$(expr $num_bytes1 - $num_bytes)
   echo $res

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1544,19 +1544,23 @@ class TestCreate:
                "subsystem \"junk\"" in caplog.text
         caplog.clear()
         cli(["namespace", "get_io_stats", "--subsystem", subsystem, "--nsid", "6"])
-        assert f'IO statistics for namespace 6 in {subsystem}' in caplog.text
+        assert f'IO statistics for namespace 6 in {subsystem}; ' in caplog.text
         caplog.clear()
         cli(["--format", "json", "namespace", "get_io_stats",
              "--subsystem", subsystem, "--nsid", "6"])
         assert '"status": 0' in caplog.text
-        assert f'"subsystem_nqn": "{subsystem}"' in caplog.text
-        assert '"nsid": 6,' in caplog.text
-        assert f'"uuid": "{uuid2}"' in caplog.text
         assert '"ticks":' in caplog.text
         assert '"bytes_written":' in caplog.text
         assert '"bytes_read":' in caplog.text
         assert '"max_write_latency_ticks":' in caplog.text
         assert '"io_error":' in caplog.text
+        caplog.clear()
+        cli(["--format", "json", "namespace", "get_io_stats", "--subsystem", subsystem])
+        assert "Failure getting IO stats for namespace, missing ID" in caplog.text
+        caplog.clear()
+        cli(["--format", "json", "namespace", "get_io_stats", "--nsid", "6"])
+        assert "Failure getting IO stats for namespace 6, " \
+               "missing subsystem NQN" in caplog.text
         caplog.clear()
         rc = 0
         try:
@@ -1567,15 +1571,46 @@ class TestCreate:
             pass
         assert "error: unrecognized arguments: --uuid" in caplog.text
         assert rc == 2
+
+    def test_namespace_io_stats_all(self, caplog, gateway):
         caplog.clear()
-        rc = 0
-        try:
-            cli(["--format", "json", "namespace", "get_io_stats", "--subsystem", subsystem])
-        except SystemExit as sysex:
-            rc = sysex.code
-            pass
-        assert "error: the following arguments are required: --nsid" in caplog.text
-        assert rc == 2
+        cli(["namespace", "get_io_stats"])
+        assert 'IO statistics for all namespaces; ' in caplog.text
+        caplog.clear()
+        cli(["--format", "json", "namespace", "get_io_stats"])
+        assert '"status": 0' in caplog.text
+        assert '"ticks":' in caplog.text
+        assert caplog.text.count('"max_write_latency_ticks":') == 12
+        assert caplog.text.count('"bytes_written":') == 12
+        assert caplog.text.count('"bytes_read":') == 12
+        assert caplog.text.count('"io_error":') == 12
+
+    def test_namespace_get_io_stats(self, caplog, gateway):
+        gw, stub = gateway
+        ns_iostat_req = pb2.namespace_get_io_stats_req(
+            subsystem_nqn=subsystem)
+        caplog.clear()
+        ret = stub.namespace_get_io_stats(ns_iostat_req)
+        assert ret.status != 0
+        assert "Failure getting IO stats for namespace, missing ID" in ret.error_message
+        ns_iostat_req = pb2.namespace_get_io_stats_req(
+            nsid=6)
+        caplog.clear()
+        ret = stub.namespace_get_io_stats(ns_iostat_req)
+        assert ret.status != 0
+        assert "Failure getting IO stats for namespace 6, " \
+               "missing subsystem NQN" in ret.error_message
+        ns_iostat_req = pb2.namespace_get_io_stats_req(
+            subsystem_nqn=subsystem,
+            nsid=6)
+        caplog.clear()
+        ret = stub.namespace_get_io_stats(ns_iostat_req)
+        assert ret.status == 0
+        assert ret.nsid == 6
+        assert ret.subsystem_nqn == subsystem
+        assert hasattr(ret, 'tick_rate')
+        assert hasattr(ret, 'ticks')
+        assert hasattr(ret, 'num_write_ops')
 
     def test_host_missing_nqn(self, caplog):
         caplog.clear()


### PR DESCRIPTION
And make namespace_get_io_stats grpc method
wrapper around list_namespaces_io_stats.

Also change "namespace get_io_stats" cli cmd
output from dictionary of bdev stats to list
of bdev stats. Make --nsid & --subsystem optional
args, and return single device stats if present.
Otherwise, return all bdev stats in a list.