### PR TITLE
Validate 'network_mask' in grpc methods

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -1498,7 +1498,7 @@ class GatewayClient:
                  help="Subsystem NQN",
                  required=True),
         argument("--force",
-                 help="Delete subsytem's namespaces if any, then delete subsystem. If not set "
+                 help="Delete subsystem's namespaces if any, then delete subsystem. If not set "
                       "a subsystem deletion would fail in case it contains namespaces",
                  action='store_true', required=False),
         argument("--i-am-sure",

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -1831,6 +1831,15 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                      error_message=errmsg,
                                      nqn=request.subsystem_nqn)
 
+        if request.network_mask:
+            for netmask in list(request.network_mask):
+                if not NICS.is_valid_subnet(netmask):
+                    errmsg = f"{create_subsystem_error_prefix}: Invalid subnet for " \
+                             f"network_mask \"{netmask}\""
+                    self.logger.error(errmsg)
+                    return pb2.subsys_status(status=errno.EADDRNOTAVAIL, error_message=errmsg,
+                                             nqn=request.subsystem_nqn)
+
         errmsg = ""
         if not GatewayState.is_key_element_valid(request.subsystem_nqn):
             errmsg = f"{create_subsystem_error_prefix}: Invalid NQN " \
@@ -2127,6 +2136,23 @@ class GatewayService(pb2_grpc.GatewayServicer):
             f"Received request to add network to subsystem {request.subsystem_nqn}, "
             f"network mask: {request.network_mask}, context: {context}")
 
+        if not request.subsystem_nqn:
+            errmsg = "Failure adding network_mask, missing subsystem NQN"
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+
+        if not request.network_mask:
+            errmsg = f"Failure adding network_mask for subsystem " \
+                     f"{request.subsystem_nqn}: Missing network_mask"
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+
+        if not NICS.is_valid_subnet(request.network_mask):
+            errmsg = f"Failure adding network_mask for subsystem " \
+                     f"{request.subsystem_nqn}: Invalid subnet \"{request.network_mask}\""
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
+
         req_status = 0
         omap_lock = self.omap_lock.get_omap_lock_to_use(context)
         with omap_lock:
@@ -2194,6 +2220,23 @@ class GatewayService(pb2_grpc.GatewayServicer):
         self.logger.info(
             f"Received request to delete network to subsystem {request.subsystem_nqn}, "
             f"network mask: {request.network_mask}, context: {context}")
+
+        if not request.subsystem_nqn:
+            errmsg = "Failure deleting network_mask, missing subsystem NQN"
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+
+        if not request.network_mask:
+            errmsg = f"Failure deleting network_mask for subsystem " \
+                     f"{request.subsystem_nqn}: Missing network_mask"
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
+
+        if not NICS.is_valid_subnet(request.network_mask):
+            errmsg = f"Failure deleting network_mask for subsystem " \
+                     f"{request.subsystem_nqn}: Invalid subnet \"{request.network_mask}\""
+            self.logger.error(errmsg)
+            return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
 
         req_status = 0
         omap_lock = self.omap_lock.get_omap_lock_to_use(context)

--- a/control/utils.py
+++ b/control/utils.py
@@ -819,6 +819,16 @@ class NICS:
                     return True
         return False
 
+    @staticmethod
+    def is_valid_subnet(subnet: str) -> bool:
+        if not subnet:
+            return False
+        try:
+            ipaddress.ip_network(subnet, strict=False)
+            return True
+        except Exception:
+            return False
+
     def get_ips_in_subnet(self, subnet):
         if not subnet:
             return []

--- a/tests/test_auto_listeners.py
+++ b/tests/test_auto_listeners.py
@@ -5,6 +5,7 @@ from control.cli import main as cli
 from control.cli import main_test as cli_test
 from control.cephutils import CephUtils
 import grpc
+from control.proto import gateway_pb2 as pb2
 from control.proto import gateway_pb2_grpc as pb2_grpc
 import time
 
@@ -112,6 +113,54 @@ class TestAutoListener:
         assert listeners.listeners[0].secure
         assert not listeners.listeners[0].manual
 
+    def test_create_subsystem_invalid_network_mask(self, caplog, gateway):
+        _, stub = gateway
+        caplog.clear()
+        serial = "Ceph00000000000001"
+        invalid_subnet = "nosubnet"
+        req = pb2.create_subsystem_req(subsystem_nqn=subsystem, max_namespaces=256,
+                                       serial_number=serial, enable_ha=True,
+                                       network_mask=[invalid_subnet])
+        ret = stub.create_subsystem(req)
+        assert ret.status != 0
+        assert f"Failure creating subsystem {subsystem}: Invalid subnet for " \
+               f"network_mask \"{invalid_subnet}\"" in caplog.text
+
+        caplog.clear()
+        req = pb2.create_subsystem_req(subsystem_nqn=subsystem, max_namespaces=256,
+                                       serial_number=serial, enable_ha=True,
+                                       network_mask=[addr_subnet, invalid_subnet])
+        ret = stub.create_subsystem(req)
+        assert ret.status != 0
+        assert f"Failure creating subsystem {subsystem}: Invalid subnet for " \
+               f"network_mask \"{invalid_subnet}\"" in caplog.text
+        caplog.clear()
+
+    def test_del_network_mask_param_fail(self, caplog, gateway):
+        _, stub = gateway
+        caplog.clear()
+        no_subsystem_param = pb2.del_subsystem_network_req(network_mask=addr_subnet)
+        ret = stub.del_subsystem_network(no_subsystem_param)
+        assert ret.status != 0
+        assert "Failure deleting network_mask, missing subsystem NQN" in caplog.text
+
+        caplog.clear()
+        no_netmask_param = pb2.del_subsystem_network_req(subsystem_nqn=subsystem)
+        ret = stub.del_subsystem_network(no_netmask_param)
+        assert ret.status != 0
+        assert f"Failure deleting network_mask for subsystem {subsystem}: " \
+               "Missing network_mask" in caplog.text
+
+        caplog.clear()
+        invalid_subnet = "nosubnet"
+        invalid_netmask_param = pb2.del_subsystem_network_req(subsystem_nqn=subsystem,
+                                                              network_mask=invalid_subnet)
+        ret = stub.del_subsystem_network(invalid_netmask_param)
+        assert ret.status != 0
+        assert f"Failure deleting network_mask for subsystem {subsystem}: " \
+               f"Invalid subnet \"{invalid_subnet}\"" in caplog.text
+        caplog.clear()
+
     def test_del_network_mask(self, caplog, gateway):
         cli(["subsystem", "list"])
         caplog.clear()
@@ -140,6 +189,31 @@ class TestAutoListener:
         assert listeners.listeners[0].active
         assert not listeners.listeners[0].secure
         assert not listeners.listeners[0].manual
+
+    def test_add_network_mask_param_fail(self, caplog, gateway):
+        _, stub = gateway
+        caplog.clear()
+        no_subsystem_param = pb2.add_subsystem_network_req(network_mask=addr_subnet)
+        ret = stub.add_subsystem_network(no_subsystem_param)
+        assert ret.status != 0
+        assert "Failure adding network_mask, missing subsystem NQN" in caplog.text
+
+        caplog.clear()
+        no_netmask_param = pb2.add_subsystem_network_req(subsystem_nqn=subsystem)
+        ret = stub.add_subsystem_network(no_netmask_param)
+        assert ret.status != 0
+        assert f"Failure adding network_mask for subsystem {subsystem}: " \
+               "Missing network_mask" in caplog.text
+
+        caplog.clear()
+        invalid_subnet = "nosubnet"
+        invalid_netmask_param = pb2.add_subsystem_network_req(subsystem_nqn=subsystem,
+                                                              network_mask=invalid_subnet)
+        ret = stub.add_subsystem_network(invalid_netmask_param)
+        assert ret.status != 0
+        assert f"Failure adding network_mask for subsystem {subsystem}: " \
+               f"Invalid subnet \"{invalid_subnet}\"" in caplog.text
+        caplog.clear()
 
     def test_add_network_mask(self, caplog, gateway):
         cli(["subsystem", "list"])


### PR DESCRIPTION
In grpc method 'add_subsystem_network' and 'del_subsystem_network', fail if 'network_mask' is empty.
This is to properly fail these commands early for new cli calls.