### PR TITLE
grpc: use "network mask" in err msg

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -1865,7 +1865,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
             for netmask in list(request.network_mask):
                 if not NICS.is_valid_subnet(netmask):
                     errmsg = f"{create_subsystem_error_prefix}: Invalid subnet for " \
-                             f"network_mask \"{netmask}\""
+                             f"network mask \"{netmask}\""
                     self.logger.error(errmsg)
                     return pb2.subsys_status(status=errno.EADDRNOTAVAIL, error_message=errmsg,
                                              nqn=request.subsystem_nqn)
@@ -2167,18 +2167,18 @@ class GatewayService(pb2_grpc.GatewayServicer):
             f"network mask: {request.network_mask}, context: {context}")
 
         if not request.subsystem_nqn:
-            errmsg = "Failure adding network_mask, missing subsystem NQN"
+            errmsg = "Failure adding network mask, missing subsystem NQN"
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
         if not request.network_mask:
-            errmsg = f"Failure adding network_mask for subsystem " \
-                     f"{request.subsystem_nqn}: Missing network_mask"
+            errmsg = f"Failure adding network mask for subsystem " \
+                     f"{request.subsystem_nqn}: Missing network mask"
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
         if not NICS.is_valid_subnet(request.network_mask):
-            errmsg = f"Failure adding network_mask for subsystem " \
+            errmsg = f"Failure adding network mask for subsystem " \
                      f"{request.subsystem_nqn}: Invalid subnet \"{request.network_mask}\""
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
@@ -2252,18 +2252,18 @@ class GatewayService(pb2_grpc.GatewayServicer):
             f"network mask: {request.network_mask}, context: {context}")
 
         if not request.subsystem_nqn:
-            errmsg = "Failure deleting network_mask, missing subsystem NQN"
+            errmsg = "Failure deleting network mask, missing subsystem NQN"
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
         if not request.network_mask:
-            errmsg = f"Failure deleting network_mask for subsystem " \
-                     f"{request.subsystem_nqn}: Missing network_mask"
+            errmsg = f"Failure deleting network mask for subsystem " \
+                     f"{request.subsystem_nqn}: Missing network mask"
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
         if not NICS.is_valid_subnet(request.network_mask):
-            errmsg = f"Failure deleting network_mask for subsystem " \
+            errmsg = f"Failure deleting network mask for subsystem " \
                      f"{request.subsystem_nqn}: Invalid subnet \"{request.network_mask}\""
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)

--- a/tests/test_auto_listeners.py
+++ b/tests/test_auto_listeners.py
@@ -124,7 +124,7 @@ class TestAutoListener:
         ret = stub.create_subsystem(req)
         assert ret.status != 0
         assert f"Failure creating subsystem {subsystem}: Invalid subnet for " \
-               f"network_mask \"{invalid_subnet}\"" in caplog.text
+               f"network mask \"{invalid_subnet}\"" in caplog.text
 
         caplog.clear()
         req = pb2.create_subsystem_req(subsystem_nqn=subsystem, max_namespaces=256,
@@ -133,7 +133,7 @@ class TestAutoListener:
         ret = stub.create_subsystem(req)
         assert ret.status != 0
         assert f"Failure creating subsystem {subsystem}: Invalid subnet for " \
-               f"network_mask \"{invalid_subnet}\"" in caplog.text
+               f"network mask \"{invalid_subnet}\"" in caplog.text
         caplog.clear()
 
     def test_del_network_mask_param_fail(self, caplog, gateway):
@@ -142,14 +142,14 @@ class TestAutoListener:
         no_subsystem_param = pb2.del_subsystem_network_req(network_mask=addr_subnet)
         ret = stub.del_subsystem_network(no_subsystem_param)
         assert ret.status != 0
-        assert "Failure deleting network_mask, missing subsystem NQN" in caplog.text
+        assert "Failure deleting network mask, missing subsystem NQN" in caplog.text
 
         caplog.clear()
         no_netmask_param = pb2.del_subsystem_network_req(subsystem_nqn=subsystem)
         ret = stub.del_subsystem_network(no_netmask_param)
         assert ret.status != 0
-        assert f"Failure deleting network_mask for subsystem {subsystem}: " \
-               "Missing network_mask" in caplog.text
+        assert f"Failure deleting network mask for subsystem {subsystem}: " \
+               "Missing network mask" in caplog.text
 
         caplog.clear()
         invalid_subnet = "nosubnet"
@@ -157,7 +157,7 @@ class TestAutoListener:
                                                               network_mask=invalid_subnet)
         ret = stub.del_subsystem_network(invalid_netmask_param)
         assert ret.status != 0
-        assert f"Failure deleting network_mask for subsystem {subsystem}: " \
+        assert f"Failure deleting network mask for subsystem {subsystem}: " \
                f"Invalid subnet \"{invalid_subnet}\"" in caplog.text
         caplog.clear()
 
@@ -196,14 +196,14 @@ class TestAutoListener:
         no_subsystem_param = pb2.add_subsystem_network_req(network_mask=addr_subnet)
         ret = stub.add_subsystem_network(no_subsystem_param)
         assert ret.status != 0
-        assert "Failure adding network_mask, missing subsystem NQN" in caplog.text
+        assert "Failure adding network mask, missing subsystem NQN" in caplog.text
 
         caplog.clear()
         no_netmask_param = pb2.add_subsystem_network_req(subsystem_nqn=subsystem)
         ret = stub.add_subsystem_network(no_netmask_param)
         assert ret.status != 0
-        assert f"Failure adding network_mask for subsystem {subsystem}: " \
-               "Missing network_mask" in caplog.text
+        assert f"Failure adding network mask for subsystem {subsystem}: " \
+               "Missing network mask" in caplog.text
 
         caplog.clear()
         invalid_subnet = "nosubnet"
@@ -211,7 +211,7 @@ class TestAutoListener:
                                                               network_mask=invalid_subnet)
         ret = stub.add_subsystem_network(invalid_netmask_param)
         assert ret.status != 0
-        assert f"Failure adding network_mask for subsystem {subsystem}: " \
+        assert f"Failure adding network mask for subsystem {subsystem}: " \
                f"Invalid subnet \"{invalid_subnet}\"" in caplog.text
         caplog.clear()
 


### PR DESCRIPTION
Use "network mask" in error message instead
of "network_mask".

Fixes: https://github.com/ceph/ceph-nvmeof/pull/1832#discussion_r2975594462


(cherry picked from commit e7370401fba98859c3b8cc893639cba7474af3f5)