### PR TITLE
Add Dockerized KMIP mock server with CLI container

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -153,6 +153,28 @@ jobs:
           path: |
             spdk-arm64.tar
 
+  build-kmip:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build KMIP container images
+        run: |
+          cd tests/kmip
+          make build
+      - name: Save KMIP container images
+        run: |
+          docker save kmip-server:latest > kmip-server.tar
+          docker save kmip-cli:latest > kmip-cli.tar
+      - name: Upload KMIP container images
+        uses: actions/upload-artifact@v4
+        with:
+          name: kmip_images
+          path: |
+            kmip-server.tar
+            kmip-cli.tar
+
   pytest:
     needs: [build, build-ceph]
     strategy:

--- a/tests/kmip/.dockerignore
+++ b/tests/kmip/.dockerignore
@@ -1,0 +1,35 @@
+# Docker ignore file for KMIP server
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Virtual environments
+venv/
+env/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test outputs
+*.log
+*.db
+
+# Documentation (we include README_DOCKER.md explicitly if needed)
+*.md
+!README_DOCKER.md
+
+# Git
+.git/
+.gitignore

--- a/tests/kmip/CLI_CONTAINER_USAGE.md
+++ b/tests/kmip/CLI_CONTAINER_USAGE.md
@@ -1,0 +1,132 @@
+# KMIP CLI Container - Quick Guide
+
+## Build (builds both server and CLI)
+
+```bash
+cd tests/kmip/
+make build
+```
+
+## Simple Usage (Docker Run - Recommended)
+
+### Start Server
+
+```bash
+docker run --network host -d --name kmip-server kmip-server:latest
+```
+
+### Setup Bash Alias
+
+```bash
+# Add to your ~/.bashrc or run in your terminal:
+alias kmip='docker run --network host --rm kmip-cli:latest'
+
+# Now you can use it simply:
+kmip create-passphrase --name "test" --value "secret123"
+kmip list
+kmip get --uuid 1
+kmip destroy --uuid 1
+kmip info --uuid 1
+```
+
+### Without Alias
+
+```bash
+docker run --network host --rm kmip-cli:latest create-passphrase --name "test" --value "secret123"
+```
+
+## Alternative: Docker Compose Usage
+
+### Start Server
+
+```bash
+make run
+```
+
+### Setup Alias
+
+```bash
+alias kmip_cli='docker compose run --rm kmip-cli --hostname kmip-mock-server'
+
+# Use it
+kmip_cli create-passphrase --name "test" --value "secret123"
+```
+
+## Certificate Requirement
+
+**YES, the CLI requires certificates!** KMIP uses TLS client certificate authentication.
+
+The certificates are automatically:
+- Generated when the server image is built
+- Copied into the CLI image during build (multi-stage build)
+- Located at `/kmip/certs/` in both containers
+
+**Both images are self-contained** You don't need to do anything - it's all automatic.
+
+## Quick Example (Docker Run)
+
+```bash
+cd tests/kmip/
+
+# Build
+make build
+
+# Start server
+docker run --network host -d --name kmip-server kmip-server:latest
+
+# Create alias
+alias kmip='docker run --network host --rm kmip-cli:latest'
+
+# Create passphrase
+kmip create-passphrase --name "rbd-key-1" --value "mysecret123"
+# Output: uuid: 1
+
+# Retrieve it
+kmip get --uuid 1
+
+# List all
+kmip list
+
+# Done!
+```
+
+## Quick Example (Docker Compose)
+
+```bash
+cd tests/kmip/
+
+# Build
+make build
+
+# Start server  
+make run
+
+# Create alias
+alias kmip_cli='docker compose run --rm kmip-cli --hostname kmip-mock-server'
+
+# Create passphrase
+kmip_cli create-passphrase --name "rbd-key-1" --value "mysecret123"
+# Output: uuid: 1
+
+# Retrieve it
+kmip_cli get --uuid 1
+
+# Done!
+```
+
+## JSON Output
+
+Use each subcommand's `-o/--output` option to select JSON output:
+```bash
+kmip_cli create-passphrase --name "test" --value "secret" -o json
+# or
+kmip_cli get --uuid 1 --output json
+```
+
+## Summary
+
+✅ `make build` - Builds both server AND CLI containers (server first, then CLI)  
+✅ Certificates are automatic (baked into both images)  
+✅ Use `--network host` for simple networking (defaults work!)  
+✅ No volumes needed - fully self-contained images!  
+✅ Use alias for simple commands

--- a/tests/kmip/Dockerfile
+++ b/tests/kmip/Dockerfile
@@ -1,0 +1,42 @@
+# Dockerfile for KMIP Mock Server
+# This container includes all certificates and is ready to accept client connections
+
+FROM python:3.11-slim
+
+LABEL description="KMIP Mock Server with TLS certificates"
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        openssl \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install PyKMIP
+RUN pip install --no-cache-dir pykmip
+
+# Create working directory
+WORKDIR /kmip
+
+# Create directory structure
+RUN mkdir -p /kmip/certs /kmip/policies /kmip/logs
+
+# Copy server script and setup script
+COPY dummy_kmip_server.py /kmip/
+COPY setup_kmip_test.sh /kmip/
+
+# Make setup script executable
+RUN chmod +x /kmip/setup_kmip_test.sh
+
+# Generate certificates during build (fail-fast if cert generation fails)
+RUN sh -eu /kmip/setup_kmip_test.sh /kmip
+
+# Expose KMIP port
+EXPOSE 5696
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('127.0.0.1', 5696)); s.close()" || exit 1
+
+# Default command - run KMIP server
+CMD ["python3", "dummy_kmip_server.py", "--address", "0.0.0.0", "--port", "5696", "--base-dir", "/kmip"]

--- a/tests/kmip/Dockerfile.cli
+++ b/tests/kmip/Dockerfile.cli
@@ -1,0 +1,35 @@
+# Dockerfile for KMIP CLI Tool
+# Separate container for running KMIP administrative commands
+
+# Stage 1: Get certificates from the server image
+FROM kmip-server:latest AS cert-source
+
+# Stage 2: Build CLI with certificates
+FROM python:3.11-slim
+
+LABEL description="KMIP CLI Tool for managing passphrases"
+
+# Install PyKMIP
+RUN pip install --no-cache-dir pykmip
+
+# Create empty PyKMIP config to suppress warnings
+RUN mkdir -p /root/.pykmip && touch /root/.pykmip/pykmip.conf
+
+# Copy certificates from server image
+COPY --from=cert-source /kmip/certs /kmip/certs
+
+# Create working directory
+WORKDIR /kmip-cli
+
+# Copy CLI script
+COPY kmip_cli.py /kmip-cli/
+
+# Make CLI executable
+RUN chmod +x /kmip-cli/kmip_cli.py
+
+# Set Python path
+ENV PYTHONUNBUFFERED=1
+
+# Default command shows help
+ENTRYPOINT ["python3", "/kmip-cli/kmip_cli.py"]
+CMD ["--help"]

--- a/tests/kmip/Makefile
+++ b/tests/kmip/Makefile
@@ -1,0 +1,76 @@
+# Makefile for KMIP Mock Server Docker deployment
+
+# Python script for testing connection
+define TEST_CONNECTION
+import socket
+import sys
+
+s = socket.socket()
+s.settimeout(2)
+try:
+    s.connect(('127.0.0.1', 5696))
+    print('✓ Server is accepting connections on port 5696')
+    s.close()
+except Exception as e:
+    print(f'✗ Connection failed: {e}')
+    sys.exit(1)
+endef
+export TEST_CONNECTION
+
+# Docker Compose command (can be overridden, e.g., DOCKER_COMPOSE=docker-compose make build)
+DOCKER_COMPOSE ?= docker compose
+
+.PHONY: help build run stop logs shell clean test clean-all
+
+help:
+	@echo "KMIP Mock Server - Docker Commands"
+	@echo "==================================="
+	@echo "build      - Build the Docker image"
+	@echo "run        - Run single KMIP server (port 5696)"
+	@echo "stop       - Stop all running containers"
+	@echo "logs       - Show server logs"
+	@echo "shell      - Access container shell"
+	@echo "test       - Run connection test"
+	@echo "clean      - Stop containers and remove volumes"
+	@echo "clean-all  - Remove everything including images"
+
+build:
+	@echo "Building KMIP server image..."
+	$(DOCKER_COMPOSE) build kmip-server
+	@echo "Building KMIP CLI image (depends on server)..."
+	$(DOCKER_COMPOSE) build kmip-cli
+
+run:
+	@echo "Starting KMIP server on port 5696..."
+	$(DOCKER_COMPOSE) up -d kmip-server
+	@echo "Waiting for server to be ready..."
+	@sleep 3
+	@$(DOCKER_COMPOSE) logs kmip-server
+	@echo ""
+	@echo "KMIP server is running!"
+	@echo "  Port: 5696"
+	@echo "  Logs: make logs"
+
+stop:
+	@echo "Stopping KMIP server..."
+	$(DOCKER_COMPOSE) down
+
+logs:
+	$(DOCKER_COMPOSE) logs -f
+
+shell:
+	$(DOCKER_COMPOSE) exec kmip-server /bin/sh
+test:
+	@echo "Testing KMIP server connection..."
+	@$(DOCKER_COMPOSE) exec -T kmip-server python3 -c "$$TEST_CONNECTION"
+
+clean:
+	@echo "Stopping all containers and removing volumes..."
+	$(DOCKER_COMPOSE) down -v
+	@echo "Cleanup complete"
+
+clean-all: clean
+	@echo "Removing Docker images..."
+	docker rmi kmip-server:latest 2>/dev/null || true
+	docker rmi kmip-cli:latest 2>/dev/null || true
+	@echo "Full cleanup complete"

--- a/tests/kmip/QUICKSTART.md
+++ b/tests/kmip/QUICKSTART.md
@@ -1,0 +1,188 @@
+# KMIP Server Docker - Quick Start Guide
+
+## Overview
+
+This Docker setup provides a ready-to-use KMIP mock server with auto-generated TLS certificates for testing purposes. Both server and CLI images are **self-contained** with certificates baked in.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+- Make (optional, for convenience commands)
+
+## Quick Start
+
+### Option 1: Simple Docker Run (Recommended for Testing)
+
+```bash
+# 1. Build the images (server + CLI)
+cd tests/kmip/
+make build
+
+# 2. Start server
+docker run --network host -d --name kmip-server kmip-server:latest
+
+# 3. Use CLI
+docker run --network host --rm kmip-cli:latest create-passphrase --name mykey --value secret123
+docker run --network host --rm kmip-cli:latest list
+```
+
+### Option 2: Using Docker Compose
+
+```bash
+# 1. Build the images
+make build
+
+# 2. Start the server
+make run
+
+# 3. Use CLI
+docker compose run --rm kmip-cli --hostname kmip-mock-server create-passphrase --name mykey --value secret123
+```
+
+That's it! Your KMIP server is running on `localhost:5696` with TLS certificates ready.
+
+## Manual Commands (without Make)
+
+```bash
+# Build
+docker compose build
+
+# Run
+docker compose up -d kmip-server
+
+# Stop
+docker compose down
+```
+
+## Verify Server is Running
+
+```bash
+# Check status
+docker ps | grep kmip
+
+# View logs
+# If you used Option 1 (Simple Docker Run):
+docker logs kmip-server
+# If you used Option 2 (Docker Compose):
+docker logs kmip-mock-server
+
+# Test connection
+make test
+```
+
+## Using the CLI Container
+
+### With Docker Run (Simplest)
+
+```bash
+# Create alias for convenience
+alias kmip='docker run --network host --rm kmip-cli:latest'
+
+# Use it
+kmip create-passphrase --name "test" --value "secret123"
+kmip list
+kmip get --uuid 1
+kmip destroy --uuid 1
+```
+
+### With Docker Compose
+
+```bash
+# Create alias
+alias kmip_cli='docker compose run --rm kmip-cli --hostname kmip-mock-server'
+
+# Use it
+kmip_cli create-passphrase --name "test" --value "secret123"
+kmip_cli get --uuid 1
+```
+
+See [CLI_CONTAINER_USAGE.md](CLI_CONTAINER_USAGE.md) for complete CLI documentation.
+
+## Available Make Commands
+
+| Command | Description |
+|---------|-------------|
+| `make build` | Build the Docker images (server + CLI) |
+| `make run` | Start single server (port 5696) |
+| `make stop` | Stop all containers |
+| `make logs` | View server logs (follow mode) |
+| `make shell` | Access container shell |
+| `make test` | Test server connection |
+| `make clean` | Stop and remove volumes |
+| `make clean-all` | Remove everything including images |
+
+## Troubleshooting
+
+### Port Already in Use
+
+```bash
+# Check what's using port 5696
+sudo lsof -i :5696
+
+# Or change the port in docker-compose.yml
+ports:
+  - "6000:5696"  # Map to different host port
+```
+
+### Connection Refused
+
+```bash
+# Check if server is running
+docker ps | grep kmip
+
+# Check logs for errors
+docker logs kmip-mock-server
+
+# Verify health
+docker inspect --format='{{.State.Health.Status}}' kmip-mock-server
+```
+
+### Certificate Issues
+
+```bash
+# Rebuild container (regenerates certs)
+make clean-all
+make build
+make run
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│  KMIP Server Container              │
+│  ┌───────────────────────────────┐  │
+│  │ KMIP Server (Python)          │  │
+│  │ - Port: 5696                  │  │
+│  │ - TLS enabled                 │  │
+│  └───────────────────────────────┘  │
+│  ┌───────────────────────────────┐  │
+│  │ Certificates (baked in)       │  │
+│  │ /kmip/certs/                  │  │
+│  │ ├── ca_cert.pem               │  │
+│  │ ├── server_cert.pem           │  │
+│  │ ├── server_key.pem            │  │
+│  │ ├── client_cert.pem           │  │
+│  │ └── client_key.pem            │  │
+│  └───────────────────────────────┘  │
+└────────────┬────────────────────────┘
+             │ --network host
+             ▼
+      localhost:5696
+
+┌─────────────────────────────────────┐
+│  CLI Container (on-demand)          │
+│  ┌───────────────────────────────┐  │
+│  │ kmip_cli.py                   │  │
+│  │ - Passphrase management       │  │
+│  │ - Certs copied from server    │  │
+│  │   during build (multi-stage)  │  │
+│  └───────────────────────────────┘  │
+└─────────────────────────────────────┘
+```
+
+## Integration with Tests
+
+To use with the test suite, see [test_kmip_client.py](test_kmip_client.py).
+

--- a/tests/kmip/docker-compose.yml
+++ b/tests/kmip/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  kmip-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: kmip-server:latest
+    container_name: kmip-mock-server
+    ports:
+      - "5696:5696"
+    volumes:
+      # Persist logs in the named volume
+      - kmip-data:/kmip/logs
+    restart: unless-stopped
+    networks:
+      - kmip-net
+
+  # KMIP CLI Tool - for running administrative commands
+  kmip-cli:
+    build:
+      context: .
+      dockerfile: Dockerfile.cli
+    image: kmip-cli:latest
+    container_name: kmip-cli
+    networks:
+      - kmip-net
+    depends_on:
+      - kmip-server
+
+volumes:
+  kmip-data:
+
+networks:
+  kmip-net:
+    driver: bridge

--- a/tests/kmip/kmip_cli.py
+++ b/tests/kmip/kmip_cli.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+#  ############################
+#  Copyright (c) 2026 International Business Machines
+#  All rights reserved.
+#
+#  SPDX-License-Identifier: LGPL-3.0-or-later
+#
+#  Authors: gadi.didi@ibm.com
+#
+
+"""
+KMIP Administrative CLI Tool
+
+Manage passphrases/secrets on a KMIP server
+
+Usage:
+    # Create and activate a passphrase in one step
+    kmip_cli.py create-passphrase --name "my-secret" --value "secretdata"
+
+    # Retrieve a passphrase
+    kmip_cli.py get --uuid <uuid>
+
+    # Destroy a passphrase
+    kmip_cli.py destroy --uuid <uuid>
+
+    # Get passphrase info
+    kmip_cli.py info --uuid <uuid>
+"""
+
+import argparse
+import sys
+import json
+from typing import Optional, Dict, Any
+from kmip.pie import client
+from kmip.pie import objects
+from kmip import enums
+
+
+class KMIPCli:
+    """KMIP Command Line Interface"""
+
+    def __init__(
+        self,
+        hostname: str = '127.0.0.1',
+        port: int = 5696,
+        cert: str = '/kmip/certs/client_cert.pem',
+        key: str = '/kmip/certs/client_key.pem',
+        ca: str = '/kmip/certs/ca_cert.pem',
+        json_output: bool = False
+    ):
+        """Initialize KMIP CLI"""
+        self.hostname = hostname
+        self.port = port
+        self.cert = cert
+        self.key = key
+        self.ca = ca
+        self.json_output = json_output
+        self.client: Optional[client.ProxyKmipClient] = None
+
+    def connect(self) -> None:
+        """Establish connection to KMIP server"""
+        try:
+            self.client = client.ProxyKmipClient(
+                hostname=self.hostname,
+                port=self.port,
+                cert=self.cert,
+                key=self.key,
+                ca=self.ca
+            )
+            self.client.open()
+        except Exception as e:
+            self._error(f"Failed to connect to KMIP server {self.hostname}:{self.port}: {e}")
+            sys.exit(1)
+
+    def disconnect(self) -> None:
+        """Close connection to KMIP server"""
+        if self.client:
+            try:
+                self.client.close()
+            except Exception:
+                pass
+
+    def _output(self, message: str, data: Optional[Dict[str, Any]] = None) -> None:
+        """Output message or JSON"""
+        if self.json_output:
+            output = {"status": "success", "message": message}
+            if data:
+                output.update(data)
+            print(json.dumps(output, indent=2))
+        else:
+            print(message)
+            if data:
+                for key, value in data.items():
+                    print(f"  {key}: {value}")
+
+    def _error(self, message: str) -> None:
+        """Output error message"""
+        if self.json_output:
+            print(json.dumps({"status": "error", "message": message}, indent=2))
+        else:
+            print(f"ERROR: {message}", file=sys.stderr)
+
+    def create_passphrase(self, name: str, value: str) -> None:
+        """Create and activate a passphrase/secret in one step"""
+        try:
+            # Create passphrase
+            secret_data = objects.SecretData(
+                value.encode(),
+                enums.SecretDataType.PASSWORD,
+                masks=[enums.CryptographicUsageMask.DERIVE_KEY],
+                name=name
+            )
+
+            secret_uuid = self.client.register(secret_data)
+
+            # Activate it immediately
+            self.client.activate(secret_uuid)
+
+            self._output(
+                f"Created and activated passphrase '{name}'",
+                {"uuid": secret_uuid, "name": name, "type": "passphrase", "state": "active"}
+            )
+
+        except Exception as e:
+            self._error(f"Failed to create passphrase: {e}")
+            sys.exit(1)
+
+    def get_passphrase(self, passphrase_uuid: str) -> None:
+        """Retrieve and display a passphrase"""
+        try:
+            passphrase_data = self.client.get(passphrase_uuid)
+            passphrase_bytes = passphrase_data.value
+
+            preview = passphrase_bytes[:32].decode('utf-8', errors='replace')
+            if len(passphrase_bytes) > 32:
+                preview += "..."
+            else:
+                preview = passphrase_bytes.decode('utf-8', errors='replace')
+
+            self._output(
+                f"Retrieved passphrase {passphrase_uuid}",
+                {
+                    "uuid": passphrase_uuid,
+                    "length_bytes": len(passphrase_bytes),
+                    "value_preview": preview
+                }
+            )
+
+        except Exception as e:
+            self._error(f"Failed to retrieve passphrase {passphrase_uuid}: {e}")
+            sys.exit(1)
+
+    def destroy_passphrase(self, passphrase_uuid: str) -> None:
+        """Destroy a passphrase"""
+        try:
+            self.client.destroy(passphrase_uuid)
+            self._output(
+                f"Destroyed passphrase {passphrase_uuid}",
+                {"uuid": passphrase_uuid, "state": "destroyed"}
+            )
+
+        except Exception as e:
+            self._error(f"Failed to destroy passphrase {passphrase_uuid}: {e}")
+            sys.exit(1)
+
+    def get_passphrase_info(self, passphrase_uuid: str) -> None:
+        """Get passphrase metadata"""
+        try:
+            # Get attributes
+            attrs = self.client.get_attributes(uid=passphrase_uuid)
+
+            info = {
+                "uuid": passphrase_uuid,
+                "attributes": {}
+            }
+
+            # Extract useful attributes
+            for attr in attrs:
+                if hasattr(attr, 'attribute_name'):
+                    attr_name = attr.attribute_name.value
+                else:
+                    attr_name = str(attr)
+
+                if hasattr(attr, 'attribute_value'):
+                    attr_value = str(attr.attribute_value)
+                else:
+                    attr_value = str(attr)
+
+                info["attributes"][attr_name] = attr_value
+
+            self._output(f"Passphrase information for {passphrase_uuid}", info)
+
+        except Exception as e:
+            self._error(f"Failed to get passphrase info for {passphrase_uuid}: {e}")
+            sys.exit(1)
+
+    def list_passphrases(self) -> None:
+        """List all passphrase UUIDs"""
+        try:
+            # Locate all secret data objects
+            uuids = self.client.locate()
+
+            if not uuids:
+                self._output("No passphrases found")
+            else:
+                if self.json_output:
+                    self._output(
+                        f"Found {len(uuids)} passphrase(s)",
+                        {"count": len(uuids), "uuids": uuids}
+                    )
+                else:
+                    # For text, print header then manually loop for custom format
+                    print(f"Found {len(uuids)} passphrase(s):")
+                    for uuid in uuids:
+                        print(f" uuid: {uuid}")
+
+        except Exception as e:
+            self._error(f"Failed to list passphrases: {e}")
+            sys.exit(1)
+
+
+def main():
+    """Main CLI entry point"""
+    parser = argparse.ArgumentParser(
+        description='KMIP Administrative CLI Tool',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    # Connection arguments
+    parser.add_argument(
+        '--hostname', '-H',
+        default='127.0.0.1',
+        help='KMIP server hostname (default: 127.0.0.1)'
+    )
+
+    parser.add_argument(
+        '--port', '-P',
+        type=int,
+        default=5696,
+        help='KMIP server port (default: 5696)'
+    )
+
+    parser.add_argument(
+        '--cert',
+        default='/kmip/certs/client_cert.pem',
+        help='Client certificate path (default: /kmip/certs/client_cert.pem)'
+    )
+
+    parser.add_argument(
+        '--key',
+        default='/kmip/certs/client_key.pem',
+        help='Client key path (default: /kmip/certs/client_key.pem)'
+    )
+
+    parser.add_argument(
+        '--ca',
+        default='/kmip/certs/ca_cert.pem',
+        help='CA certificate path (default: /kmip/certs/ca_cert.pem)'
+    )
+
+    # Subcommands
+    subparsers = parser.add_subparsers(dest='command', help='Commands')
+
+    # create-passphrase (auto-activates)
+    create_pass_parser = subparsers.add_parser(
+        'create-passphrase',
+        help='Create and activate a passphrase/secret in one step'
+    )
+    create_pass_parser.add_argument(
+        '--name', required=True, help='Passphrase name (for reference)')
+    create_pass_parser.add_argument(
+        '--value', required=True, help='Passphrase value')
+    create_pass_parser.add_argument(
+        '-o', '--output', choices=['text', 'json'],
+        default='text', help='Output format')
+
+    # get
+    get_parser = subparsers.add_parser('get', help='Retrieve a passphrase')
+    get_parser.add_argument('--uuid', required=True, help='Passphrase UUID')
+    get_parser.add_argument(
+        '-o', '--output', choices=['text', 'json'],
+        default='text', help='Output format')
+
+    # destroy
+    destroy_parser = subparsers.add_parser(
+        'destroy', help='Destroy a passphrase')
+    destroy_parser.add_argument('--uuid', required=True, help='Passphrase UUID')
+    destroy_parser.add_argument(
+        '-o', '--output', choices=['text', 'json'],
+        default='text', help='Output format')
+
+    # info
+    info_parser = subparsers.add_parser(
+        'info', help='Get passphrase metadata')
+    info_parser.add_argument('--uuid', required=True, help='Passphrase UUID')
+    info_parser.add_argument(
+        '-o', '--output', choices=['text', 'json'],
+        default='text', help='Output format')
+
+    # list
+    list_parser = subparsers.add_parser(
+        'list', help='List all passphrase UUIDs')
+    list_parser.add_argument(
+        '-o', '--output', choices=['text', 'json'],
+        default='text', help='Output format')
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    cli = KMIPCli(
+        hostname=args.hostname,
+        port=args.port,
+        cert=args.cert,
+        key=args.key,
+        ca=args.ca,
+        json_output=(args.output == 'json')
+    )
+
+    # Connect to server
+    cli.connect()
+
+    try:
+        # Execute command
+        if args.command == 'create-passphrase':
+            cli.create_passphrase(args.name, args.value)
+
+        elif args.command == 'get':
+            cli.get_passphrase(args.uuid)
+
+        elif args.command == 'destroy':
+            cli.destroy_passphrase(args.uuid)
+
+        elif args.command == 'info':
+            cli.get_passphrase_info(args.uuid)
+
+        elif args.command == 'list':
+            cli.list_passphrases()
+
+    finally:
+        cli.disconnect()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/kmip/setup_kmip_test.sh
+++ b/tests/kmip/setup_kmip_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Setup script for KMIP test environment
 
 BASE_DIR=${1:-/tmp/kmip_test}


### PR DESCRIPTION
fixed:  https://github.com/ceph/ceph-nvmeof/issues/1859

## KMIP Mock Server - Docker Setup

Adds containerized KMIP server for testing RBD encryption with passphrases.

### What's included:

**Server:**
- Docker container with PyKMIP mock server
- TLS certificates auto-generated during build

**CLI Tool:**
- Separate container for server management.
- Commands: create, get, list, destroy, info

**Usage:**
```bash
# Start server
make build && make run

# Use CLI
alias kmip_cli='docker compose run --rm kmip-cli --hostname kmip-mock-server'

kmip_cli create-passphrase --name "test" --value "secret123"
kmip_cli list
kmip_cli get --uuid 1 -o json
```

**Artifact:**
the GitHub Action will deploy the tar files for CLI and kmip server. 

Files:
Dockerfile - Server container
Dockerfile.cli - CLI container
docker-compose.yml- Orchestration
kmip_cli.py- CLI tool
Makefile - Build/run shortcuts
QUICKSTART.md- Quick start guide
CLI_CONTAINER_USAGE.md- CLI documentation