### PR TITLE
bump atom to fix use_ceph_cli param value

### DIFF
--- a/.env
+++ b/.env
@@ -72,7 +72,7 @@ CEPH_SHA=latest
 CEPH_DEVEL_MGR_PATH=../ceph
 
 # Atom
-ATOM_SHA=5aa694071c43d6e394db2f43c9919dae5dd051f8
+ATOM_SHA=80a40ad03f151d580ff58af1c8c4e3494613d94f
 
 # Demo settings
 RBD_POOL=rbd


### PR DESCRIPTION
the `use_ceph_cli` param was not used in atom.py. this PR fixes it by bumping atom.