### PR TITLE
Handle IPs overlap between networks in del_network

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -1233,7 +1233,7 @@ class GatewayClient:
     def subsystem_add_network_mask(self, args):
         """Add subsystem's network mask"""
 
-        out_func, err_func, _ = self.get_output_functions(args)
+        out_func, err_func, wrn_func = self.get_output_functions(args)
 
         req = pb2.add_subsystem_network_req(subsystem_nqn=args.subsystem,
                                             network_mask=args.network_mask)
@@ -1245,8 +1245,10 @@ class GatewayClient:
 
         if args.format == "text" or args.format == "plain":
             if ret.status == 0:
-                out_func(f"Network mask {args.network_mask} added to subsystem "
+                out_func(f"Adding network mask {args.network_mask} to subsystem "
                          f"{args.subsystem}: Successful")
+                if ret.error_message:
+                    wrn_func(ret.error_message)
             else:
                 err_func(f"{ret.error_message}")
         elif args.format == "json" or args.format == "yaml":
@@ -1268,7 +1270,7 @@ class GatewayClient:
     def subsystem_del_network_mask(self, args):
         """Delete subsystem's network mask"""
 
-        out_func, err_func, _ = self.get_output_functions(args)
+        out_func, err_func, wrn_func = self.get_output_functions(args)
 
         req = pb2.del_subsystem_network_req(subsystem_nqn=args.subsystem,
                                             network_mask=args.network_mask)
@@ -1280,8 +1282,10 @@ class GatewayClient:
 
         if args.format == "text" or args.format == "plain":
             if ret.status == 0:
-                out_func(f"Network mask {args.network_mask} deleted for subsystem "
+                out_func(f"Deleting network mask {args.network_mask} from subsystem "
                          f"{args.subsystem}: Successful")
+                if ret.error_message:
+                    wrn_func(ret.error_message)
             else:
                 err_func(f"{ret.error_message}")
         elif args.format == "json" or args.format == "yaml":

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -2115,6 +2115,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
     def add_listeners(self, subsystem_nqn, ip_list, is_secure, port):
         req_status = 0
+        nics = NICS(self.logger, True)
         for ip in ip_list:
             hostname = self.host_name
             if not port:
@@ -2124,6 +2125,10 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     port = GatewayService.LISTENER_PORT_DEFAULT
             adrfam = f'ipv{ip_address(ip).version}'
             secure = is_secure
+            if not nics.verify_ip_address(ip, adrfam):
+                self.logger.info(f'Skip to create auto-listener at {ip} for {subsystem_nqn}: '
+                                 f'Address not available as {adrfam} address')
+                continue
             lstnr_req = pb2.create_listener_req(
                 nqn=subsystem_nqn,
                 host_name=hostname,
@@ -2349,15 +2354,31 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     return pb2.req_status(status=0, error_message="")
 
                 found_ips = NICS(self.logger, True).get_ips_in_subnet(network_to_delete)
-                req_status = self.del_listeners(request.subsystem_nqn, found_ips,
+
+                existing_network_mask.remove(network_to_delete)
+                remaining_network_masks = list(existing_network_mask)
+
+                ips_to_delete = []
+                ips_to_keep = []
+                for ip in found_ips:
+                    if NICS.is_ip_in_network_masks(ip, remaining_network_masks):
+                        ips_to_keep.append(ip)
+                    else:
+                        ips_to_delete.append(ip)
+
+                if ips_to_keep:
+                    self.logger.info(f"Keeping {len(ips_to_keep)} auto-listener(s) for "
+                                     f"{request.subsystem_nqn}: {ips_to_keep} still covered by "
+                                     f"remaining network masks {remaining_network_masks}")
+
+                req_status = self.del_listeners(request.subsystem_nqn, ips_to_delete,
                                                 subsys_entry.secure_listeners, subsys_entry.port)
                 if req_status != 0:
                     self.logger.error(f'Failed to delete all listeners under network mask '
-                                      f'{request.network_mask} (all IPs: {found_ips}) '
+                                      f'{request.network_mask} (tried to remove: {ips_to_delete}) '
                                       f'for subsystem {request.subsystem_nqn}.')
                 else:
-                    existing_network_mask.remove(network_to_delete)
-                    new_network_mask = list(existing_network_mask)
+                    new_network_mask = remaining_network_masks
                     self.subsys_network[request.subsystem_nqn] = new_network_mask
                     if context:
                         # remove listener from subsystem's OMAP

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -2097,10 +2097,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
         if request.network_mask and context:
             try:
                 rt = self._create_auto_listeners_safe(request)
-                if rt.status != 0:
-                    error_message = f"Subsystem {request.subsystem_nqn} created successfully; " \
-                                    f"Failed to create one or more NVMeoF listeners " \
-                                    f"(network mask). You can try adding these listeners manually."
+                error_message = rt.error_message
             except Exception:
                 error_message = f"Created subsystem {request.subsystem_nqn}. " \
                                 f"An error occurred when adding network mask. Try " \
@@ -2114,7 +2111,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
         return self.execute_grpc_function(self.create_subsystem_safe, request, context, err_prefix)
 
     def add_listeners(self, subsystem_nqn, ip_list, is_secure, port):
-        req_status = 0
+        final_err_msg = ""
         nics = NICS(self.logger, True)
         for ip in ip_list:
             hostname = self.host_name
@@ -2139,21 +2136,22 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 verify_host_name=False)
             rt = self.create_listener_safe(lstnr_req, None)
             status = rt.status
-            if status != 0:
-                errmsg = f"Failure creating auto-listeners for {subsystem_nqn} " \
-                         f"subsystem: {rt.error_message}"
-                self.logger.error(errmsg)
-                if status != errno.EEXIST:
-                    req_status = status
-            else:
-                ip_ = GatewayUtils.escape_address_if_ipv6(ip)
+            ip_ = GatewayUtils.escape_address_if_ipv6(ip)
+            if status == 0:
                 self.logger.info(f'Automatically created listener at {ip_}:{port} for '
                                  f'{subsystem_nqn}')
                 self.subsystem_auto_listeners[subsystem_nqn].add((adrfam, ip, port))
-        return req_status
+            elif status != errno.EEXIST:
+                warnmsg = f"Warning: failed to create auto-listener at {ip_}:{port} for " \
+                          f"{subsystem_nqn}: {rt.error_message}"
+                self.logger.warning(warnmsg)
+                if final_err_msg:
+                    final_err_msg += "\n"
+                final_err_msg += warnmsg
+        return pb2.req_status(status=0, error_message=final_err_msg)
 
     def del_listeners(self, subsystem_nqn, ip_list, is_secure, port):
-        req_status = 0
+        final_err_msg = ""
         if not port:
             if is_secure:
                 port = GatewayService.SECURE_LISTENER_PORT_DEFAULT
@@ -2171,16 +2169,17 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 force=True)
             rt = self.delete_listener_safe(lstnr_req, None)
             status = rt.status
-            if status != 0:
-                errmsg = f"Failure deleting auto-listeners for {subsystem_nqn} " \
-                         f"subsystem: {rt.error_message}"
-                self.logger.error(errmsg)
-                if status != errno.ENOENT:
-                    req_status = status
-            else:
-                ip_ = GatewayUtils.escape_address_if_ipv6(ip)
+            ip_ = GatewayUtils.escape_address_if_ipv6(ip)
+            if status == 0:
                 self.logger.info(f'Automatically deleted listener at {ip_}:{port} for '
                                  f'{subsystem_nqn}')
+            elif status != errno.ENOENT:
+                warnmsg = f"Warning: failed to delete auto-listener at {ip_}:{port} for " \
+                          f"{subsystem_nqn}: {rt.error_message}"
+                self.logger.warning(warnmsg)
+                if final_err_msg:
+                    final_err_msg += "\n"
+                final_err_msg += warnmsg
 
             if status == 0 or status == errno.ENOENT:
                 if subsystem_nqn in self.subsystem_auto_listeners:
@@ -2188,7 +2187,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     if lstnr in self.subsystem_auto_listeners[subsystem_nqn]:
                         self.subsystem_auto_listeners[subsystem_nqn].remove(lstnr)
 
-        return req_status
+        return pb2.req_status(status=0, error_message=final_err_msg)
 
     def _create_auto_listeners_safe(self, request):
         """
@@ -2196,16 +2195,17 @@ class GatewayService(pb2_grpc.GatewayServicer):
         request: create_subsystem_req type
         """
 
-        req_status = 0
+        final_err_msg = ""
         network_mask_subnets = request.network_mask
         for subnet in set(network_mask_subnets):
             found_host_ips = NICS(self.logger, True).get_ips_in_subnet(subnet)
-            req_status = self.add_listeners(request.subsystem_nqn, found_host_ips,
-                                            request.secure_listeners, request.port)
-        if req_status != 0:
-            err_msg = f"Failed to create auto-listeners for subsystem {request.subsystem_nqn}"
-            return pb2.req_status(status=req_status, error_message=err_msg)
-        return pb2.req_status(status=0, error_message="")
+            ret = self.add_listeners(request.subsystem_nqn, found_host_ips,
+                                     request.secure_listeners, request.port)
+            if ret.error_message:
+                if final_err_msg:
+                    final_err_msg += "\n"
+                final_err_msg += ret.error_message
+        return pb2.req_status(status=0, error_message=final_err_msg)
 
     def create_auto_listeners(self, request):
         """
@@ -2241,7 +2241,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
 
-        req_status = 0
+        rt = pb2.req_status(status=0, error_message="")
         omap_lock = self.omap_lock.get_omap_lock_to_use(context)
         with omap_lock:
             subsys_entry = None
@@ -2260,38 +2260,31 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 network_to_add = request.network_mask
                 existing_network_masks = set(subsys_entry.network_mask)
                 if network_to_add in existing_network_masks:
-                    self.logger.warning(f"Network mask already exists for "
-                                        f"subsystem {request.subsystem_nqn}")
-                    return pb2.req_status(status=0, error_message="")
+                    warnmsg = f"Network mask {request.network_mask} already exists for " \
+                              f"subsystem {request.subsystem_nqn}"
+                    self.logger.warning(warnmsg)
+                    return pb2.req_status(status=0, error_message=warnmsg)
 
                 found_ips = NICS(self.logger, True).get_ips_in_subnet(network_to_add)
-                req_status = self.add_listeners(request.subsystem_nqn, found_ips,
-                                                subsys_entry.secure_listeners, subsys_entry.port)
-                if req_status != 0:
-                    self.logger.error(f'Failed to add all listeners in network mask '
-                                      f'{request.network_mask} (all IPs: {found_ips}) '
-                                      f'for subsystem {request.subsystem_nqn}.')
-                else:
-                    existing_network_masks.add(network_to_add)
-                    new_network_mask = list(existing_network_masks)
-                    self.subsys_network[request.subsystem_nqn] = new_network_mask
-                    if context:
-                        # remove listener from subsystem's OMAP
-                        subsys_entry.network_mask[:] = new_network_mask
-                        json_req = json_format.MessageToJson(
-                            subsys_entry, preserving_proto_field_name=True,
-                            including_default_value_fields=True)
-                        self.gateway_state.add_subsystem(request.subsystem_nqn, json_req)
-                    self.logger.info(f"Added network {request.network_mask} for subsystem "
-                                     f"{request.subsystem_nqn}")
+                rt = self.add_listeners(request.subsystem_nqn, found_ips,
+                                        subsys_entry.secure_listeners, subsys_entry.port)
+                existing_network_masks.add(network_to_add)
+                new_network_mask = list(existing_network_masks)
+                self.subsys_network[request.subsystem_nqn] = new_network_mask
+                if context:
+                    # add network to subsystem's OMAP
+                    subsys_entry.network_mask[:] = new_network_mask
+                    json_req = json_format.MessageToJson(
+                        subsys_entry, preserving_proto_field_name=True,
+                        including_default_value_fields=True)
+                    self.gateway_state.add_subsystem(request.subsystem_nqn, json_req)
+                self.logger.info(f"Added network {request.network_mask} for subsystem "
+                                 f"{request.subsystem_nqn}")
             except Exception as ex:
                 errmsg = f"Failure occurred:\n{ex}"
                 self.logger.error(errmsg)
                 return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
-        err_msg = ""
-        if req_status != 0:
-            err_msg = f"Failed to add network for subsystem {request.subsystem_nqn}"
-        return pb2.req_status(status=req_status, error_message=err_msg)
+        return pb2.req_status(status=rt.status, error_message=rt.error_message)
 
     def add_subsystem_network(self, request, context=None):
         """Add a network_mask on subsystem"""
@@ -2326,7 +2319,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
 
-        req_status = 0
+        rt = pb2.req_status(status=0, error_message="")
         omap_lock = self.omap_lock.get_omap_lock_to_use(context)
         with omap_lock:
             subsys_entry = None
@@ -2344,14 +2337,16 @@ class GatewayService(pb2_grpc.GatewayServicer):
             try:
                 network_to_delete = request.network_mask
                 if not subsys_entry.network_mask:
-                    errmsg = f"No existing network mask found for " \
-                             f"subsystem {request.subsystem_nqn}"
-                    return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
+                    warnmsg = f"No existing network mask found for " \
+                              f"subsystem {request.subsystem_nqn}"
+                    self.logger.warning(warnmsg)
+                    return pb2.req_status(status=0, error_message=warnmsg)
                 existing_network_mask = set(subsys_entry.network_mask)
                 if network_to_delete not in existing_network_mask:
-                    self.logger.warning(f"Network mask {request.network_mask} not "
-                                        f"found for subsystem {request.subsystem_nqn}")
-                    return pb2.req_status(status=0, error_message="")
+                    warnmsg = f"Network mask {request.network_mask} not " \
+                              f"found for subsystem {request.subsystem_nqn}"
+                    self.logger.warning(warnmsg)
+                    return pb2.req_status(status=0, error_message=warnmsg)
 
                 found_ips = NICS(self.logger, True).get_ips_in_subnet(network_to_delete)
 
@@ -2371,32 +2366,24 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                      f"{request.subsystem_nqn}: {ips_to_keep} still covered by "
                                      f"remaining network masks {remaining_network_masks}")
 
-                req_status = self.del_listeners(request.subsystem_nqn, ips_to_delete,
-                                                subsys_entry.secure_listeners, subsys_entry.port)
-                if req_status != 0:
-                    self.logger.error(f'Failed to delete all listeners under network mask '
-                                      f'{request.network_mask} (tried to remove: {ips_to_delete}) '
-                                      f'for subsystem {request.subsystem_nqn}.')
-                else:
-                    new_network_mask = remaining_network_masks
-                    self.subsys_network[request.subsystem_nqn] = new_network_mask
-                    if context:
-                        # remove listener from subsystem's OMAP
-                        subsys_entry.network_mask[:] = new_network_mask
-                        json_req = json_format.MessageToJson(
-                            subsys_entry, preserving_proto_field_name=True,
-                            including_default_value_fields=True)
-                        self.gateway_state.add_subsystem(request.subsystem_nqn, json_req)
-                    self.logger.info(f"Deleted network {network_to_delete} for subsystem "
-                                     f"{request.subsystem_nqn}")
+                rt = self.del_listeners(request.subsystem_nqn, ips_to_delete,
+                                        subsys_entry.secure_listeners, subsys_entry.port)
+                new_network_mask = remaining_network_masks
+                self.subsys_network[request.subsystem_nqn] = new_network_mask
+                if context:
+                    # remove network from subsystem's OMAP
+                    subsys_entry.network_mask[:] = new_network_mask
+                    json_req = json_format.MessageToJson(
+                        subsys_entry, preserving_proto_field_name=True,
+                        including_default_value_fields=True)
+                    self.gateway_state.add_subsystem(request.subsystem_nqn, json_req)
+                self.logger.info(f"Deleted network {network_to_delete} for subsystem "
+                                 f"{request.subsystem_nqn}")
             except Exception as ex:
                 errmsg = f"Failure occurred:\n{ex}"
                 self.logger.error(errmsg)
                 return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
-        err_msg = ""
-        if req_status != 0:
-            err_msg = f"Failed to delete network for subsystem {request.subsystem_nqn}"
-        return pb2.req_status(status=req_status, error_message=err_msg)
+        return pb2.req_status(status=rt.status, error_message=rt.error_message)
 
     def del_subsystem_network(self, request, context=None):
         """Delete a network mask on subsystem"""

--- a/control/utils.py
+++ b/control/utils.py
@@ -829,6 +829,20 @@ class NICS:
         except Exception:
             return False
 
+    @staticmethod
+    def is_ip_in_network_masks(ip: str, network_masks: list) -> bool:
+        if not ip or not network_masks:
+            return False
+        try:
+            ip_addr = ipaddress.ip_address(ip)
+            for mask in network_masks:
+                subnet = ipaddress.ip_network(mask, strict=False)
+                if ip_addr in subnet:
+                    return True
+            return False
+        except (ValueError, TypeError):
+            return False
+
     def get_ips_in_subnet(self, subnet):
         if not subnet:
             return []

--- a/tests/test_auto_listeners.py
+++ b/tests/test_auto_listeners.py
@@ -25,6 +25,18 @@ config = "ceph-nvmeof.conf"
 group_name = "GROUPNAME"
 
 
+def wait_for_listener_count(subsystem_nqn, expected_count, timeout=30):
+    for i in range(timeout):
+        try:
+            listeners = cli_test(["listener", "list", "--subsystem", subsystem_nqn])
+            if len(listeners.listeners) == expected_count:
+                return True
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+
 @pytest.fixture(scope="module")
 def gateway(config):
     """Sets up and tears down Gateway"""
@@ -70,7 +82,7 @@ class TestAutoListener:
 
     def test_listener_list(self, caplog, gateway):
         cli(["subsystem", "list"])
-        time.sleep(30)
+        assert wait_for_listener_count(subsystem, 2)
         caplog.clear()
         listeners = cli_test(["listener", "list", "--subsystem", subsystem])
         assert len(listeners.listeners) == 2
@@ -179,7 +191,7 @@ class TestAutoListener:
 
     def test_del_network_listener_list(self, caplog, gateway):
         cli(["subsystem", "list"])
-        time.sleep(30)
+        assert wait_for_listener_count(subsystem, 1)
         caplog.clear()
         listeners = cli_test(["listener", "list", "--subsystem", subsystem])
         assert len(listeners.listeners) == 1
@@ -232,7 +244,7 @@ class TestAutoListener:
 
     def test_add_network_listener_list(self, caplog, gateway):
         cli(["subsystem", "list"])
-        time.sleep(30)
+        assert wait_for_listener_count(subsystem, 2)
         caplog.clear()
         listeners = cli_test(["listener", "list", "--subsystem", subsystem])
         assert len(listeners.listeners) == 2
@@ -310,7 +322,7 @@ class TestAutoListener:
         assert f"Network mask {addr_subnet} deleted for subsystem {subsystem3}: " \
                f"Successful" in caplog.text
         cli(["subsystem", "list"])
-        time.sleep(30)
+        assert wait_for_listener_count(subsystem3, 1)
         listeners = cli_test(["listener", "list", "--subsystem", subsystem3])
         assert len(listeners.listeners) == 1
         caplog.clear()
@@ -319,7 +331,7 @@ class TestAutoListener:
         assert f"Added network {addr_subnet} for subsystem {subsystem3}" in caplog.text
         assert f"Automatically created listener at {addr}:4500 for {subsystem3}" in caplog.text
         cli(["subsystem", "list"])
-        time.sleep(30)
+        assert wait_for_listener_count(subsystem3, 2)
         listeners = cli_test(["listener", "list", "--subsystem", subsystem3])
         assert len(listeners.listeners) == 2
         assert listeners.listeners[0].trsvcid == 4500
@@ -344,3 +356,49 @@ class TestAutoListener:
             rc = sysex.code
         assert "Secure listeners cannot be set without a network mask" in caplog.text
         assert rc == 2
+
+    def test_overlapping_network_masks(self, caplog, gateway):
+        caplog.clear()
+        larger_subnet = "127.0.0.0/16"
+        smaller_subnet = addr_subnet  # 127.0.0.1/24
+        cli(["subsystem", "add", "--subsystem", subsystem5, "--no-group-append",
+             '--network-mask', larger_subnet, smaller_subnet])
+        assert f"Adding subsystem {subsystem5}: Successful" in caplog.text
+
+        subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem5])
+        masks = subsystems.subsystems[0].network_mask
+        assert len(masks) == 2
+        assert set(masks) == {larger_subnet, smaller_subnet}
+
+        cli(["subsystem", "list"])
+        assert wait_for_listener_count(subsystem5, 1, timeout=30)
+
+        caplog.clear()
+        cli(["subsystem", "del_network", "--subsystem", subsystem5,
+             '--network-mask', smaller_subnet])
+        assert f"Network mask {smaller_subnet} deleted for subsystem " \
+               f"{subsystem5}: Successful" in caplog.text
+        assert f"Keeping 1 auto-listener(s) for {subsystem5}" in caplog.text
+
+        subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem5])
+        masks = subsystems.subsystems[0].network_mask
+        assert len(masks) == 1
+        assert masks[0] == larger_subnet
+
+        assert wait_for_listener_count(subsystem5, 1)
+        listeners = cli_test(["listener", "list", "--subsystem", subsystem5])
+        assert len(listeners.listeners) == 1
+
+        caplog.clear()
+        cli(["subsystem", "del_network", "--subsystem", subsystem5,
+             '--network-mask', larger_subnet])
+        assert f"Network mask {larger_subnet} deleted for subsystem " \
+               f"{subsystem5}: Successful" in caplog.text
+
+        subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem5])
+        masks = subsystems.subsystems[0].network_mask
+        assert len(masks) == 0
+
+        assert wait_for_listener_count(subsystem5, 0)
+        listeners = cli_test(["listener", "list", "--subsystem", subsystem5])
+        assert len(listeners.listeners) == 0

--- a/tests/test_auto_listeners.py
+++ b/tests/test_auto_listeners.py
@@ -71,9 +71,10 @@ class TestAutoListener:
     def test_subsystem_with_networks(self, caplog, gateway):
         cli(["subsystem", "list"])
         caplog.clear()
-        cli(["subsystem", "add", "--subsystem", subsystem, "--no-group-append",
-             '--network-mask', addr_subnet, addr_ipv6_subnet])
-        assert f"Adding subsystem {subsystem}: Successful" in caplog.text
+        ret = cli_test(["subsystem", "add", "--subsystem", subsystem, "--no-group-append",
+                        '--network-mask', addr_subnet, addr_ipv6_subnet])
+        assert ret.status == 0
+        assert ret.error_message == ""
         assert "ipv4" in caplog.text.lower()
         assert f"Automatically created listener at {addr}:4420 for {subsystem}" in caplog.text
         assert "ipv6" in caplog.text.lower()
@@ -85,6 +86,7 @@ class TestAutoListener:
         assert wait_for_listener_count(subsystem, 2)
         caplog.clear()
         listeners = cli_test(["listener", "list", "--subsystem", subsystem])
+        assert listeners.status == 0
         assert len(listeners.listeners) == 2
         assert listeners.listeners[0].trtype == "TCP"
         assert listeners.listeners[0].trsvcid == 4420
@@ -107,9 +109,10 @@ class TestAutoListener:
 
     def test_auto_listener_secure(self, caplog, gateway):
         caplog.clear()
-        cli(["subsystem", "add", "--subsystem", subsystem2, "--no-group-append",
-             '--network-mask', addr_subnet, '--secure-listeners'])
-        assert f"Adding subsystem {subsystem2}: Successful" in caplog.text
+        ret = cli_test(["subsystem", "add", "--subsystem", subsystem2, "--no-group-append",
+                        '--network-mask', addr_subnet, '--secure-listeners'])
+        assert ret.status == 0
+        assert ret.error_message == ""
         assert "ipv4" in caplog.text.lower()
         assert f"Automatically created listener at {addr}:4421 for {subsystem2}" in caplog.text
 
@@ -118,6 +121,7 @@ class TestAutoListener:
         time.sleep(30)
         caplog.clear()
         listeners = cli_test(["listener", "list", "--subsystem", subsystem2])
+        assert listeners.status == 0
         assert listeners.listeners[0].trtype == "TCP"
         assert listeners.listeners[0].traddr == addr
         assert listeners.listeners[0].trsvcid == 4421
@@ -173,13 +177,26 @@ class TestAutoListener:
                f"Invalid subnet \"{invalid_subnet}\"" in caplog.text
         caplog.clear()
 
+    def test_del_network_mask_not_found(self, caplog, gateway):
+        _, stub = gateway
+        caplog.clear()
+        nonexistent_subnet = "10.0.0.0/24"
+        req = pb2.del_subsystem_network_req(subsystem_nqn=subsystem,
+                                            network_mask=nonexistent_subnet)
+        ret = stub.del_subsystem_network(req)
+        assert ret.status == 0
+        expected_warn = f"Network mask {nonexistent_subnet} not found for subsystem {subsystem}"
+        assert expected_warn in ret.error_message
+        assert expected_warn in caplog.text
+
     def test_del_network_mask(self, caplog, gateway):
         cli(["subsystem", "list"])
         caplog.clear()
-        cli(["subsystem", "del_network", "--subsystem", subsystem,
-             '--network-mask', addr_subnet])
-        assert f"Network mask {addr_subnet} deleted for subsystem {subsystem}: " \
-               f"Successful" in caplog.text
+        ret = cli_test(["subsystem", "del_network", "--subsystem", subsystem,
+                        '--network-mask', addr_subnet])
+        assert ret.status == 0
+        assert ret.error_message == ""
+        assert f"Deleted network {addr_subnet} for subsystem {subsystem}" in caplog.text
         assert f"Automatically deleted listener at {addr}:4420 for {subsystem}" in caplog.text
         assert f"Automatically created listener at {addr}:4420 for {subsystem}" not in caplog.text
 
@@ -194,6 +211,7 @@ class TestAutoListener:
         assert wait_for_listener_count(subsystem, 1)
         caplog.clear()
         listeners = cli_test(["listener", "list", "--subsystem", subsystem])
+        assert listeners.status == 0
         assert len(listeners.listeners) == 1
         assert listeners.listeners[0].trtype == "TCP"
         assert listeners.listeners[0].traddr == addr_ipv6
@@ -230,11 +248,23 @@ class TestAutoListener:
     def test_add_network_mask(self, caplog, gateway):
         cli(["subsystem", "list"])
         caplog.clear()
-        cli(["subsystem", "add_network", "--subsystem", subsystem,
-             '--network-mask', addr_subnet])
+        ret = cli_test(["subsystem", "add_network", "--subsystem", subsystem,
+                        '--network-mask', addr_subnet])
+        assert ret.status == 0
+        assert ret.error_message == ""
         assert f"Added network {addr_subnet} for subsystem {subsystem}" in caplog.text
         assert f"Automatically created listener at {addr}:4420 for {subsystem}" in caplog.text
         assert f"Automatically deleted listener at {addr}:4420 for {subsystem}" not in caplog.text
+
+    def test_add_network_mask_already_exists(self, caplog, gateway):
+        _, stub = gateway
+        caplog.clear()
+        req = pb2.add_subsystem_network_req(subsystem_nqn=subsystem, network_mask=addr_subnet)
+        ret = stub.add_subsystem_network(req)
+        assert ret.status == 0
+        expected_warn = f"Network mask {addr_subnet} already exists for subsystem {subsystem}"
+        assert expected_warn in ret.error_message
+        assert expected_warn in caplog.text
 
     def test_add_network_subsystem_list(self, caplog, gateway):
         subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem])
@@ -272,9 +302,10 @@ class TestAutoListener:
     def test_subsystem_with_networks_and_port(self, caplog, gateway):
         cli(["subsystem", "list"])
         caplog.clear()
-        cli(["subsystem", "add", "--subsystem", subsystem3, "--no-group-append",
-             '--network-mask', addr_subnet, addr_ipv6_subnet, "--port", "4500"])
-        assert f"Adding subsystem {subsystem3}: Successful" in caplog.text
+        ret = cli_test(["subsystem", "add", "--subsystem", subsystem3, "--no-group-append",
+                        '--network-mask', addr_subnet, addr_ipv6_subnet, "--port", "4500"])
+        assert ret.status == 0
+        assert ret.error_message == ""
         assert "ipv4" in caplog.text.lower()
         assert f"Automatically created listener at {addr}:4500 for {subsystem3}" in caplog.text
         assert "ipv6" in caplog.text.lower()
@@ -300,9 +331,10 @@ class TestAutoListener:
 
     def test_auto_listener_secure_with_port(self, caplog, gateway):
         caplog.clear()
-        cli(["subsystem", "add", "--subsystem", subsystem4, "--no-group-append",
-             '--network-mask', addr_subnet, '--secure-listeners', "--port", "4501"])
-        assert f"Adding subsystem {subsystem4}: Successful" in caplog.text
+        ret = cli_test(["subsystem", "add", "--subsystem", subsystem4, "--no-group-append",
+                        '--network-mask', addr_subnet, '--secure-listeners', "--port", "4501"])
+        assert ret.status == 0
+        assert ret.error_message == ""
         assert "ipv4" in caplog.text.lower()
         assert f"Automatically created listener at {addr}:4501 for {subsystem4}" in caplog.text
         cli(["subsystem", "list"])
@@ -318,16 +350,20 @@ class TestAutoListener:
 
     def test_del_and_add_network_mask(self, caplog, gateway):
         caplog.clear()
-        cli(["subsystem", "del_network", "--subsystem", subsystem3, '--network-mask', addr_subnet])
-        assert f"Network mask {addr_subnet} deleted for subsystem {subsystem3}: " \
-               f"Successful" in caplog.text
+        ret = cli_test(["subsystem", "del_network", "--subsystem", subsystem3,
+                        '--network-mask', addr_subnet])
+        assert ret.status == 0
+        assert ret.error_message == ""
+        assert f"Deleted network {addr_subnet} for subsystem {subsystem3}" in caplog.text
         cli(["subsystem", "list"])
         assert wait_for_listener_count(subsystem3, 1)
         listeners = cli_test(["listener", "list", "--subsystem", subsystem3])
         assert len(listeners.listeners) == 1
         caplog.clear()
-        cli(["subsystem", "add_network", "--subsystem", subsystem3,
-             '--network-mask', addr_subnet])
+        ret = cli_test(["subsystem", "add_network", "--subsystem", subsystem3,
+                        '--network-mask', addr_subnet])
+        assert ret.status == 0
+        assert ret.error_message == ""
         assert f"Added network {addr_subnet} for subsystem {subsystem3}" in caplog.text
         assert f"Automatically created listener at {addr}:4500 for {subsystem3}" in caplog.text
         cli(["subsystem", "list"])
@@ -361,9 +397,10 @@ class TestAutoListener:
         caplog.clear()
         larger_subnet = "127.0.0.0/16"
         smaller_subnet = addr_subnet  # 127.0.0.1/24
-        cli(["subsystem", "add", "--subsystem", subsystem5, "--no-group-append",
-             '--network-mask', larger_subnet, smaller_subnet])
-        assert f"Adding subsystem {subsystem5}: Successful" in caplog.text
+        ret = cli_test(["subsystem", "add", "--subsystem", subsystem5, "--no-group-append",
+                        '--network-mask', larger_subnet, smaller_subnet])
+        assert ret.status == 0
+        assert ret.error_message == ""
 
         subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem5])
         masks = subsystems.subsystems[0].network_mask
@@ -374,10 +411,11 @@ class TestAutoListener:
         assert wait_for_listener_count(subsystem5, 1, timeout=30)
 
         caplog.clear()
-        cli(["subsystem", "del_network", "--subsystem", subsystem5,
-             '--network-mask', smaller_subnet])
-        assert f"Network mask {smaller_subnet} deleted for subsystem " \
-               f"{subsystem5}: Successful" in caplog.text
+        ret = cli_test(["subsystem", "del_network", "--subsystem", subsystem5,
+                        '--network-mask', smaller_subnet])
+        assert ret.status == 0
+        assert ret.error_message == ""
+        assert f"Deleted network {smaller_subnet} for subsystem {subsystem5}" in caplog.text
         assert f"Keeping 1 auto-listener(s) for {subsystem5}" in caplog.text
 
         subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem5])
@@ -390,10 +428,11 @@ class TestAutoListener:
         assert len(listeners.listeners) == 1
 
         caplog.clear()
-        cli(["subsystem", "del_network", "--subsystem", subsystem5,
-             '--network-mask', larger_subnet])
-        assert f"Network mask {larger_subnet} deleted for subsystem " \
-               f"{subsystem5}: Successful" in caplog.text
+        ret = cli_test(["subsystem", "del_network", "--subsystem", subsystem5,
+                        '--network-mask', larger_subnet])
+        assert ret.status == 0
+        assert ret.error_message == ""
+        assert f"Deleted network {larger_subnet} for subsystem {subsystem5}" in caplog.text
 
         subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem5])
         masks = subsystems.subsystems[0].network_mask
@@ -402,3 +441,13 @@ class TestAutoListener:
         assert wait_for_listener_count(subsystem5, 0)
         listeners = cli_test(["listener", "list", "--subsystem", subsystem5])
         assert len(listeners.listeners) == 0
+
+    def test_del_network_no_masks(self, caplog, gateway):
+        _, stub = gateway
+        caplog.clear()
+        req = pb2.del_subsystem_network_req(subsystem_nqn=subsystem5, network_mask=addr_subnet)
+        ret = stub.del_subsystem_network(req)
+        assert ret.status == 0
+        expected_warn = f"No existing network mask found for subsystem {subsystem5}"
+        assert expected_warn in ret.error_message
+        assert expected_warn in caplog.text


### PR DESCRIPTION
This PR solves 2 bugs in two commits:

1. [Handle IPs overlap between networks in del_network](https://github.com/ceph/ceph-nvmeof/pull/1877/changes/bc3a2332925d748404f742d636a624865f0c08bb)
If a subsystem has two network_mask configured
and there are auto-listener who's IP belong in
both network mask, then while removing one of
the network mask, do not delete listeners with
IP which belong to other non-removed network mask.
Fixes: https://github.com/ceph/ceph-nvmeof/issues/1876

2. [Always return success for network_mask add/del](https://github.com/ceph/ceph-nvmeof/pull/1877/changes/8a2adf9e18919475429e25206e441775c6b78f4a)
If an interface is down on 1 gw but not on another,
it could fail network_mask add/del for 1 gateway and
pass for another.
It's more ideal to always return status=0 and log
warnings for failure in listener-del and listener-add
for auto-listener.
Fixes: https://github.com/ceph/ceph-nvmeof/issues/1898