### PR TITLE
Adding Bob

### DIFF
--- a/.bob/rules-advance/AGENTS.md
+++ b/.bob/rules-advance/AGENTS.md
@@ -1,0 +1,75 @@
+# Advance Mode Rules (Non-Obvious Only)
+
+## Project-Specific Coding Patterns (with MCP/Browser Access)
+
+**State persistence via OMAP (not files):**
+- All gateway state stored in Ceph OMAP, not local filesystem
+- State keys built using `GatewayState.build_*_key()` methods in `control/state.py`
+- Key components CANNOT contain underscores (validated by `is_key_element_valid()`)
+- Example: `namespace_nqn.2016-06.io.spdk:cnode1_1` (underscore separates prefix from NQN from NSID)
+
+**SPDK subprocess management:**
+- SPDK runs as subprocess, not in-process library
+- Must register SIGCHLD handler to detect SPDK crashes
+- RPC calls via `spdk.rpc.client` over Unix socket
+- Socket path: `rpc_socket_dir + rpc_socket_name` from config (default: `/var/tmp/spdk.sock`)
+
+**GatewayLogger singleton pattern:**
+- NEVER use `import logging` directly
+- Always use: `from .utils import GatewayLogger` then `GatewayLogger().logger`
+- Logger configured from `[gateway-logs]` section in config file
+- Singleton ensures consistent logging across all modules
+
+**CLI invocation in tests:**
+- Import: `from control.cli import main as cli`
+- Call: `cli(["subsystem", "add", "--subsystem", "nqn.example"])`
+- NOT: subprocess or shell execution
+- Captures output via pytest caplog fixture
+
+**Config file access pattern:**
+- Use `GatewayConfig` class, not raw configparser
+- Methods: `get_with_default()`, `getboolean_with_default()`, etc.
+- Config sections are hardcoded strings (no constants): `"gateway"`, `"spdk"`, `"ceph"`
+
+**Protobuf imports:**
+- Gateway protobuf: `from .proto import gateway_pb2 as pb2`
+- gRPC stubs: `from .proto import gateway_pb2_grpc as pb2_grpc`
+- JSON conversion: `from google.protobuf import json_format`
+- Monitor protobuf: `from .proto import monitor_pb2_grpc`
+
+**Test context managers:**
+- Gateway server: `with GatewayServer(config) as gateway:`
+- Must call `gateway.serve()` after entering context
+- Tests run inside containers only (cannot run on host)
+
+**Cluster allocation strategy (critical):**
+- Only ONE of these can be set in `[spdk]` section:
+  - `bdevs_per_cluster` (legacy, per ANA group)
+  - `flat_bdevs_per_cluster` (ignores ANA groups)
+  - `cluster_connections` (pool-based, recommended)
+- Setting multiple will cause undefined behavior
+
+**Error handling in tests:**
+- Use `@pytest.mark.filterwarnings("error::pytest.PytestUnhandledThreadExceptionWarning")`
+- Check caplog for "failed" and "Failure" strings (case-sensitive)
+- Exclude known warnings: `.replace("failed to notify", "")`
+
+**PDM not pip:**
+- Dependencies in `pyproject.toml`, lockfile is `pdm.lock`
+- Update deps: `make update-lockfile` (runs PDM in container)
+- PDM configured with `use_venv = false` in pdm.toml
+- NEVER use `pip install` for dependencies
+
+**Protobuf regeneration:**
+- After modifying `.proto` files in `control/proto/`
+- MUST run: `make protoc`
+- Generates: `*_pb2.py`, `*_pb2_grpc.py`, `*_pb2.pyi` files
+- These are NOT in .gitignore (committed to repo)
+
+## MCP/Browser-Specific Considerations
+
+**External documentation:**
+- SPDK docs: https://spdk.io/doc/
+- Ceph docs: https://docs.ceph.com/
+- NVMe-oF spec: https://nvmexpress.org/specification/nvme-of-specification/
+- Project repo: https://github.com/ceph/ceph-nvmeof

--- a/.bob/rules-ask/AGENTS.md
+++ b/.bob/rules-ask/AGENTS.md
@@ -1,0 +1,63 @@
+# Ask Mode Rules (Non-Obvious Only)
+
+## Project Documentation Context
+
+**Container-based architecture (counterintuitive):**
+- Gateway CANNOT run directly on host (requires SPDK + Ceph cluster)
+- Development uses `nvmeof-devel` service with mounted source code
+- Production uses `nvmeof` service with baked-in code
+- All tests must run inside containers: `docker compose run --rm nvmeof-devel pytest ...`
+
+**Discovery service is separate:**
+- Discovery service runs independently: `python3 -m control.discovery`
+- Sources target info from Ceph OMAP, not from live gateways
+- Default port 8009 (not the gateway port 5500)
+- Can be started separately: `docker compose up --detach discovery`
+
+**State storage location (hidden):**
+- Gateway state is NOT in local files or database
+- All state persisted to Ceph OMAP (object map)
+- State keys use underscore delimiter with strict validation
+- Key element components cannot contain underscores
+
+**Config file structure (non-standard):**
+- Multiple config sections with specific purposes
+- `[spdk]` section has THREE mutually exclusive cluster allocation strategies
+- Only ONE strategy can be set at a time (not documented in config comments)
+- Setting multiple strategies causes undefined behavior
+
+**Testing environment requirements:**
+- Tests require full Ceph cluster + SPDK environment
+- Cannot run tests on host machine
+- Must use docker compose with specific services
+- Test fixtures in `conftest.py` provide config/image parameters
+
+**PDM package manager (not pip):**
+- Project uses PDM, not pip or poetry
+- Dependencies in `pyproject.toml`, lockfile is `pdm.lock`
+- PDM configured with `use_venv = false` (no virtual environment)
+- Update lockfile: `make update-lockfile` (runs PDM in container)
+
+**SPDK as git submodule:**
+- SPDK is included as git submodule, not external dependency
+- Must initialize: `git submodule update --init --recursive`
+- SPDK has its own nested submodules
+- Required before building
+
+**Huge pages requirement (hidden dependency):**
+- SPDK requires huge pages allocated on host
+- Setup command: `make setup` (requires sudo)
+- Default: 2048 pages (4GB)
+- Alternative: Set `mem_size=4096` in [spdk] section to avoid huge pages
+
+**CLI invocation patterns:**
+- CLI can be invoked as module: `python3 -m control.cli`
+- In tests, imported as function: `from control.cli import main as cli`
+- Environment variables: `CEPH_NVMEOF_SERVER_ADDRESS`, `CEPH_NVMEOF_SERVER_PORT`
+- NOT invoked via subprocess in tests
+
+**Protobuf file generation:**
+- Protobuf files ARE committed to repo (not gitignored)
+- After modifying `.proto` files, must run: `make protoc`
+- Generates `*_pb2.py`, `*_pb2_grpc.py`, `*_pb2.pyi` files
+- Build will fail if protobuf files are out of sync

--- a/.bob/rules-code/AGENTS.md
+++ b/.bob/rules-code/AGENTS.md
@@ -1,0 +1,67 @@
+# Code Mode Rules (Non-Obvious Only)
+
+## Project-Specific Coding Patterns
+
+**State persistence via OMAP (not files):**
+- All gateway state stored in Ceph OMAP, not local filesystem
+- State keys built using `GatewayState.build_*_key()` methods in `control/state.py`
+- Key components CANNOT contain underscores (validated by `is_key_element_valid()`)
+- Example: `namespace_nqn.2016-06.io.spdk:cnode1_1` (underscore separates prefix from NQN from NSID)
+
+**SPDK subprocess management:**
+- SPDK runs as subprocess, not in-process library
+- Must register SIGCHLD handler to detect SPDK crashes
+- RPC calls via `spdk.rpc.client` over Unix socket
+- Socket path: `rpc_socket_dir + rpc_socket_name` from config (default: `/var/tmp/spdk.sock`)
+
+**GatewayLogger singleton pattern:**
+- NEVER use `import logging` directly
+- Always use: `from .utils import GatewayLogger` then `GatewayLogger().logger`
+- Logger configured from `[gateway-logs]` section in config file
+- Singleton ensures consistent logging across all modules
+
+**CLI invocation in tests:**
+- Import: `from control.cli import main as cli`
+- Call: `cli(["subsystem", "add", "--subsystem", "nqn.example"])`
+- NOT: subprocess or shell execution
+- Captures output via pytest caplog fixture
+
+**Config file access pattern:**
+- Use `GatewayConfig` class, not raw configparser
+- Methods: `get_with_default()`, `getboolean_with_default()`, etc.
+- Config sections are hardcoded strings (no constants): `"gateway"`, `"spdk"`, `"ceph"`
+
+**Protobuf imports:**
+- Gateway protobuf: `from .proto import gateway_pb2 as pb2`
+- gRPC stubs: `from .proto import gateway_pb2_grpc as pb2_grpc`
+- JSON conversion: `from google.protobuf import json_format`
+- Monitor protobuf: `from .proto import monitor_pb2_grpc`
+
+**Test context managers:**
+- Gateway server: `with GatewayServer(config) as gateway:`
+- Must call `gateway.serve()` after entering context
+- Tests run inside containers only (cannot run on host)
+
+**Cluster allocation strategy (critical):**
+- Only ONE of these can be set in `[spdk]` section:
+  - `bdevs_per_cluster` (legacy, per ANA group)
+  - `flat_bdevs_per_cluster` (ignores ANA groups)
+  - `cluster_connections` (pool-based, recommended)
+- Setting multiple will cause undefined behavior
+
+**Error handling in tests:**
+- Use `@pytest.mark.filterwarnings("error::pytest.PytestUnhandledThreadExceptionWarning")`
+- Check caplog for "failed" and "Failure" strings (case-sensitive)
+- Exclude known warnings: `.replace("failed to notify", "")`
+
+**PDM not pip:**
+- Dependencies in `pyproject.toml`, lockfile is `pdm.lock`
+- Update deps: `make update-lockfile` (runs PDM in container)
+- PDM configured with `use_venv = false` in pdm.toml
+- NEVER use `pip install` for dependencies
+
+**Protobuf regeneration:**
+- After modifying `.proto` files in `control/proto/`
+- MUST run: `make protoc`
+- Generates: `*_pb2.py`, `*_pb2_grpc.py`, `*_pb2.pyi` files
+- These are NOT in .gitignore (committed to repo)

--- a/.bob/rules-plan/AGENTS.md
+++ b/.bob/rules-plan/AGENTS.md
@@ -1,0 +1,69 @@
+# Plan Mode Rules (Non-Obvious Only)
+
+## Project Architecture Constraints
+
+**SPDK subprocess architecture (not library):**
+- SPDK runs as separate subprocess, not in-process library
+- Gateway must handle SIGCHLD signal when SPDK terminates
+- Communication via RPC over Unix socket (not function calls)
+- SPDK crash causes gateway to exit (by design)
+
+**State persistence via OMAP (architectural decision):**
+- All gateway state stored in Ceph OMAP, not local storage
+- Enables multi-gateway coordination without shared filesystem
+- State keys have strict validation (no underscores in components)
+- OMAP provides atomic operations for state updates
+
+**Cluster allocation strategies (architectural choice):**
+- Three mutually exclusive strategies for BDEV-to-cluster mapping
+- Choice affects performance, scalability, and resource usage
+- Only ONE can be active (enforced by configuration validation)
+- Strategies: legacy ANA-based, flat distribution, pool-based
+
+**Container-only execution (deployment constraint):**
+- Gateway cannot run on bare metal (requires SPDK + Ceph cluster)
+- Development uses mounted source code in containers
+- Production uses baked-in code in containers
+- Tests must run inside containers with full environment
+
+**Discovery service separation (architectural pattern):**
+- Discovery service is independent from gateway service
+- Sources data from OMAP, not from live gateways
+- Allows discovery even when gateways are down
+- Separate lifecycle and scaling from gateway instances
+
+**GatewayLogger singleton (design pattern):**
+- Singleton pattern ensures consistent logging across modules
+- Configured once from config file `[gateway-logs]` section
+- All modules must use `GatewayLogger().logger`, not `logging` directly
+- Prevents logging configuration conflicts
+
+**Test execution architecture:**
+- Tests require full Ceph cluster + SPDK environment
+- Cannot mock SPDK or Ceph (integration tests by design)
+- CLI invoked as Python function in tests (not subprocess)
+- Gateway server uses context manager pattern for lifecycle
+
+**PDM package management (tooling choice):**
+- PDM chosen over pip/poetry for dependency management
+- Configured with `use_venv = false` (no virtual environments)
+- Lockfile updates must run inside container (not on host)
+- Ensures consistent dependencies across environments
+
+**Protobuf code generation (build process):**
+- Protobuf files committed to repo (not generated at build time)
+- Must manually regenerate after `.proto` changes: `make protoc`
+- Generates Python, gRPC stubs, and type hints
+- Build fails if protobuf files are out of sync
+
+**Huge pages requirement (system dependency):**
+- SPDK requires huge pages allocated on host system
+- Setup requires sudo: `make setup HUGEPAGES=2048`
+- Alternative: Use `mem_size` config to avoid huge pages
+- Affects performance and memory allocation strategy
+
+**Config file architecture:**
+- Multiple sections for different subsystems
+- Some settings are mutually exclusive (not validated at parse time)
+- Config accessed via `GatewayConfig` wrapper (not raw configparser)
+- Settings have fallback defaults in code, not in config file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## Project-Specific Build/Test Commands
+
+**Running a single test file:**
+```bash
+# Tests must run inside docker container with proper Ceph/SPDK environment
+docker compose run --rm nvmeof-devel pytest tests/test_grpc.py -v
+```
+
+**Running tests with specific config:**
+```bash
+pytest --config=tests/ceph-nvmeof.tls.conf tests/test_cli.py
+```
+
+**Verify Python code (flake8):**
+```bash
+make verify  # Runs: flake8 control/*.py tests/*.py tests/kmip/*.py
+```
+
+**Update Python dependencies lockfile:**
+```bash
+make update-lockfile  # Uses PDM inside container
+```
+
+**Regenerate gRPC protobuf files:**
+```bash
+make protoc  # Must run after modifying .proto files in control/proto/
+```
+
+## Non-Obvious Architecture Patterns
+
+**OMAP State Management:**
+- Gateway state is persisted to Ceph OMAP (not local files)
+- State keys use underscore delimiter: `GatewayState.OMAP_KEY_DELIMITER = "_"`
+- Key prefixes defined in `control/state.py` (e.g., `NAMESPACE_PREFIX`, `SUBSYSTEM_PREFIX`)
+- OMAP keys cannot contain underscores in their element components (validated by `is_key_element_valid()`)
+
+**SPDK Integration:**
+- SPDK runs as subprocess, not library
+- RPC communication via Unix socket (default: `/var/tmp/spdk.sock`)
+- Gateway must handle SIGCHLD when SPDK subprocess terminates
+- SPDK target path: `/usr/local/bin/nvmf_tgt` (configurable in ceph-nvmeof.conf)
+
+**Cluster Allocation Strategies (Non-Standard):**
+Three mutually exclusive strategies for mapping BDEVs to Ceph cluster contexts:
+1. `bdevs_per_cluster` - Legacy ANA group-based (per ANA group)
+2. `flat_bdevs_per_cluster` - Ignores ANA groups, flat distribution
+3. `cluster_connections` - Pre-defined pool, assigns to least-loaded context
+
+Only ONE should be set in config. See `ceph-nvmeof.conf` [spdk] section.
+
+**Discovery Service:**
+- Separate service from main gateway: `python3 -m control.discovery`
+- Runs on port 8009 (configurable)
+- Sources target info from Ceph OMAP, not live gateways
+- Can be started independently: `docker compose up --detach discovery`
+
+## Code Style (Non-Obvious)
+
+**Flake8 config in tox.ini:**
+- Max line length: 100 characters
+- No ignored errors by default (empty ignore list)
+- Use `# noqa: E501` for specific line exceptions
+
+**Import patterns:**
+- Relative imports within control package: `from .proto import gateway_pb2 as pb2`
+- SPDK RPC client: `import spdk.rpc.client as rpc_client`
+- Protobuf JSON: `from google.protobuf import json_format`
+
+**Logging:**
+- Use `GatewayLogger` singleton, not direct logging
+- Logger instance: `GatewayLogger().logger`
+- Config-driven log levels in `[gateway-logs]` section
+
+## Testing Specifics
+
+**Test fixtures in conftest.py:**
+- `config` fixture: Returns `GatewayConfig` object from `--config` CLI arg
+- `conffile` fixture: Returns path to config file
+- `image` fixture: Returns RBD image name from `--image` CLI arg
+
+**Test execution context:**
+- Tests MUST run inside containers (require Ceph cluster + SPDK)
+- Use `docker compose run --rm nvmeof-devel pytest ...`
+- Tests use pytest caplog for output verification
+- Filter warnings: `@pytest.mark.filterwarnings("error::pytest.PytestUnhandledThreadExceptionWarning")`
+
+**Test patterns:**
+- CLI invoked via `from control.cli import main as cli` then `cli(["subsystem", "add", ...])`
+- Gateway server context manager: `with GatewayServer(config) as gateway:`
+- Wait for async operations: `wait_for_string(caplog, "expected_text", timeout_seconds)`
+
+## Critical Gotchas
+
+**Huge pages required:**
+- SPDK requires huge pages allocated: `make setup` (requires sudo)
+- Default: 2048 pages (4GB), configurable: `make setup HUGEPAGES=512`
+- Alternative: Set `mem_size=4096` in [spdk] section to avoid huge pages
+
+**Container-only development:**
+- Cannot run gateway directly on host (needs SPDK + Ceph cluster)
+- Use `nvmeof-devel` service for development with mounted source
+- Production uses `nvmeof` service with baked-in code
+
+**PDM package manager (not pip):**
+- Dependencies in `pyproject.toml`, lockfile is `pdm.lock`
+- Use `make update-lockfile` to update dependencies
+- PDM configured with `use_venv = false` in pdm.toml
+
+**Git submodules:**
+- SPDK is a submodule: `git submodule update --init --recursive`
+- Must initialize before building
+
+**Config file sections:**
+- `[gateway]` - Main gateway settings
+- `[spdk]` - SPDK-specific (cluster allocation, RPC socket, etc.)
+- `[ceph]` - Ceph connection (pool, config file)
+- `[mtls]` - Mutual TLS certificates
+- `[kmip]` - KMIP server for encryption keys
+- `[discovery]` - Discovery service settings
+- `[gateway-logs]` - Logging configuration
+- `[monitor]` - Monitor service settings


### PR DESCRIPTION
The `/init` command scans a project and generates a structured summary file called AGENTS.md that Bob uses as persistent context in every conversation. The /init command is how you give Bob knowledge about a project's structure, conventions, and codebase, without requiring Bob to re-read every file at the start of each interaction.
Bob read the relevant files in the project. Bob then generated the main AGENTS.md Bob also created a .bob folder that contains an AGENTS.md for each mode.

Re-run /init after you make the following project adjustments:

- Adding new modules or services
- Changing the directory structure
- Adopting new technologies or frameworks
- Onboarding new team members who will use Bob

You can also manually edit the AGENTS.md to add context that Bob's automated scan might not capture, such as business rules, deployment conventions, or team-specific practices.