### PR TITLE
Handle listener-del update for other gateways

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -7367,11 +7367,16 @@ class GatewayService(pb2_grpc.GatewayServicer):
                         )
                         self.logger.debug(f"delete_listener: {ret}")
                 else:
-                    errmsg = f"{delete_listener_error_prefix}: Gateway's host name must " \
-                             f"match current host ({self.host_name}). You can continue to " \
-                             f"delete the listener by adding the \"--force\" parameter."
-                    self.logger.error(errmsg)
-                    return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
+                    if context:
+                        errmsg = f"{delete_listener_error_prefix}: Gateway's host name must " \
+                                 f"match current host ({self.host_name}). You can continue to " \
+                                 f"delete the listener by adding the \"--force\" parameter."
+                        self.logger.error(errmsg)
+                        return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
+                    else:
+                        self.logger.warning(f"Listener not deleted as it belongs to gateway "
+                                            f"{request.host_name}, not this gateway "
+                                            f"({self.host_name})")
             except Exception as ex:
                 self.logger.exception(delete_listener_error_prefix)
                 # It's OK for SPDK to fail in case we used a different host name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2305,6 +2305,14 @@ class TestDelete:
              "-a", addr, "-s", "7777", "--force"])
         assert f"Failed to delete listener {addr}:7777 from {subsystem}: " \
                f"Listener not found" in caplog.text
+        gw, _ = gateway
+        caplog.clear()  # test listener-del update on other gateways
+        req = pb2.delete_listener_req(nqn=subsystem, host_name="JUNK",
+                                      traddr=addr, trsvcid=5555, adrfam="ipv4")
+        ret = gw.delete_listener(req)
+        assert ret.status == 0
+        assert f"Listener not deleted as it belongs to gateway JUNK, not this gateway" \
+               f" ({gw.host_name})" in caplog.text
         caplog.clear()
         cli(["listener", "del", "--subsystem", subsystem, "--host-name", "JUNK",
              "-a", addr, "-s", "5555", "-f", "ipv4", "--force"])


### PR DESCRIPTION
Only returns error on host-mismatch if context is there. With no context, log and skips it.

Fixes: https://github.com/ceph/ceph-nvmeof/issues/1907