### PR TITLE
control/state: fix OmapReadGuard silent failure and retry count off-by-one

### DIFF
--- a/control/state.py
+++ b/control/state.py
@@ -567,7 +567,7 @@ class OmapLock:
 
         if need_to_update:
             raise RuntimeError(f"Unable to execute function under OMAP file lock after reloading "
-                               f"{i} times, exiting")
+                               f"{i + 1} times, exiting")
         elif i > 2:
             self.logger.debug(f"Succeeded to execute {omap_locking_func.__name__} "
                               f"under OMAP file lock after {i} reloads of OMAP file")
@@ -852,7 +852,8 @@ class OmapReadGuard:
             self.actually_locked = False
             return self
         except Exception:
-            pass
+            self.omap_lock.logger.exception(
+                "Failed to acquire shared OMAP lock, falling back to unlocked read")
         return None
 
     def __exit__(self, typ, value, traceback):


### PR DESCRIPTION
## Problem

Two small independent bugs in `control/state.py`:

1. **`OmapReadGuard.__enter__` silently swallows all exceptions** — a bare
   `except Exception: pass` meant lock-acquisition failures were invisible
   in logs, making it impossible to diagnose read-path issues.

2. **Off-by-one in retry error message** — `execute_omap_locking_function`
   reports `{i} times` after exhausting reloads, but the loop variable `i`
   is zero-based, so the last value is one less than the actual attempt
   count. Use `i + 1` to report the correct number.

## Changes

- `OmapReadGuard.__enter__`: replace `pass` with
  `self.omap_lock.logger.exception(...)` so lock failures surface with a
  full traceback and a human-readable message.
- `execute_omap_locking_function`: change `{i}` → `{i + 1}` in the
  RuntimeError message.

No behaviour change on the happy path; no class-level design changes.