### PR TITLE
Add "gw refresh-network" cmd

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -770,6 +770,49 @@ class GatewayClient:
 
         return listeners_info.status
 
+    def gw_refresh_network(self, args):
+        """Re-evaluate subsystem network masks and update listeners for this gateway"""
+
+        out_func, err_func, wrn_func = self.get_output_functions(args)
+        req = pb2.gw_refresh_network_req(subsystem_nqn=args.subsystem)
+        try:
+            ret = self.stub.gw_refresh_network(req)
+        except Exception as ex:
+            ret = pb2.gw_refresh_network_status(
+                status=errno.EINVAL,
+                error_message=f"Failure refreshing network listeners:\n{ex}")
+
+        if args.format == "text" or args.format == "plain":
+            if ret.status == 0:
+                out_func(f"Refreshed configured network masks for subsystem {args.subsystem}"
+                         f" on this gateway: Successful")
+                if ret.added:
+                    out_func(f"Added: {', '.join(ret.added)}")
+                if ret.removed:
+                    out_func(f"Removed: {', '.join(ret.removed)}")
+                if ret.error_message:
+                    wrn_func(ret.error_message)
+            else:
+                err_func(f"{ret.error_message}")
+        elif args.format == "json" or args.format == "yaml":
+            ret_str = json_format.MessageToJson(ret, indent=4,
+                                                including_default_value_fields=True,
+                                                preserving_proto_field_name=True)
+            if args.format == "json":
+                out_func(ret_str)
+            elif args.format == "yaml":
+                obj = json.loads(ret_str)
+                out_func(yaml.dump(obj))
+        elif args.format == "python":
+            return ret
+        else:
+            assert False
+
+        return ret.status
+
+    gw_refresh_network_args = [
+        argument("--subsystem", "-n", help="Subsystem NQN", required=True),
+    ]
     gw_set_log_level_args = [
         argument("--level", "-l", help="Gateway log level", required=True,
                  type=str.lower, choices=get_enum_keys_list(pb2.GwLogLevel, False)),
@@ -811,6 +854,10 @@ class GatewayClient:
     gw_actions.append({"name": "set_io_stats_mode",
                        "args": gw_set_io_stats_mode_args,
                        "help": "Set gateway IO statistics on or off"})
+    gw_actions.append({"name": "refresh_network",
+                       "args": gw_refresh_network_args,
+                       "help": "Re-evaluate subsystem network masks and update listeners"
+                               " for this gateway"})
     gw_choices = get_actions(gw_actions)
 
     @cli.cmd(gw_actions, ["gw"])
@@ -833,6 +880,8 @@ class GatewayClient:
             return self.gw_get_thread_stats(args)
         elif args.action == "set_io_stats_mode":
             return self.gw_set_io_stats_mode(args)
+        elif args.action == "refresh_network":
+            return self.gw_refresh_network(args)
         if not args.action:
             self.cli.parser.error(f"missing action for gw command (choose from "
                                   f"{GatewayClient.gw_choices})")

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -2264,15 +2264,15 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
+        failure_prefix = f"Failure adding network mask for subsystem {request.subsystem_nqn}"
+
         if not request.network_mask:
-            errmsg = f"Failure adding network mask for subsystem " \
-                     f"{request.subsystem_nqn}: Missing network mask"
+            errmsg = f"{failure_prefix}: Missing network mask"
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
         if not NICS.is_valid_subnet(request.network_mask):
-            errmsg = f"Failure adding network mask for subsystem " \
-                     f"{request.subsystem_nqn}: Invalid subnet \"{request.network_mask}\""
+            errmsg = f"{failure_prefix}: Invalid subnet \"{request.network_mask}\""
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
 
@@ -2287,10 +2287,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 subsys_entry = json_format.Parse(state_subsys, pb2.create_subsystem_req(),
                                                  ignore_unknown_fields=True)
             except Exception:
-                errmsg = f"Can't find entry for subsystem {request.subsystem_nqn}"
+                errmsg = f"{failure_prefix}: Can't find entry for subsystem " \
+                         f"{request.subsystem_nqn}"
                 self.logger.error(errmsg)
                 return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
-            assert subsys_entry, f"Can't find entry for subsystem {request.subsystem_nqn}"
+            assert subsys_entry, f"{failure_prefix}: Can't find entry for subsystem " \
+                                 f"{request.subsystem_nqn}"
             try:
                 network_to_add = request.network_mask
                 existing_network_masks = set(subsys_entry.network_mask)
@@ -2316,7 +2318,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 self.logger.info(f"Added network {request.network_mask} for subsystem "
                                  f"{request.subsystem_nqn}")
             except Exception as ex:
-                errmsg = f"Failure occurred:\n{ex}"
+                errmsg = f"{failure_prefix}: Failure occurred:\n{ex}"
                 self.logger.error(errmsg)
                 return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
         return pb2.req_status(status=0, error_message=err_msg)
@@ -2342,15 +2344,15 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
+        failure_prefix = f"Failure deleting network mask for subsystem {request.subsystem_nqn}"
+
         if not request.network_mask:
-            errmsg = f"Failure deleting network mask for subsystem " \
-                     f"{request.subsystem_nqn}: Missing network mask"
+            errmsg = f"{failure_prefix}: Missing network mask"
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
 
         if not NICS.is_valid_subnet(request.network_mask):
-            errmsg = f"Failure deleting network mask for subsystem " \
-                     f"{request.subsystem_nqn}: Invalid subnet \"{request.network_mask}\""
+            errmsg = f"{failure_prefix}: Invalid subnet \"{request.network_mask}\""
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
 
@@ -2365,10 +2367,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 subsys_entry = json_format.Parse(state_subsys, pb2.create_subsystem_req(),
                                                  ignore_unknown_fields=True)
             except Exception:
-                errmsg = f"Can't find entry for subsystem {request.subsystem_nqn}"
+                errmsg = f"{failure_prefix}: Can't find entry for subsystem " \
+                         f"{request.subsystem_nqn}"
                 self.logger.error(errmsg)
                 return pb2.req_status(status=errno.ENOENT, error_message=errmsg)
-            assert subsys_entry, f"Can't find entry for subsystem {request.subsystem_nqn}"
+            assert subsys_entry, f"{failure_prefix}: Can't find entry for subsystem " \
+                                 f"{request.subsystem_nqn}"
             try:
                 network_to_delete = request.network_mask
                 if not subsys_entry.network_mask:
@@ -2415,7 +2419,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 self.logger.info(f"Deleted network {network_to_delete} for subsystem "
                                  f"{request.subsystem_nqn}")
             except Exception as ex:
-                errmsg = f"Failure occurred:\n{ex}"
+                errmsg = f"{failure_prefix}: Failure occurred:\n{ex}"
                 self.logger.error(errmsg)
                 return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
         return pb2.req_status(status=0, error_message=err_msg)
@@ -2440,8 +2444,10 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.gw_refresh_network_status(status=errno.EINVAL, error_message=errmsg)
 
+        failure_prefix = f"Failure refreshing network for subsystem {request.subsystem_nqn}"
+
         if request.subsystem_nqn not in self.subsys_serial:
-            errmsg = f"Failure refreshing network: subsystem {request.subsystem_nqn} not found"
+            errmsg = f"{failure_prefix}: subsystem {request.subsystem_nqn} not found"
             self.logger.error(errmsg)
             return pb2.gw_refresh_network_status(status=errno.ENOENT, error_message=errmsg)
 
@@ -2458,13 +2464,15 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 subsys_entry = json_format.Parse(state_subsys, pb2.create_subsystem_req(),
                                                  ignore_unknown_fields=True)
             except Exception:
-                errmsg = f"Can't find entry for subsystem {request.subsystem_nqn}"
+                errmsg = f"{failure_prefix}: Can't find entry for subsystem " \
+                         f"{request.subsystem_nqn}"
                 self.logger.error(errmsg)
                 return pb2.gw_refresh_network_status(status=errno.ENOENT, error_message=errmsg)
-            assert subsys_entry, f"Can't find entry for subsystem {request.subsystem_nqn}"
+            assert subsys_entry, f"{failure_prefix}: Can't find entry for subsystem " \
+                                 f"{request.subsystem_nqn}"
 
             if not subsys_entry.network_mask:
-                errmsg = (f"Failure refreshing network: subsystem {request.subsystem_nqn} "
+                errmsg = (f"{failure_prefix}: subsystem {request.subsystem_nqn} "
                           f"has no network masks configured")
                 self.logger.error(errmsg)
                 return pb2.gw_refresh_network_status(status=errno.ENOENT, error_message=errmsg)
@@ -2499,7 +2507,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                             final_err_msg += "\n"
                         final_err_msg += err_msg
             except Exception as ex:
-                errmsg = f"Failure occurred:\n{ex}"
+                errmsg = f"{failure_prefix}: Failure occurred:\n{ex}"
                 self.logger.error(errmsg)
                 return pb2.gw_refresh_network_status(status=errno.EINVAL, error_message=errmsg)
 

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -2143,6 +2143,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
     def add_listeners(self, subsystem_nqn, ip_list, is_secure, port):
         final_err_msg = ""
+        succeeded = []
         nics = NICS(self.logger, True)
         for ip in ip_list:
             hostname = self.host_name
@@ -2172,6 +2173,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 self.logger.info(f'Automatically created listener at {ip_}:{port} for '
                                  f'{subsystem_nqn}')
                 self.subsystem_auto_listeners[subsystem_nqn].add((adrfam, ip, port))
+                succeeded.append(f"{ip_}:{port}")
             elif status != errno.EEXIST:
                 warnmsg = f"Warning: failed to create auto-listener at {ip_}:{port} for " \
                           f"{subsystem_nqn}: {rt.error_message}"
@@ -2179,10 +2181,11 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 if final_err_msg:
                     final_err_msg += "\n"
                 final_err_msg += warnmsg
-        return pb2.req_status(status=0, error_message=final_err_msg)
+        return final_err_msg, succeeded
 
     def del_listeners(self, subsystem_nqn, ip_list, is_secure, port):
         final_err_msg = ""
+        succeeded = []
         if not port:
             if is_secure:
                 port = GatewayService.SECURE_LISTENER_PORT_DEFAULT
@@ -2204,6 +2207,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
             if status == 0:
                 self.logger.info(f'Automatically deleted listener at {ip_}:{port} for '
                                  f'{subsystem_nqn}')
+                succeeded.append(f"{ip_}:{port}")
             elif status != errno.ENOENT:
                 warnmsg = f"Warning: failed to delete auto-listener at {ip_}:{port} for " \
                           f"{subsystem_nqn}: {rt.error_message}"
@@ -2218,7 +2222,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     if lstnr in self.subsystem_auto_listeners[subsystem_nqn]:
                         self.subsystem_auto_listeners[subsystem_nqn].remove(lstnr)
 
-        return pb2.req_status(status=0, error_message=final_err_msg)
+        return final_err_msg, succeeded
 
     def _create_auto_listeners_safe(self, request):
         """
@@ -2230,12 +2234,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
         network_mask_subnets = request.network_mask
         for subnet in set(network_mask_subnets):
             found_host_ips = NICS(self.logger, True).get_ips_in_subnet(subnet)
-            ret = self.add_listeners(request.subsystem_nqn, found_host_ips,
-                                     request.secure_listeners, request.port)
-            if ret.error_message:
+            err_msg, _ = self.add_listeners(request.subsystem_nqn, found_host_ips,
+                                            request.secure_listeners, request.port)
+            if err_msg:
                 if final_err_msg:
                     final_err_msg += "\n"
-                final_err_msg += ret.error_message
+                final_err_msg += err_msg
         return pb2.req_status(status=0, error_message=final_err_msg)
 
     def create_auto_listeners(self, request):
@@ -2272,7 +2276,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
 
-        rt = pb2.req_status(status=0, error_message="")
+        err_msg = ""
         omap_lock = self.omap_lock.get_omap_lock_to_use(context)
         with omap_lock:
             subsys_entry = None
@@ -2297,8 +2301,8 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     return pb2.req_status(status=0, error_message=warnmsg)
 
                 found_ips = NICS(self.logger, True).get_ips_in_subnet(network_to_add)
-                rt = self.add_listeners(request.subsystem_nqn, found_ips,
-                                        subsys_entry.secure_listeners, subsys_entry.port)
+                err_msg, _ = self.add_listeners(request.subsystem_nqn, found_ips,
+                                                subsys_entry.secure_listeners, subsys_entry.port)
                 existing_network_masks.add(network_to_add)
                 new_network_mask = list(existing_network_masks)
                 self.subsys_network[request.subsystem_nqn] = new_network_mask
@@ -2315,7 +2319,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 errmsg = f"Failure occurred:\n{ex}"
                 self.logger.error(errmsg)
                 return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
-        return pb2.req_status(status=rt.status, error_message=rt.error_message)
+        return pb2.req_status(status=0, error_message=err_msg)
 
     def add_subsystem_network(self, request, context=None):
         """Add a network_mask on subsystem"""
@@ -2350,7 +2354,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
             self.logger.error(errmsg)
             return pb2.req_status(status=errno.EADDRNOTAVAIL, error_message=errmsg)
 
-        rt = pb2.req_status(status=0, error_message="")
+        err_msg = ""
         omap_lock = self.omap_lock.get_omap_lock_to_use(context)
         with omap_lock:
             subsys_entry = None
@@ -2397,8 +2401,8 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                      f"{request.subsystem_nqn}: {ips_to_keep} still covered by "
                                      f"remaining network masks {remaining_network_masks}")
 
-                rt = self.del_listeners(request.subsystem_nqn, ips_to_delete,
-                                        subsys_entry.secure_listeners, subsys_entry.port)
+                err_msg, _ = self.del_listeners(request.subsystem_nqn, ips_to_delete,
+                                                subsys_entry.secure_listeners, subsys_entry.port)
                 new_network_mask = remaining_network_masks
                 self.subsys_network[request.subsystem_nqn] = new_network_mask
                 if context:
@@ -2414,13 +2418,98 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 errmsg = f"Failure occurred:\n{ex}"
                 self.logger.error(errmsg)
                 return pb2.req_status(status=errno.EINVAL, error_message=errmsg)
-        return pb2.req_status(status=rt.status, error_message=rt.error_message)
+        return pb2.req_status(status=0, error_message=err_msg)
 
     def del_subsystem_network(self, request, context=None):
         """Delete a network mask on subsystem"""
         err_prefix = f"Failure deleting network {request.network_mask} for " \
                      f"subsystem {request.subsystem_nqn}: "
         return self.execute_grpc_function(self.del_subsystem_network_safe, request,
+                                          context, err_prefix)
+
+    def gw_refresh_network_safe(self, request, context):
+        """Re-evaluate subsystem network masks and update auto-listeners for this gateway"""
+        assert self.rpc_lock.locked(), \
+            "RPC is unlocked when calling gw_refresh_network_safe()"
+
+        self.logger.info(f"Received request to refresh network for subsystem "
+                         f"{request.subsystem_nqn}, context: {context}")
+
+        if not request.subsystem_nqn:
+            errmsg = "Failure refreshing network: missing subsystem NQN"
+            self.logger.error(errmsg)
+            return pb2.gw_refresh_network_status(status=errno.EINVAL, error_message=errmsg)
+
+        if request.subsystem_nqn not in self.subsys_serial:
+            errmsg = f"Failure refreshing network: subsystem {request.subsystem_nqn} not found"
+            self.logger.error(errmsg)
+            return pb2.gw_refresh_network_status(status=errno.ENOENT, error_message=errmsg)
+
+        final_err_msg = ""
+        added = []
+        removed = []
+        omap_lock = self.omap_lock.get_omap_lock_to_use(context)
+        with omap_lock:
+            subsys_entry = None
+            state = self.gateway_state.local.get_state()
+            subsys_key = GatewayState.build_subsystem_key(request.subsystem_nqn)
+            try:
+                state_subsys = state[subsys_key]
+                subsys_entry = json_format.Parse(state_subsys, pb2.create_subsystem_req(),
+                                                 ignore_unknown_fields=True)
+            except Exception:
+                errmsg = f"Can't find entry for subsystem {request.subsystem_nqn}"
+                self.logger.error(errmsg)
+                return pb2.gw_refresh_network_status(status=errno.ENOENT, error_message=errmsg)
+            assert subsys_entry, f"Can't find entry for subsystem {request.subsystem_nqn}"
+
+            if not subsys_entry.network_mask:
+                errmsg = (f"Failure refreshing network: subsystem {request.subsystem_nqn} "
+                          f"has no network masks configured")
+                self.logger.error(errmsg)
+                return pb2.gw_refresh_network_status(status=errno.ENOENT, error_message=errmsg)
+
+            try:
+                nics = NICS(self.logger, True)
+                subnet_ips = set()
+                for mask in subsys_entry.network_mask:
+                    for ip in nics.get_ips_in_subnet(mask):
+                        adrfam = f'ipv{ip_address(ip).version}'
+                        if nics.verify_ip_address(ip, adrfam):
+                            subnet_ips.add(ip)
+
+                current_ips = {ip for (_, ip, _) in
+                               self.subsystem_auto_listeners.get(request.subsystem_nqn, set())}
+                to_add = subnet_ips - current_ips
+                to_remove = current_ips - subnet_ips
+
+                if to_add:
+                    err_msg, added = self.add_listeners(request.subsystem_nqn, sorted(to_add),
+                                                        subsys_entry.secure_listeners,
+                                                        subsys_entry.port)
+                    if err_msg:
+                        final_err_msg += err_msg
+
+                if to_remove:
+                    err_msg, removed = self.del_listeners(request.subsystem_nqn, sorted(to_remove),
+                                                          subsys_entry.secure_listeners,
+                                                          subsys_entry.port)
+                    if err_msg:
+                        if final_err_msg:
+                            final_err_msg += "\n"
+                        final_err_msg += err_msg
+            except Exception as ex:
+                errmsg = f"Failure occurred:\n{ex}"
+                self.logger.error(errmsg)
+                return pb2.gw_refresh_network_status(status=errno.EINVAL, error_message=errmsg)
+
+        return pb2.gw_refresh_network_status(status=0, error_message=final_err_msg,
+                                             added=added, removed=removed)
+
+    def gw_refresh_network(self, request, context=None):
+        """Re-evaluate subsystem network masks and update auto-listeners for this gateway"""
+        err_prefix = "Failure refreshing network listeners: "
+        return self.execute_grpc_function(self.gw_refresh_network_safe, request,
                                           context, err_prefix)
 
     def _add_one_kmip_server_endpoint(self, subsys, server, endpoint, context):

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -71,6 +71,9 @@ service Gateway {
 	// Delete a subsystem network
 	rpc del_subsystem_network(del_subsystem_network_req) returns(req_status) {}
 
+	// Refresh auto-listeners for all network masks configured on the given subsystem on this gateway
+	rpc gw_refresh_network(gw_refresh_network_req) returns(gw_refresh_network_status) {}
+
 	// Add KMIP server endpoints
 	rpc add_kmip_server_endpoints(add_kmip_server_endpoints_req) returns(req_status) {}
 
@@ -327,6 +330,17 @@ message add_subsystem_network_req {
 message del_subsystem_network_req {
 	string subsystem_nqn = 1;
 	string network_mask = 2;
+}
+
+message gw_refresh_network_req {
+	string subsystem_nqn = 1;
+}
+
+message gw_refresh_network_status {
+	int32 status = 1;
+	string error_message = 2;
+	repeated string added = 3;
+	repeated string removed = 4;
 }
 
 message kmip_server_endpoint {

--- a/tests/test_auto_listeners.py
+++ b/tests/test_auto_listeners.py
@@ -451,3 +451,60 @@ class TestAutoListener:
         expected_warn = f"No existing network mask found for subsystem {subsystem5}"
         assert expected_warn in ret.error_message
         assert expected_warn in caplog.text
+
+    def test_refresh_network_no_change(self, caplog, gateway):
+        caplog.clear()
+        ret = cli_test(["gw", "refresh_network", "--subsystem", subsystem])
+        assert ret.status == 0
+        assert ret.error_message == ""
+        assert len(ret.added) == 0
+        assert len(ret.removed) == 0
+        assert "Automatically created listener" not in caplog.text
+        assert "Automatically deleted listener" not in caplog.text
+
+    def test_refresh_network_removes(self, caplog, gateway):
+        gw, stub = gateway
+        fake_ip = "192.168.99.99"
+        gw.subsystem_auto_listeners[subsystem].add(("ipv4", fake_ip, 4420))
+        caplog.clear()
+        req = pb2.gw_refresh_network_req(subsystem_nqn=subsystem)
+        ret = stub.gw_refresh_network(req)
+        assert ret.status == 0
+        assert len(ret.added) == 0
+        assert f"{fake_ip}:4420" in ret.removed
+        assert f"Automatically deleted listener at {fake_ip}:4420 for {subsystem}" in caplog.text
+
+    def test_refresh_network_adds(self, caplog, gateway):
+        gw, stub = gateway
+        # simulate a new IP in netmask subnet by
+        # removing auto-listener without removing network_mask from subsystem
+        with gw.rpc_lock:
+            gw.del_listeners(subsystem, [addr], False, 4420)
+        caplog.clear()
+        req = pb2.gw_refresh_network_req(subsystem_nqn=subsystem)
+        ret = stub.gw_refresh_network(req)
+        assert ret.status == 0
+        assert f"{addr}:4420" in ret.added
+        assert len(ret.removed) == 0
+        assert f"Automatically created listener at {addr}:4420 for {subsystem}" in caplog.text
+
+    def test_refresh_network_invalid_subsystem(self, caplog, gateway):
+        _, stub = gateway
+        caplog.clear()
+        req = pb2.gw_refresh_network_req(subsystem_nqn="nqn.invalid")
+        ret = stub.gw_refresh_network(req)
+        assert ret.status != 0
+        assert len(ret.added) == 0
+        assert len(ret.removed) == 0
+        assert "Failure refreshing network: subsystem nqn.invalid not found" in ret.error_message
+
+    def test_refresh_network_netmasks_not_configured(self, caplog, gateway):
+        _, stub = gateway
+        caplog.clear()
+        req = pb2.gw_refresh_network_req(subsystem_nqn=subsystem5)
+        ret = stub.gw_refresh_network(req)
+        assert ret.status != 0
+        assert len(ret.added) == 0
+        assert len(ret.removed) == 0
+        assert (f"Failure refreshing network: subsystem {subsystem5} has no network masks"
+                f" configured") in ret.error_message

--- a/tests/test_auto_listeners.py
+++ b/tests/test_auto_listeners.py
@@ -496,7 +496,8 @@ class TestAutoListener:
         assert ret.status != 0
         assert len(ret.added) == 0
         assert len(ret.removed) == 0
-        assert "Failure refreshing network: subsystem nqn.invalid not found" in ret.error_message
+        assert "Failure refreshing network for subsystem nqn.invalid: subsystem nqn.invalid" \
+               " not found" in ret.error_message
 
     def test_refresh_network_netmasks_not_configured(self, caplog, gateway):
         _, stub = gateway
@@ -506,5 +507,5 @@ class TestAutoListener:
         assert ret.status != 0
         assert len(ret.added) == 0
         assert len(ret.removed) == 0
-        assert (f"Failure refreshing network: subsystem {subsystem5} has no network masks"
-                f" configured") in ret.error_message
+        assert (f"Failure refreshing network for subsystem {subsystem5}: subsystem {subsystem5}"
+                f" has no network masks configured") in ret.error_message


### PR DESCRIPTION
This command lets users reconfigure auto-listeners in the subsystem's network masks to current
network config (i.e. add/delete auto-listeners within the subnets accordingly).

Fixes: https://github.com/ceph/ceph-nvmeof/issues/1900

Use-cases
-----------

### CASE 1: removing auto-listener with refresh:

1. Add a network interface: 
```
[root@refreshn-vallari-cluster-node1 ~]# ip link add eth0-alias type dummy
[root@refreshn-vallari-cluster-node1 ~]# ip addr add 10.240.63.4/24 dev eth0-alias
[root@refreshn-vallari-cluster-node1 ~]# ip link set eth0-alias up
[root@refreshn-vallari-cluster-node1 ~]# ip addr show eth0-alias
44: eth0-alias: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 62:19:ab:17:d7:24 brd ff:ff:ff:ff:ff:ff
    inet 10.240.63.4/24 scope global eth0-alias
       valid_lft forever preferred_lft forever
    inet6 fe80::6019:abff:fe17:d724/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
```
2. create a subsystem with auto-listener on above dummy IP:
```
[root@refreshn-vallari-cluster-node1 ~]# ceph nvmeof subsystem add nqn.2016-06.io.spdk:cnode25 --network-mask '10.240.63.0/24'
Adding subsystem nqn.2016-06.io.spdk:cnode25.mygroup1: Successful
[root@refreshn-vallari-cluster-node1 ~]# ceph nvmeof listener list nqn.2016-06.io.spdk:cnode25.mygroup1
+------------------------------+---------+--------------+-----------+----+------+------+------+
|Host                          |Transport|Address Family|Address    |Port|Secure|Active|Manual|
+------------------------------+---------+--------------+-----------+----+------+------+------+
|refreshn-vallari-cluster-node1|TCP      |ipv4          |10.240.63.4|4420|False |True  |False |
+------------------------------+---------+--------------+-----------+----+------+------+------+
[root@refreshn-vallari-cluster-node1 ~]#
```
3. bring it down:
```
[root@refreshn-vallari-cluster-node1 ~]# ip link set eth0-alias down
[root@refreshn-vallari-cluster-node1 ~]# ip addr show eth0-alias
44: eth0-alias: <BROADCAST,NOARP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
    link/ether 62:19:ab:17:d7:24 brd ff:ff:ff:ff:ff:ff
    inet 10.240.63.4/24 scope global eth0-alias
       valid_lft forever preferred_lft forever
[root@refreshn-vallari-cluster-node1 ~]#
```
4. refresh network on subsystem:
```
[root@refreshn-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:add-refresh-network-cmd-2 --server-address 10.243.64.30 gw refresh_network -n nqn.2016-06.io.spdk:cnode25.mygroup1
Refreshed configured network masks for subsystem nqn.2016-06.io.spdk:cnode25.mygroup1 on this gateway: Successful
Removed: 10.240.63.4:4420
```

### CASE 2: Adding auto-listener on refresh:

1. Add a new subsystem with network mask of the "down" interface IP (no auto-listener created because IP is down):
```[
root@refreshn-vallari-cluster-node1 ~]# ip addr show eth0-alias
44: eth0-alias: <BROADCAST,NOARP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
    link/ether 62:19:ab:17:d7:24 brd ff:ff:ff:ff:ff:ff
    inet 10.240.63.4/24 scope global eth0-alias
       valid_lft forever preferred_lft forever
[root@refreshn-vallari-cluster-node1 ~]# ceph nvmeof subsystem add nqn.2016-06.io.spdk:cnode26 --network-mask '10.240.63.0/24'
Adding subsystem nqn.2016-06.io.spdk:cnode26.mygroup1: Successful
[root@refreshn-vallari-cluster-node1 ~]# ceph nvmeof listener list nqn.2016-06.io.spdk:cnode26.mygroup1
++
||
++
++
```
2. bring up the network:
```
[root@refreshn-vallari-cluster-node1 ~]# ip link set eth0-alias up
[root@refreshn-vallari-cluster-node1 ~]# ip addr show eth0-alias
44: eth0-alias: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 62:19:ab:17:d7:24 brd ff:ff:ff:ff:ff:ff
    inet 10.240.63.4/24 scope global eth0-alias
       valid_lft forever preferred_lft forever
    inet6 fe80::6019:abff:fe17:d724/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
[root@refreshn-vallari-cluster-node1 ~]# ceph nvmeof listener list nqn.2016-06.io.spdk:cnode26.mygroup1
++
||
++
++
```
3. refresh
```
[root@refreshn-vallari-cluster-node1 ~]# docker run -it quay.io/vallari/nvmeof-cli:add-refresh-network-cmd-2 --server-address 10.243.64.30 gw refresh_network -n nqn.2016-06.io.spdk:cnode26.mygroup1
Refreshed configured network masks for subsystem nqn.2016-06.io.spdk:cnode26.mygroup1 on this gateway: Successful
Added:   10.240.63.4:4420
[root@refreshn-vallari-cluster-node1 ~]# ceph nvmeof listener list nqn.2016-06.io.spdk:cnode26.mygroup1
+------------------------------+---------+--------------+-----------+----+------+------+------+
|Host                          |Transport|Address Family|Address    |Port|Secure|Active|Manual|
+------------------------------+---------+--------------+-----------+----+------+------+------+
|refreshn-vallari-cluster-node1|TCP      |ipv4          |10.240.63.4|4420|False |True  |False |
+------------------------------+---------+--------------+-----------+----+------+------+------+
[root@refreshn-vallari-cluster-node1 ~]#
```