### PR TITLE
prometheus: Add rados ns to subsystem_namespace_metadata

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -7841,6 +7841,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                             s["nqn"], n["nsid"])
                         n["auto_visible"] = find_ret.auto_visible
                         n["hosts"] = find_ret.host_list
+                        n["rados_namespace_name"] = find_ret.rados_namespace_name or ""
                 else:
                     s["namespace_count"] = 0
                     s["enable_ha"] = False

--- a/control/prometheus.py
+++ b/control/prometheus.py
@@ -475,7 +475,7 @@ class NVMeOFCollector:
         subsystem_namespace_metadata = GaugeMetricFamily(
             f"{self.metric_prefix}_subsystem_namespace_metadata",
             "Namespace information for the subsystem",
-            labels=["nqn", "nsid", "bdev_name", "anagrpid"])
+            labels=["nqn", "nsid", "bdev_name", "anagrpid", "rados_namespace_name"])
         host_connection_state = GaugeMetricFamily(
             f"{self.metric_prefix}_host_connection_state",
             "Host connection state 0=disconnected, 1=connected",
@@ -511,7 +511,8 @@ class NVMeOFCollector:
                     nqn,
                     str(ns.nsid),
                     ns.bdev_name,
-                    str(ns.anagrpid)
+                    str(ns.anagrpid),
+                    ns.rados_namespace_name,
                 ], 1)
 
             conn_list = []

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -590,6 +590,7 @@ message namespace {
 	optional string nonce = 7;
 	optional bool auto_visible = 8;
 	repeated string hosts = 9;
+	optional string rados_namespace_name = 10;
 }
 
 message subsystems_info_cli {


### PR DESCRIPTION
Add rados_namespace_name to namespace info in response of get_subsystems(), to include in subsystems_info.subsystem.namespace.

Then use that to add rados_namespace_name to prometheus metric 'subsystem_namespace_metadata'.