### PR TITLE
Make get_gateway_info and list_namespaces_io_stats req to debug logs

### DIFF
--- a/control/grpc.py
+++ b/control/grpc.py
@@ -4502,9 +4502,9 @@ class GatewayService(pb2_grpc.GatewayServicer):
     def list_namespaces_io_stats(self, request, context=None):
         """Get namespaces IO stats."""
         peer_msg = self.get_peer_message(context)
-        self.logger.info(f"Received request to list IO stats for namespaces with "
-                         f"nsid: {request.nsid}, subsystem: {request.subsystem_nqn}, "
-                         f"context: {context}{peer_msg}")
+        self.logger.debug(f"Received request to list IO stats for namespaces with "
+                          f"nsid: {request.nsid}, subsystem: {request.subsystem_nqn}, "
+                          f"context: {context}{peer_msg}")
         failure_prefix = "Failure listing IO stats for namespaces"
         if (request.nsid):
             failure_prefix += f" with ID {request.nsid}"
@@ -8093,7 +8093,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
         assert self.rpc_lock.locked(), "RPC is unlocked when calling get_gateway_info_safe()"
         peer_msg = self.get_peer_message(context)
-        self.logger.info(f"Received request to get gateway's info{peer_msg}")
+        self.logger.debug(f"Received request to get gateway's info{peer_msg}")
         gw_version_string = os.getenv("NVMEOF_VERSION")
         if not self.spdk_version:
             try:


### PR DESCRIPTION
Make "Received request.." logging of list IO stats and get gateway's info into debug level logs.
These pollute the gateway logs when top io runs (because these methods are called repeatedly by top tool).

Fixes: https://github.com/ceph/ceph-nvmeof/issues/1934