### PR TITLE
discovery: notify every pending host, not just the first one

### DIFF
--- a/control/discovery.py
+++ b/control/discovery.py
@@ -1061,8 +1061,10 @@ class DiscoveryService:
         if not should_send_async_event:
             return
 
-        for key in list(self.conn_vals.keys()):
-            if self.conn_vals[key].recv_async is True:
+        with self.lock:
+            for self_conn in self.conn_vals.values():
+                if not self_conn.recv_async:
+                    continue
                 pdu_reply = Pdu()
                 pdu_reply.type = NVME_TCP_PDU.RSP
                 pdu_reply.header_length = 24
@@ -1071,20 +1073,23 @@ class DiscoveryService:
                 async_reply = CqeNVMe()
                 # async_event_type:0x2 async_event_info:0xf0 log_page_identifier:0x70
                 async_reply.dword0 = int.from_bytes(b'\x02\xf0\x70\x00', byteorder='little')
-                async_reply.sq_head_ptr = self.conn_vals[key].sq_head_ptr
-                async_reply.cmd_id = self.conn_vals[key].async_cmd_id
+                async_reply.sq_head_ptr = self_conn.sq_head_ptr
+                async_reply.cmd_id = self_conn.async_cmd_id
 
                 try:
-                    self.conn_vals[key].connection.sendall(pdu_reply + async_reply)
+                    self_conn.connection.sendall(pdu_reply + async_reply)
                 except BrokenPipeError:
-                    self.logger.error("client disconnected unexpectedly.")
-                    return
+                    # let handle_timeout() reap the dead connection, keep
+                    # notifying the other hosts
+                    self.logger.error(f"client {self_conn.connection} "
+                                      f"disconnected unexpectedly.")
+                    continue
                 except OSError as ex:
-                    self.logger.exception(f"got OS error {ex.errno}: {ex.strerror}")
-                    return
+                    self.logger.exception(f"got OS error {ex.errno}: {ex.strerror} "
+                                          f"notifying {self_conn.connection}")
+                    continue
                 self.logger.debug("notify and reply async request.")
-                self.conn_vals[key].recv_async = False
-                return
+                self_conn.recv_async = False
 
     def handle_timeout(self):
         """Handle connection timeout."""


### PR DESCRIPTION
_state_notify_update() returned right after completing the async event of the first connection with a parked AER, on the error paths too, so when a subsystem or listener change fired, only one of the hosts with a persistent discovery connection learned about it; the rest kept waiting on AERs that never complete. A dead connection was worse: BrokenPipeError returned before any remaining host was notified.

AENs complete per controller, so send the Discovery Log Page Change notice to every parked AER: loop over all connections, continue past send failures, and let the keep-alive reaper collect the dead ones.

Take self.lock while walking conn_vals, like every other accessor (nvmeof_tcp_connection, nvmeof_accept, handle_timeout): this function runs on the state-update thread, racing the reaper's del. The payload is a 40-byte AEN on a non-blocking socket, so holding the lock across the loop is fine.

break_interval stays unused: it paces heavy RPC batches in server.py's version of this callback, but here it would only delay notifications, and sleeping under the lock would stall the request path.

Fixes #1976