### PR TITLE
state: make delete_state() clear the OMAP atomically

### DIFF
--- a/control/state.py
+++ b/control/state.py
@@ -1229,9 +1229,12 @@ class OmapGatewayState(GatewayState):
             raise RuntimeError("Can't delete state when Rados is closed")
 
         try:
+            # Clear the object and re-add the version key in a single atomic
+            # write operation. Committing the clear on its own would leave the
+            # object momentarily empty, and a peer gateway's update thread
+            # reading it in that window would see no version key.
             with rados.WriteOpCtx() as write_op:
                 self.ioctx.clear_omap(write_op)
-                self.ioctx.operate_write_op(write_op, self.omap_name)
                 self.ioctx.set_omap(write_op, (self.OMAP_VERSION_KEY,),
                                     (str(1),))
                 self.ioctx.operate_write_op(write_op, self.omap_name)


### PR DESCRIPTION
`delete_state()` cleared the OMAP object and re-added the version key in two separate operate_write_op() commits. The clear committed on its own, so the object had no keys until the second commit restored the version key.

A peer gateway's _update_caller thread that read the object in that window got an empty dict, and `update()` raised `KeyError` on the missing 'omap_version' key. `test_nsid` failed intermittently as a result: the gateway's state-update thread died and never synced a subsystem created on the other gateway.

Clear the object and re-add the version key in one atomic write operation, so a reader never observes the object without its version key.