### PR TITLE
add GW gRPC and CLI support for CNC config (NVMe TP4130)

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -126,12 +126,13 @@ transport_tcp_options = {"in_capsule_data_size" : 8192, "max_io_qpairs_per_ctrlr
 qos_timeslice_in_usecs = 0
 #notifications_interval = 60
 
-#Configuration for CNC support:
+#Configuration for CNC support (NVMe TP4130 Cross Namespace Copy):
 
 #cnc_enable = True
 #cnc_rate_limiter_bytes = 100000000
 #cnc_chunk_blocks = 512
 #cnc_parallel_chunks = 8
+#cnc_fmt2_enable = True
 [monitor]
 #timeout = 1.0
 #log_file_dir =

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -1039,6 +1039,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
         else:
             self.logger.info("Gateway's IO statistics is disabled")
 
+
         self.fsid = None
         spdk_notifications_interval = self.config.getint_with_default("spdk",
                                                                       "notifications_interval",

--- a/control/proto/gateway.proto
+++ b/control/proto/gateway.proto
@@ -501,6 +501,7 @@ message set_gateway_io_stats_mode_req {
 	bool enabled = 1;
 }
 
+
 // From https://nvmexpress.org/wp-content/uploads/NVM-Express-1_4-2019.06.10-Ratified.pdf page 138
 // Asymmetric Namespace Access state for all namespaces in this ANA
 // Group when accessed through this controller.

--- a/control/server.py
+++ b/control/server.py
@@ -946,14 +946,15 @@ class GatewayServer:
         cnc_rate_limiter_bytes = self.config.getint_with_default("spdk", "cnc_rate_limiter_bytes",
                                                                  100000000)
         cnc_chunk_blocks = self.config.getint_with_default("spdk", "cnc_chunk_blocks", 512)
-
         cnc_parallel_chunks = self.config.getint_with_default("spdk", "cnc_parallel_chunks", 8)
+        cnc_fmt2_enable = self.config.getboolean_with_default("spdk", "cnc_fmt2_enable", True)
 
         try:
             self.spdk_rpc_client.nvmf_cnc_set_config(host_behav_support_cnc=cnc_support,
                                                      rate_limit_bytes=cnc_rate_limiter_bytes,
                                                      max_inflight=cnc_parallel_chunks,
-                                                     chunk_nlb=cnc_chunk_blocks)
+                                                     chunk_nlb=cnc_chunk_blocks,
+                                                     fmt2_enabled=cnc_fmt2_enable)
         except Exception:
             self.logger.exception("Failure setting cnc config")
             raise


### PR DESCRIPTION
### Purpose

This PR extends the CNC (Cross Namespace Copy, NVMe TP4130) configuration introduced in #1970 by adding support for the fmt2_enabled parameter in nvmf_cnc_set_config.

### Changes

control/server.py: Reads a new cnc_fmt2_enable config key (default: True) and passes it as fmt2_enabled to nvmf_cnc_set_config() on SPDK startup.
ceph-nvmeof.conf: Documents the new cnc_fmt2_enable option and clarifies the CNC section comment to reference NVMe TP4130 Cross Namespace Copy.

### Note

This is not a fix for #1972 , that is already addressed by #1970. This PR is a follow-up that adds the missing fmt2_enabled field to the CNC SPDK RPC call.

Depends on / related to: #1970