### PR TITLE
Show IP instead of daemon_name in listener_list "hostname"

### DIFF
--- a/control/cephutils.py
+++ b/control/cephutils.py
@@ -63,6 +63,41 @@ class CephUtils:
                                 f"{rply[2]}\nCommand was \"{cmd}\"")
         return rply
 
+    def execute_ceph_mgr_command(self, cmd):
+        self.logger.debug(f"Execute mgr command: {cmd}")
+        with rados.Rados(conffile=self.ceph_conf, rados_id=self.rados_id) as cluster:
+            rply = cluster.mgr_command(cmd, b'')
+        self.logger.debug(f"Mgr reply: {rply}")
+        if not rply or len(rply) != 3:
+            self.logger.error(f"Invalid Ceph reply: {rply} for command \"{cmd}\"")
+            return (-errno.EINVAL, b'', '')
+        if rply[0] != 0:
+            self.logger.warning(f"Got error {-rply[0]} ({os.strerror(-rply[0])}) from Ceph mgr: "
+                                f"{rply[2]}\nCommand was \"{cmd}\"")
+        return rply
+
+    def get_gw_hostnames(self) -> dict:
+        try:
+            cmd = '{"prefix":"service dump", "format": "json"}'
+            self.logger.debug(f"service dump string: {cmd}")
+            rply = self.execute_ceph_mgr_command(cmd)
+            self.logger.debug(f"reply \"{rply}\"")
+            if rply and rply[0] != 0:
+                return {}
+            data = json.loads(rply[1].decode())
+            daemons = data.get("services", {}).get("nvmeof", {}).get("daemons", {})
+            hostnames = {}
+            for daemon_id, daemon_info in daemons.items():
+                if not isinstance(daemon_info, dict):
+                    continue
+                hostname = daemon_info.get("metadata", {}).get("hostname")
+                if hostname:
+                    hostnames[daemon_id] = hostname
+            return hostnames
+        except Exception as e:
+            self.logger.debug(f"Gateway failed to get mgr command \"service dump\": {e}")
+            return {}
+
     def get_gw_listeners(self, pool, group) -> list:
         try:
             str = '{' + f'"prefix":"nvme-gw listeners", "pool":"{pool}", "group":"{group}"' + '}'

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -7977,9 +7977,10 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 if request.subsystem in nvmemon_listeners:
                     subsystem_listeners = nvmemon_listeners[request.subsystem]
                     secure = subsystem.get('secure_listeners', False)
+                    gw_hostnames = self.ceph_utils.get_gw_hostnames()
                     for _listener in subsystem_listeners:
                         listener = {
-                            "host_name": _listener["gw_id"],
+                            "host_name": _listener["address"],
                             "adrfam": (_listener["address_family"] or '').lower(),
                             "trsvcid": int(_listener["svcid"] or 0),
                             "nqn": request.subsystem,
@@ -7989,7 +7990,11 @@ class GatewayService(pb2_grpc.GatewayServicer):
                         listener_key = (listener["traddr"], listener["trsvcid"])
                         if listener_key in omap_listeners:
                             continue
-                        hostname = GatewayUtils.get_hostname(listener["traddr"], self.logger)
+                        gw_id = _listener["gw_id"].removeprefix("client.nvmeof.")
+                        hostname = gw_hostnames.get(gw_id)
+                        if not hostname:
+                            self.logger.debug(f"No hostname in service dump for {gw_id=}")
+                            hostname = GatewayUtils.get_hostname(listener["traddr"], self.logger)
                         if hostname:
                             listener["host_name"] = hostname
                         listener_json = json.dumps(listener)

--- a/control/utils.py
+++ b/control/utils.py
@@ -124,13 +124,14 @@ class GatewayUtils:
 
         return True
 
+    @staticmethod
     def get_hostname(ip_addr: str, logger) -> str:
         try:
             ret = socket.gethostbyaddr(ip_addr)
             if ret:
                 return ret[0]
         except Exception as e:
-            logger.error(f'error in get_hostname: {e}')
+            logger.error(f'Failed to resolve hostname for IP {ip_addr}: {e}')
         return ''
 
     @staticmethod

--- a/tests/test_auto_listeners.py
+++ b/tests/test_auto_listeners.py
@@ -1,6 +1,7 @@
 import pytest
 from control.server import GatewayServer
 import socket
+import control.utils as utils
 from control.cli import main as cli
 from control.cli import main_test as cli_test
 from control.cephutils import CephUtils
@@ -100,6 +101,87 @@ class TestAutoListener:
         assert listeners.listeners[1].active
         assert not listeners.listeners[1].secure
         assert not listeners.listeners[1].manual
+
+    def test_auto_listener_hostname_from_service_dump(self, caplog, gateway):
+        gateway_rpc, _ = gateway
+        mock_hostname = "cluster-node1"
+        mock_gw_id = "client.nvmeof.mypool.mygroup.cluster-node1.abcd"
+        mock_daemon_id = "mypool.mygroup.cluster-node1.abcd"
+        remote_addr = "10.0.0.99"
+
+        def mock_get_gw_listeners(pool, group):
+            return {
+                subsystem: [{
+                    "gw_id": mock_gw_id,
+                    "address": remote_addr,
+                    "address_family": "ipv4",
+                    "svcid": "4420",
+                }]
+            }
+
+        def mock_get_gw_hostnames():
+            return {mock_daemon_id: mock_hostname}
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(gateway_rpc.ceph_utils, "get_gw_listeners", mock_get_gw_listeners)
+            mp.setattr(gateway_rpc.ceph_utils, "get_gw_hostnames", mock_get_gw_hostnames)
+            caplog.clear()
+            listeners = cli_test(["listener", "list", "--subsystem", subsystem])
+
+            assert listeners.status == 0
+            matched = [listener for listener in listeners.listeners
+                       if listener.traddr == remote_addr]
+            assert len(matched) == 1
+            assert not matched[0].manual
+            assert matched[0].host_name == mock_hostname
+
+    def test_auto_listener_hostname_from_address(self, caplog, gateway):
+        gateway_rpc, _ = gateway
+        dns_hostname = "node1"
+
+        def mock_get_gw_hostnames():
+            return {}
+
+        def mock_gethostbyaddr(ip_addr):
+            return (dns_hostname, [], [ip_addr])
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(gateway_rpc.ceph_utils, "get_gw_hostnames", mock_get_gw_hostnames)
+            mp.setattr(utils.socket, "gethostbyaddr", mock_gethostbyaddr)
+            caplog.clear()
+            listeners = cli_test(["listener", "list", "--subsystem", subsystem])
+
+            assert listeners.status == 0
+            assert len(listeners.listeners) == 2
+            for listener in listeners.listeners:
+                assert not listener.manual
+                assert listener.host_name == dns_hostname
+
+    def test_auto_listener_hostname_ip_fallback(self, caplog, gateway):
+        gateway_rpc, _ = gateway
+
+        def mock_get_gw_hostnames():
+            return {}
+
+        def raise_gethostbyaddr(ip_addr):
+            raise OSError("Unknown host")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(gateway_rpc.ceph_utils, "get_gw_hostnames", mock_get_gw_hostnames)
+            mp.setattr(utils.socket, "gethostbyaddr", raise_gethostbyaddr)
+            caplog.clear()
+            listeners = cli_test(["listener", "list", "--subsystem", subsystem])
+
+            assert listeners.status == 0
+            assert len(listeners.listeners) == 2
+            for listener in listeners.listeners:
+                assert not listener.manual
+                assert listener.traddr in (addr, addr_ipv6)
+                assert listener.host_name == listener.traddr
+                assert listener.host_name != host_name
+
+            for a in (addr, addr_ipv6):
+                assert (f"Failed to resolve hostname for IP {a}: Unknown host") in caplog.text
 
     def test_subsystem_list(self, caplog, gateway):
         subsystems = cli_test(["subsystem", "list", "--subsystem", subsystem])


### PR DESCRIPTION
Depends on https://github.com/ceph/ceph/pull/70281

Fixes: https://github.com/ceph/ceph-nvmeof/issues/1974

## Cause of problem
In list_listener, we call “nvme-gw listeners” to get auto-listener information. But this command returns gw_id (daemon_name) instead of hostname. So right now, we do a reverse DNS lookup to get hostnames and when that fails gw_id is displayed. 

We need a more reliable way to display hostname for auto-listeners. 

## Solution/Fix
Gateways will call “service dump” command (where all gateways are registered in service_map during gateway initialisation), and use the result to create a map for gw_id->hostname. This should reliably work to show hostname. In any case, if this fails, gateway will try reverse DNS lookup (like it does right now), and if that fails, it will show IP address as fallback. 

