### PR TITLE
Better error on ns add with invalid uuid

### DIFF
--- a/control/cli.py
+++ b/control/cli.py
@@ -2800,6 +2800,9 @@ class GatewayClient:
             self.cli.parser.error("load-balancing-group value must be positive")
         if args.nsid is not None and args.nsid <= 0:
             self.cli.parser.error("nsid value must be positive")
+        if args.uuid is not None and not GatewayUtils.is_valid_uuid(args.uuid):
+            self.cli.parser.error(f"--uuid value '{args.uuid}' is not a valid UUID "
+                                  f"(expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)")
         if args.rbd_create_image:
             if args.size is None:
                 self.cli.parser.error("--size argument is mandatory for add command when "

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -3519,6 +3519,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
 
         if not request.uuid:
             request.uuid = str(uuid.uuid4())
+        elif not GatewayUtils.is_valid_uuid(request.uuid):
+            errmsg = (f"Failure adding namespace {nsid_msg}to {request.subsystem_nqn}: "
+                      f"Invalid UUID '{request.uuid}' "
+                      f"(expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)")
+            self.logger.error(errmsg)
+            return pb2.nsid_status(status=errno.EINVAL, error_message=errmsg)
 
         if request.trash_image and not request.create_image:
             self.logger.warning("Can't trash the RBD image on delete if it "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -567,6 +567,27 @@ class TestCreate:
         cli(["namespace", "del", "--subsystem", subsystem, "--nsid", "1"])
         assert f"Deleting namespace 1 from {subsystem}: Successful" in caplog.text
 
+    def test_add_namespace_invalid_uuid(self, caplog, gateway):
+        invalid_uuids = [
+            "not-a-uuid",
+            "948878ee-c3b2-4d58-a29b",  # too short
+            "948878ee-c3b2-4d58-a29b-2cff713fc02dXXXX",  # too long
+            "948878ee-ZZZZ-4d58-a29b-2cff713fc02d",  # non-hex chars
+            "948878eec3b24d58a29b2cff713fc02d",  # no dashes
+        ]
+        for bad_uuid in invalid_uuids:
+            caplog.clear()
+            rc = 0
+            try:
+                cli(["namespace", "add", "--subsystem", subsystem,
+                     "--rbd-pool", pool, "--rbd-image", image2,
+                     "--uuid", bad_uuid, "--size", "16MB", "--rbd-create-image"])
+            except SystemExit as sysex:
+                rc = sysex.code
+            assert rc == 2, f"Expected exit code 2 for uuid={bad_uuid!r}, got {rc}"
+            assert "is not a valid UUID" in caplog.text, (
+                f"Expected validation error for uuid={bad_uuid!r}, got: {caplog.text}")
+
     def test_add_namespace_double_uuid(self, caplog, gateway):
         caplog.clear()
         cli(["namespace", "add", "--subsystem", subsystem, "--rbd-pool", pool,


### PR DESCRIPTION
before:
```
[xxx@xxx ~]# ceph nvmeof ns add --nqn=nqn.2016-06.io.spdk:cnode4.mygroup1 --uuid=adsfasf --create-image=true --rbd-image-size=10MB --rbd_image_name sub2image4 --rbd-pool=mypool
Error EINVAL: Failure adding namespace to nqn.2016-06.io.spdk:cnode4.mygroup1: spdk_json_decode_object failed
```

after:
```
[root@uuid-tomer-cluster-node1 ~]# docker run -it --rm quay.io/barakda1/nvmeof-cli:pr2026 --server-address=10.243.64.116 namespace add --subsystem=nqn.2016-06.io.spdk:cnode2.mygroup1 --size=10MB --uuid=asdfasf --rbd-image=hello --rbd-pool=mypool
usage: python3 -m control.cli [-h] [--format {text,json,yaml,plain,python}] [--output {log,stdio}] [--log-level {debug,DEBUG,info,INFO,warning,WARNING,error,ERROR,critical,CRITICAL}] [--server-address SERVER_ADDRESS]
                              [--server-port SERVER_PORT] [--client-key CLIENT_KEY] [--client-cert CLIENT_CERT] [--server-cert SERVER_CERT] [--max-message-length MAX_MESSAGE_LENGTH] [--verbose]
                              {version,gateway,gw,spdk_log_level,subsystem,listener,host,connection,namespace,ns,get_subsystems} ...
error: --uuid value 'asdfasf' is not a valid UUID (expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)

[xxx@xxx ~]# ceph nvmeof ns add --nqn=nqn.2016-06.io.spdk:cnode4.mygroup1 --uuid=adsfasf --create-image=true --rbd-image-size=10MB --rbd_image_name sub2image4 --rbd-pool=mypool
Error EINVAL: Failure adding namespace to nqn.2016-06.io.spdk:cnode4.mygroup1: Invalid UUID 'adsfasf' (expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
```