### PR TITLE
Handle the case we use an encrypted namespace with a plain image

### DIFF
--- a/control/cephutils.py
+++ b/control/cephutils.py
@@ -401,6 +401,47 @@ class CephUtils:
             return rbd.RBD_ENCRYPTION_ALGORITHM_AES256
         return -1
 
+    def verify_image_encryption_settings(self, pool_name, rados_namespace_name,
+                                         image_name, image_path,
+                                         encryption_entries) -> str:
+
+        if not encryption_entries:
+            return ""
+
+        specs = []
+        for enc in encryption_entries:
+            if not enc.format:
+                return "Missing encryption format"
+            if not enc.key_id:
+                return "Empty passphrase"
+            rbd_enc_format = CephUtils.gateway_encryption_format_to_rbd(enc.format)
+            if rbd_enc_format is None:
+                return "Missing encryption format"
+            elif rbd_enc_format < 0:
+                return f"Invalid encryption format {enc.format}"
+            specs.append((rbd_enc_format, enc.key_id))
+
+        with rados.Rados(conffile=self.ceph_conf, rados_id=self.rados_id) as cluster:
+            with cluster.open_ioctx(pool_name) as ioctx:
+                if rados_namespace_name:
+                    ioctx.set_namespace(rados_namespace_name)
+                try:
+                    with rbd.Image(ioctx, image_name) as img:
+                        img.encryption_load2(specs)
+                except rbd.InvalidArgument:
+                    errmsg = f"RBD image {image_path} is not formatted for encryption"
+                    self.logger.exception(errmsg)
+                    return errmsg
+                except rbd.PermissionError:
+                    errmsg = f"Wrong passphrase for RBD image {image_path}"
+                    self.logger.exception(errmsg)
+                    return errmsg
+                except Exception:
+                    errmsg = f"Can't verify encryption state for RBD image {image_path}"
+                    self.logger.exception(errmsg)
+                    return errmsg
+        return ""
+
     def create_image(self, pool_name, data_pool_name, rados_namespace_name, image_name,
                      size, encryption_format=None, encryption_algorithm=None,
                      passphrase=None) -> bool:
@@ -423,25 +464,32 @@ class CephUtils:
             image_size = self.get_image_size(pool_name, image_name, rados_namespace_name)
             image_exists = True
         except rbd.ImageNotFound:
-            self.logger.debug(f"Image {image_path} doesn't exist, will "
+            self.logger.debug(f"RBD Image {image_path} doesn't exist, will "
                               f"create it using size {size}")
             pass
 
+        rbd_encryption_format = CephUtils.gateway_encryption_format_to_rbd(
+            encryption_format)
+        if rbd_encryption_format is not None and rbd_encryption_format < 0:
+            raise ValueError("Invalid encryption format")
+        rbd_encryption_algorithm = CephUtils.gateway_encryption_algorithm_to_rbd(
+            encryption_algorithm)
+        if rbd_encryption_algorithm is not None and rbd_encryption_algorithm < 0:
+            raise ValueError("Invalid encryption algorithm")
+
         if image_exists:
             if image_size != size:
-                raise rbd.ImageExists(f"Image {image_path} already exists with "
+                raise rbd.ImageExists(f"RBD Image {image_path} already exists with "
                                       f"a size of {image_size} bytes which differs from the "
                                       f"requested size of {size} bytes",
                                       errno=errno.EEXIST)
+            if rbd_encryption_format is not None and passphrase is not None:
+                enc = pb2.encryption_entry(format=encryption_format, key_id=passphrase)
+                enc_msg = self.verify_image_encryption_settings(
+                    pool_name, rados_namespace_name, image_name, image_path, [enc])
+                if enc_msg:
+                    raise rbd.PermissionError(enc_msg, errno=errno.EPERM)
             return False    # Image exists with an identical size, there is nothing to do here
-
-        encryption_format = CephUtils.gateway_encryption_format_to_rbd(encryption_format)
-        if encryption_format is not None and encryption_format < 0:
-            raise ValueError("Invalid encryption format")
-
-        encryption_algorithm = CephUtils.gateway_encryption_algorithm_to_rbd(encryption_algorithm)
-        if encryption_algorithm is not None and encryption_algorithm < 0:
-            raise ValueError("Invalid encryption algorithm")
 
         with rados.Rados(conffile=self.ceph_conf, rados_id=self.rados_id) as cluster:
             with cluster.open_ioctx(pool_name) as ioctx:
@@ -459,17 +507,17 @@ class CephUtils:
                     self.logger.exception(f"Can't create image {image_path}")
                     raise
 
-                if encryption_format is not None and passphrase is not None:
+                if rbd_encryption_format is not None and passphrase is not None:
                     try:
                         with rbd.Image(ioctx, image_name) as img:
-                            if encryption_algorithm is not None:
-                                img.encryption_format(encryption_format,
+                            if rbd_encryption_algorithm is not None:
+                                img.encryption_format(rbd_encryption_format,
                                                       passphrase,
-                                                      encryption_algorithm)
+                                                      rbd_encryption_algorithm)
                             else:
-                                img.encryption_format(encryption_format, passphrase)
+                                img.encryption_format(rbd_encryption_format, passphrase)
                     except Exception:
-                        self.logger.exception(f"Can't encrypt image {image_path}")
+                        self.logger.exception(f"Can't encrypt format RBD image {image_path}")
                         try:
                             self.logger.info(f"Will delete the created image {image_path}")
                             self.delete_image(pool_name, image_name, rados_namespace_name)

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -1744,11 +1744,12 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 if len(encryption_entries) > 0:
                     enc_format = encryption_entries[0].format
                     passphrase = encryption_entries[0].key_id
-                rc = self.ceph_utils.create_image(rbd_pool_name, rbd_data_pool_name,
-                                                  rados_namespace_name,
-                                                  rbd_image_name, rbd_image_size,
-                                                  enc_format, encryption_algorithm,
-                                                  passphrase)
+                rc = self.ceph_utils.create_image(
+                    rbd_pool_name, rbd_data_pool_name,
+                    rados_namespace_name,
+                    rbd_image_name, rbd_image_size,
+                    enc_format, encryption_algorithm,
+                    passphrase=passphrase)
                 if rc:
                     data_pool_msg = ""
                     if rbd_data_pool_name:
@@ -1799,11 +1800,22 @@ class GatewayService(pb2_grpc.GatewayServicer):
                                   error_message=errmsg)
             except Exception:
                 self.logger.exception(f"Error getting {image_path} size")
-                self.logger.error(f"Error verifying RBD image {image_path} "
-                                  f"existence")
+                errmsg = f"Error verifying RBD image {image_path} existence"
+                self.logger.error(errmsg)
                 return BdevStatus(status=errno.EIO,
-                                  error_message=f"Error verifying RBD image {image_path} "
-                                                f"existence")
+                                  error_message=errmsg)
+
+            if len(encryption_entries) > 0:
+                enc_msg = self.ceph_utils.verify_image_encryption_settings(
+                    rbd_pool_name,
+                    rados_namespace_name,
+                    rbd_image_name,
+                    image_path,
+                    encryption_entries)
+                if enc_msg:
+                    self.logger.error(enc_msg)
+                    return BdevStatus(status=errno.EPERM,
+                                      error_message=enc_msg)
 
         if disable_auto_resize:
             try:

--- a/tests/test_rbd_encrypt.py
+++ b/tests/test_rbd_encrypt.py
@@ -27,6 +27,7 @@ image2 = "enc_test_image2"
 image3 = "enc_test_image3"
 image4 = "enc_test_image4"
 image5 = "enc_test_image5"
+image6 = "enc_test_image6"
 pool = "rbd"
 subsystem1 = "nqn.2016-06.io.spdk:cnode1"
 subsystem2 = "nqn.2016-06.io.spdk:cnode2"
@@ -1211,7 +1212,26 @@ def test_open_with_encryption_wrong_key_id(caplog, two_gateways):
     cli(["namespace", "add", "--subsystem", subsystem1, "--rbd-pool", pool,
          "--rbd-data-pool", pool, "--rbd-image", image,
          "--encryption-format", "luks1", "--key-id", key_id])
-    assert f"Failure adding namespace to {subsystem1}: Operation not permitted" in caplog.text
+    assert f"Failure adding namespace to {subsystem1}: Wrong passphrase for RBD " \
+           f"image {pool}/{image}" in caplog.text
+
+
+def test_open_with_encryption_plain_image(caplog, two_gateways):
+    key_id = add_key_to_kmip_server_endpoint(kmip_dir1, kmip_addr, kmip_port, "bla")
+    caplog.clear()
+    cli(["namespace", "add", "--subsystem", subsystem1, "--rbd-pool", pool,
+         "--rbd-data-pool", pool, "--rbd-image", image6,
+         "--rbd-create-image", "--size", "16MB"])
+    wait_for_string(caplog, f"Adding namespace 1 to {subsystem1}: Successful", 5)
+    caplog.clear()
+    cli(["namespace", "del", "--subsystem", subsystem1, "--nsid", "1"])
+    assert f"Deleting namespace 1 from {subsystem1}: Successful" in caplog.text
+    caplog.clear()
+    cli(["namespace", "add", "--subsystem", subsystem1, "--rbd-pool", pool,
+         "--rbd-data-pool", pool, "--rbd-image", image6,
+         "--encryption-format", "luks1", "--key-id", key_id])
+    assert f"Failure adding namespace to {subsystem1}: RBD " \
+           f"image {pool}/{image6} is not formatted for encryption" in caplog.text
 
 
 def test_list_namespaces(caplog, two_gateways):
@@ -1329,7 +1349,8 @@ def test_open_with_encryption_second_server(caplog, two_gateways):
     cli(["namespace", "add", "--subsystem", subsystem2, "--rbd-pool", pool,
          "--rbd-data-pool", pool, "--rbd-image", image,
          "--encryption-format", "luks1", "--key-id", key_id])
-    assert f"Failure adding namespace to {subsystem2}: Operation not permitted" in caplog.text
+    assert f"Failure adding namespace to {subsystem2}: Wrong passphrase for RBD " \
+           f"image {pool}/{image}" in caplog.text
     caplog.clear()
     cli(["namespace", "add", "--subsystem", subsystem2, "--rbd-pool", pool,
          "--rbd-data-pool", pool, "--rbd-image", image,


### PR DESCRIPTION
We should display a human readable error for the user in this case.
Fixes: #2008