### PR TITLE
ci: nodejs 20 -> 24, resolve deprecated warning

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -60,14 +60,14 @@ jobs:
           docker save $QUAY_SPDK:$SPDK_VERSION > spdk.tar
 
       - name: Upload bdevperf container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_bdevperf
           path: |
             bdevperf.tar
 
       - name: Upload nvmeof container images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_nvmeof
           path: |
@@ -75,7 +75,7 @@ jobs:
             nvmeof-cli.tar
 
       - name: Upload spdk container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_image_spdk
           path: |
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build container images - ceph
         run: make build SVC=ceph
@@ -96,7 +96,7 @@ jobs:
           docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
 
       - name: Upload ceph container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_ceph
           path: |
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build KMIP container images
         run: |
@@ -117,7 +117,7 @@ jobs:
           docker save kmip-server:latest > kmip-server.tar
           docker save kmip-cli:latest > kmip-cli.tar
       - name: Upload KMIP container images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: kmip_images
           path: |
@@ -135,14 +135,14 @@ jobs:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup huge pages
         run: |
           make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -239,7 +239,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_pytest_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -266,13 +266,13 @@ jobs:
       HUGEPAGES: 512
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -348,7 +348,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_demo_${{ matrix.security_protocol }}
           path: /tmp/out/*.log
@@ -375,13 +375,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -543,13 +543,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -613,7 +613,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_ha_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -633,10 +633,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: container_images_nvmeof
 
@@ -653,7 +653,7 @@ jobs:
     runs-on: dailyAtomRunner
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Container_images_nvmeof folder (tar files) download
         run: |
@@ -680,7 +680,7 @@ jobs:
 
       # TODO: investigating upluad to artifact issue
       # - name: Upload artifact for non-schedule events
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@v7
       #   if: always()
       #   with:
       #     name: atom-artifact
@@ -693,7 +693,7 @@ jobs:
   #   timeout-minutes: 1440
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Container_images_nvmeof folder (tar files) download
   #       run: |
@@ -720,13 +720,13 @@ jobs:
 
   #     - name: Upload nightly nvmeof console as artifact
   #       if: always()
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: atom-nightly-nvmeof-full-console
   #         path: atom_nightly_nvmeof_console.log
 
   #     - name: Upload artifact for schedule events
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       if: always()
   #       with:
   #         name: atom-artifact
@@ -739,16 +739,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download container images (nvmeof)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images_nvmeof*
           merge-multiple: true
 
       - name: Download container image (spdk)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_image_spdk
           merge-multiple: true
@@ -777,10 +777,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images_nvmeof*
           merge-multiple: true
@@ -810,7 +810,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup
         run: make setup

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
       has-go: ${{ steps.check.outputs.has-go }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Check for Go code
         id: check
@@ -80,7 +80,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -90,7 +90,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -102,7 +102,7 @@ jobs:
         # queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"
 
@@ -119,15 +119,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: go
         build-mode: autobuild
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:go"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: ${{env.REF}} 
-      - uses: pdm-project/setup-pdm@v3
+      - uses: pdm-project/setup-pdm@v4
         with:
           python-version: ${{env.DEFAULT_PYTHON}}
           version: ${{env.DEFAULT_PDM}}

--- a/.github/workflows/squid-8.1-schedule.yml
+++ b/.github/workflows/squid-8.1-schedule.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'squid_8.1'  # Checkout the squid_8.1 branch
           submodules: recursive
@@ -47,14 +47,14 @@ jobs:
           docker save $QUAY_SPDK:$SPDK_VERSION > spdk.tar
 
       - name: Upload bdevperf container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_bdevperf
           path: |
             bdevperf.tar
 
       - name: Upload nvmeof container images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_nvmeof
           path: |
@@ -62,7 +62,7 @@ jobs:
             nvmeof-cli.tar
 
       - name: Upload spdk container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_image_spdk
           path: |
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'squid_8.1'  # Checkout the squid_8.1 branch
 
@@ -85,7 +85,7 @@ jobs:
           docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
 
       - name: Upload ceph container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_ceph
           path: |
@@ -102,7 +102,7 @@ jobs:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'squid_8.1'  # Checkout the squid_8.1 branch
 
@@ -111,7 +111,7 @@ jobs:
           make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_pytest_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -219,7 +219,7 @@ jobs:
       HUGEPAGES: 512
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'squid_8.1'  # Checkout the squid_8.1 branch
 
@@ -227,7 +227,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -298,7 +298,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_demo_${{ matrix.security_protocol }}
           path: /tmp/out/*.log
@@ -325,7 +325,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'squid_8.1'  # Checkout the squid_8.1 branch
 
@@ -333,7 +333,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -495,7 +495,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'squid_8.1'  # Checkout the squid_8.1 branch
 
@@ -503,7 +503,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -567,7 +567,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_ha_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -589,7 +589,7 @@ jobs:
   #   timeout-minutes: 1440
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #       with:
   #         ref: 'squid_8.1'  # Checkout the squid_8.1 branch
 
@@ -617,13 +617,13 @@ jobs:
 
   #     - name: Upload nightly nvmeof console as artifact
   #       if: always()
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: atom-nightly-nvmeof-full-console
   #         path: atom_nightly_nvmeof_console.log
 
   #     - name: Upload artifact for schedule events
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       if: always()
   #       with:
   #         name: atom-artifact

--- a/.github/workflows/tentacle-9.0-schedule.yml
+++ b/.github/workflows/tentacle-9.0-schedule.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.0'  # Checkout the tentacle_9.0 branch
           submodules: recursive
@@ -46,14 +46,14 @@ jobs:
           docker save $QUAY_SPDK:$SPDK_VERSION > spdk.tar
 
       - name: Upload bdevperf container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_bdevperf
           path: |
             bdevperf.tar
 
       - name: Upload nvmeof container images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_nvmeof
           path: |
@@ -61,7 +61,7 @@ jobs:
             nvmeof-cli.tar
 
       - name: Upload spdk container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_image_spdk
           path: |
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.0'  # Checkout the tentacle_9.0 branch
 
@@ -84,7 +84,7 @@ jobs:
           docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
 
       - name: Upload ceph container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_ceph
           path: |
@@ -101,7 +101,7 @@ jobs:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.0'  # Checkout the tentacle_9.0 branch
 
@@ -110,7 +110,7 @@ jobs:
           make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_pytest_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -218,7 +218,7 @@ jobs:
       HUGEPAGES: 512
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.0'  # Checkout the tentacle_9.0 branch
 
@@ -226,7 +226,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -297,7 +297,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_demo_${{ matrix.security_protocol }}
           path: /tmp/out/*.log
@@ -324,7 +324,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.0'  # Checkout the tentacle_9.0 branch
 
@@ -332,7 +332,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -494,7 +494,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.0'  # Checkout the tentacle_9.0 branch
 
@@ -502,7 +502,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -566,7 +566,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_ha_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -588,7 +588,7 @@ jobs:
   #   timeout-minutes: 1440
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #       with:
   #         ref: 'tentacle_9.0'  # Checkout the tentacle_9.0 branch
 
@@ -616,13 +616,13 @@ jobs:
 
   #     - name: Upload nightly nvmeof console as artifact
   #       if: always()
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: atom-nightly-nvmeof-full-console
   #         path: atom_nightly_nvmeof_console.log
 
   #     - name: Upload artifact for schedule events
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       if: always()
   #       with:
   #         name: atom-artifact

--- a/.github/workflows/tentacle-9.1-schedule.yml
+++ b/.github/workflows/tentacle-9.1-schedule.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.1'  # Checkout the tentacle_9.1 branch
           submodules: recursive
@@ -46,14 +46,14 @@ jobs:
           docker save $QUAY_SPDK:$SPDK_VERSION > spdk.tar
 
       - name: Upload bdevperf container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_bdevperf
           path: |
             bdevperf.tar
 
       - name: Upload nvmeof container images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_nvmeof
           path: |
@@ -61,7 +61,7 @@ jobs:
             nvmeof-cli.tar
 
       - name: Upload spdk container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_image_spdk
           path: |
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.1'  # Checkout the tentacle_9.1 branch
 
@@ -84,7 +84,7 @@ jobs:
           docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
 
       - name: Upload ceph container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_ceph
           path: |
@@ -101,7 +101,7 @@ jobs:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.1'  # Checkout the tentacle_9.1 branch
 
@@ -110,7 +110,7 @@ jobs:
           make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_pytest_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -218,7 +218,7 @@ jobs:
       HUGEPAGES: 512
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.1'  # Checkout the tentacle_9.1 branch
 
@@ -226,7 +226,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -297,7 +297,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_demo_${{ matrix.security_protocol }}
           path: /tmp/out/*.log
@@ -324,7 +324,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.1'  # Checkout the tentacle_9.1 branch
 
@@ -332,7 +332,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -494,7 +494,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.1'  # Checkout the tentacle_9.1 branch
 
@@ -502,7 +502,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -566,7 +566,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_ha_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -588,7 +588,7 @@ jobs:
   #   timeout-minutes: 1440
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #       with:
   #         ref: 'tentacle_9.1'  # Checkout the tentacle_9.1 branch
 
@@ -616,13 +616,13 @@ jobs:
 
   #     - name: Upload nightly nvmeof console as artifact
   #       if: always()
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: atom-nightly-nvmeof-full-console
   #         path: atom_nightly_nvmeof_console.log
 
   #     - name: Upload artifact for schedule events
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       if: always()
   #       with:
   #         name: atom-artifact

--- a/.github/workflows/tentacle-9.2-schedule.yml
+++ b/.github/workflows/tentacle-9.2-schedule.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.2'  # Checkout the tentacle_9.2 branch
           submodules: recursive
@@ -46,14 +46,14 @@ jobs:
           docker save $QUAY_SPDK:$SPDK_VERSION > spdk.tar
 
       - name: Upload bdevperf container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_bdevperf
           path: |
             bdevperf.tar
 
       - name: Upload nvmeof container images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_nvmeof
           path: |
@@ -61,7 +61,7 @@ jobs:
             nvmeof-cli.tar
 
       - name: Upload spdk container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_image_spdk
           path: |
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.2'  # Checkout the tentacle_9.2 branch
 
@@ -84,7 +84,7 @@ jobs:
           docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
 
       - name: Upload ceph container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_ceph
           path: |
@@ -101,7 +101,7 @@ jobs:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.2'  # Checkout the tentacle_9.2 branch
 
@@ -110,7 +110,7 @@ jobs:
           make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_pytest_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -218,7 +218,7 @@ jobs:
       HUGEPAGES: 512
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.2'  # Checkout the tentacle_9.2 branch
 
@@ -226,7 +226,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -297,7 +297,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_demo_${{ matrix.security_protocol }}
           path: /tmp/out/*.log
@@ -324,7 +324,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.2'  # Checkout the tentacle_9.2 branch
 
@@ -332,7 +332,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -494,7 +494,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'tentacle_9.2'  # Checkout the tentacle_9.2 branch
 
@@ -502,7 +502,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -566,7 +566,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_ha_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -588,7 +588,7 @@ jobs:
   #   timeout-minutes: 1440
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #       with:
   #         ref: 'tentacle_9.2'  # Checkout the tentacle_9.2 branch
 
@@ -616,13 +616,13 @@ jobs:
 
   #     - name: Upload nightly nvmeof console as artifact
   #       if: always()
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: atom-nightly-nvmeof-full-console
   #         path: atom_nightly_nvmeof_console.log
 
   #     - name: Upload artifact for schedule events
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       if: always()
   #       with:
   #         name: atom-artifact

--- a/.github/workflows/umbrella-schedule.yml
+++ b/.github/workflows/umbrella-schedule.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'umbrella'  # Checkout the umbrella branch
           submodules: recursive
@@ -46,14 +46,14 @@ jobs:
           docker save $QUAY_SPDK:$SPDK_VERSION > spdk.tar
 
       - name: Upload bdevperf container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_bdevperf
           path: |
             bdevperf.tar
 
       - name: Upload nvmeof container images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_nvmeof
           path: |
@@ -61,7 +61,7 @@ jobs:
             nvmeof-cli.tar
 
       - name: Upload spdk container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_image_spdk
           path: |
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'umbrella'  # Checkout the umbrella branch
 
@@ -84,7 +84,7 @@ jobs:
           docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
 
       - name: Upload ceph container image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: container_images_ceph
           path: |
@@ -101,7 +101,7 @@ jobs:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'umbrella'  # Checkout the umbrella branch
 
@@ -110,7 +110,7 @@ jobs:
           make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_pytest_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -218,7 +218,7 @@ jobs:
       HUGEPAGES: 512
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'umbrella'  # Checkout the umbrella branch
 
@@ -226,7 +226,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -297,7 +297,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_demo_${{ matrix.security_protocol }}
           path: /tmp/out/*.log
@@ -324,7 +324,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'umbrella'  # Checkout the umbrella branch
 
@@ -332,7 +332,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -494,7 +494,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'umbrella'  # Checkout the umbrella branch
 
@@ -502,7 +502,7 @@ jobs:
         run: make setup HUGEPAGES=$HUGEPAGES
 
       - name: Download container images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: container_images*
           merge-multiple: true
@@ -566,7 +566,7 @@ jobs:
 
       - name: Upload ceph logs
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ceph_out_ha_${{ matrix.test }}
           path: /tmp/out/*.log
@@ -588,7 +588,7 @@ jobs:
   #   timeout-minutes: 1440
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #       with:
   #         ref: 'umbrella'  # Checkout the umbrella branch
 
@@ -616,13 +616,13 @@ jobs:
 
   #     - name: Upload nightly nvmeof console as artifact
   #       if: always()
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: atom-nightly-nvmeof-full-console
   #         path: atom_nightly_nvmeof_console.log
 
   #     - name: Upload artifact for schedule events
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       if: always()
   #       with:
   #         name: atom-artifact


### PR DESCRIPTION
# ci: nodejs 20 -> 24, resolve deprecated warning

for instance here https://github.com/ceph/ceph-nvmeof/actions/runs/31641691638 
warning:
`build-kmip` 
```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/upload-artifact@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
