### PR TITLE
ci: umbrella fix typo rref -> ref

### DIFF
--- a/.github/workflows/umbrella-schedule.yml
+++ b/.github/workflows/umbrella-schedule.yml
@@ -496,7 +496,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          rref: 'umbrella'  # Checkout the umbrella branch
+          ref: 'umbrella'  # Checkout the umbrella branch
 
       - name: Setup huge-pages
         run: make setup HUGEPAGES=$HUGEPAGES


### PR DESCRIPTION
# ci: umbrella fix typo rref -> ref

actions/checkout expects input key ref; rref is ignored, so this step will check out the default branch instead of umbrella.