### PR TITLE
Rephrase "image is not formatted for encryption" message to fit all cases

### DIFF
--- a/control/cephutils.py
+++ b/control/cephutils.py
@@ -429,7 +429,8 @@ class CephUtils:
                     with rbd.Image(ioctx, image_name) as img:
                         img.encryption_load2(specs)
                 except rbd.InvalidArgument:
-                    errmsg = f"RBD image {image_path} is not formatted for encryption"
+                    errmsg = f"RBD image {image_path} is not formatted for encryption or " \
+                             f"is formatted using the wrong encryption format"
                     self.logger.exception(errmsg)
                     return errmsg
                 except rbd.PermissionError:

--- a/tests/test_rbd_encrypt.py
+++ b/tests/test_rbd_encrypt.py
@@ -1231,7 +1231,8 @@ def test_open_with_encryption_plain_image(caplog, two_gateways):
          "--rbd-data-pool", pool, "--rbd-image", image6,
          "--encryption-format", "luks1", "--key-id", key_id])
     assert f"Failure adding namespace to {subsystem1}: RBD " \
-           f"image {pool}/{image6} is not formatted for encryption" in caplog.text
+           f"image {pool}/{image6} is not formatted for encryption or " \
+           f"is formatted using the wrong encryption format" in caplog.text
 
 
 def test_list_namespaces(caplog, two_gateways):


### PR DESCRIPTION
Fixes: #2075