### PR TITLE
atom ci: sha update with pool create command fix

### DIFF
--- a/.env
+++ b/.env
@@ -76,7 +76,7 @@ CEPH_SHA=latest
 CEPH_DEVEL_MGR_PATH=../ceph
 
 # Atom
-ATOM_SHA=fddf96bf46ab9e7c031361e31b11aa315a2520f0
+ATOM_SHA=14c2792a0ac052bed7a4fe61e699d32b288883f2
 
 # Demo settings
 RBD_POOL=rbd


### PR DESCRIPTION
`-yes-i-really-mean-it` removed from pool create command due to ceph code change
`cmd: ceph osd pool create nvmeof --yes-i-really-mean-it`