### PR TITLE
tentacle 9.1: .env: calculate CEPH_VERSION from CEPH_BRANCH/CEPH_SHA

### DIFF
--- a/.env
+++ b/.env
@@ -66,7 +66,7 @@ SPDK_CENTOS_REPO_VER="9.0-38.el9"
 # are derived by the Makefile. `make` exports them for compose. For a direct
 # `docker compose` invocation, run: eval "$(make -s ceph-env)"
 CEPH_BRANCH=tentacle
-CEPH_SHA=latest
+CEPH_SHA=20.2.2
 # Note: CEPH_SHA supports three formats:
 # - "latest" - fetches the most recent ready build from Shaman for CEPH_BRANCH
 # - Release number (e.g., "v20.2.1" or "20.2.1") - resolves the GitHub tag to a commit SHA

--- a/.env
+++ b/.env
@@ -1,6 +1,5 @@
 # Globals
 VERSION="1.6.24"
-CEPH_VERSION="20.2.4"
 SPDK_VERSION="25.09"
 CONTAINER_REGISTRY="quay.io/ceph"
 QUAY_SPDK="${CONTAINER_REGISTRY}/spdk"
@@ -27,7 +26,6 @@ HUGEPAGES_DIR="/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
 NVMEOF_VERSION="${VERSION}"
 NVMEOF_CONFIG="./ceph-nvmeof.conf"
 NVMEOF_SPDK_VERSION="${SPDK_VERSION}"
-NVMEOF_CEPH_VERSION="${CEPH_VERSION}"
 NVMEOF_NAME="ceph-nvmeof"
 NVMEOF_SUMMARY="Ceph NVMe over Fabrics Gateway"
 NVMEOF_DESCRIPTION="Service to provide block storage on top of Ceph for platforms (e.g.: VMWare) without native Ceph support (RBD), replacing existing approaches (iSCSI) with a newer and more versatile standard (NVMe-oF)."
@@ -49,7 +47,6 @@ NVMEOF_CLI_SUMMARY="Ceph NVMe over Fabrics CLI"
 NVMEOF_CLI_DESCRIPTION="Command line interface for Ceph NVMe over Fabrics Gateway"
 
 # SPDK
-SPDK_CEPH_VERSION="${CEPH_VERSION}"
 SPDK_NAME="SPDK"
 SPDK_SUMMARY="Build Ultra High-Performance Storage Applications with the Storage Performance Development Kit"
 SPDK_DESCRIPTION="The Storage Performance Development Kit (SPDK) provides a set of tools and libraries for writing high performance, scalable, user-mode storage applications"
@@ -65,9 +62,15 @@ SPDK_CENTOS_BASE="https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Pac
 SPDK_CENTOS_REPO_VER="9.0-38.el9"
 
 # Ceph Cluster
-CEPH_CLUSTER_VERSION="${CEPH_VERSION}"
+# CEPH_VERSION, CEPH_CLUSTER_VERSION, NVMEOF_CEPH_VERSION, and SPDK_CEPH_VERSION
+# are derived by the Makefile. `make` exports them for compose. For a direct
+# `docker compose` invocation, run: eval "$(make -s ceph-env)"
 CEPH_BRANCH=tentacle
 CEPH_SHA=latest
+# Note: CEPH_SHA supports three formats:
+# - "latest" - fetches the most recent ready build from Shaman for CEPH_BRANCH
+# - Release number (e.g., "v20.2.1" or "20.2.1") - resolves the GitHub tag to a commit SHA
+# - Direct commit SHA (e.g., "6a49aff47758778a5f5951e731d437c317f72fb2")
 
 CEPH_DEVEL_MGR_PATH=../ceph
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -79,6 +79,8 @@ jobs:
 
   build-ceph:
     runs-on: ubuntu-latest
+    outputs:
+      ceph_version: ${{ steps.ceph-version.outputs.ceph_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -87,8 +89,11 @@ jobs:
         run: make build SVC=ceph
 
       - name: Save container images
+        id: ceph-version
         run: |
           . .env
+          CEPH_VERSION=$(make -s ceph-version)
+          echo "ceph_version=$CEPH_VERSION" >> "$GITHUB_OUTPUT"
           docker save $QUAY_CEPH:$CEPH_VERSION > ceph.tar
 
       - name: Upload ceph container image
@@ -158,6 +163,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 512  # for multi gateway test, approx 256 per gateway instance
+      CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      CEPH_CLUSTER_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      NVMEOF_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      SPDK_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -289,6 +298,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 512
+      CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      CEPH_CLUSTER_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      NVMEOF_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      SPDK_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -397,6 +410,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 768  # 3 spdk instances
+      CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      CEPH_CLUSTER_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      NVMEOF_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      SPDK_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
 
     steps:
       - name: Checkout code
@@ -565,6 +582,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGEPAGES: 1024  # 4 spdk instances
+      CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      CEPH_CLUSTER_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      NVMEOF_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      SPDK_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
 
     steps:
       - name: Checkout code
@@ -656,6 +677,11 @@ jobs:
   kmip_test:
     needs: [build, build-ceph]
     runs-on: ubuntu-latest
+    env:
+      CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      CEPH_CLUSTER_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      NVMEOF_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
+      SPDK_CEPH_VERSION: ${{ needs.build-ceph.outputs.ceph_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -63,31 +63,162 @@ build: export SPDK_CONFIGURE_DSA := $(SPDK_CONFIGURE_DSA)
 # Variables
 SHAMAN_FETCH_ATTEMPTS := 3
 
-# Fetch and export CEPH_CLUSTER_CEPH_REPO_BASEURL with retries
-build: export CEPH_CLUSTER_CEPH_REPO_BASEURL != \
+# Derive CEPH_VERSION from a release tag/number without hitting the network.
+# "latest" and raw commit SHAs are filled in from Shaman extra.version below.
+CEPH_VERSION_FROM_TAG := $(shell \
+	sha="$(CEPH_SHA)"; \
+	if printf '%s' "$$sha" | grep -qE '^[vV]?[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		printf '%s' "$$sha" | sed 's/^[vV]//'; \
+	fi)
+ifneq ($(CEPH_VERSION_FROM_TAG),)
+CEPH_VERSION := $(CEPH_VERSION_FROM_TAG)
+endif
+
+# Only perform the Ceph Shaman repo lookup when a goal needs the repo URL,
+# commit SHA, or derived CEPH_VERSION. Key compose-facing goals off
+# DOCKER_COMPOSE_COMMANDS (image tags) plus `up`/`all`/`image_name` and the
+# version helpers. `push` does not use Ceph image tags, so it stays offline.
+_ceph_lookup_goals := all up image_name ceph-version ceph-env check-ceph-repo-url check-ceph-version $(DOCKER_COMPOSE_COMMANDS)
+_ceph_url_goals := build check-ceph-repo-url
+_do_ceph_lookup := $(if $(MAKECMDGOALS),$(filter $(_ceph_lookup_goals),$(MAKECMDGOALS)),yes)
+# Skip Shaman when X.Y.Z is already known (release tag or env), except for
+# goals that need the repo URL / commit SHA.
+ifneq ($(CEPH_VERSION),)
+ifeq ($(filter $(_ceph_url_goals),$(MAKECMDGOALS)),)
+_do_ceph_lookup :=
+endif
+endif
+ifneq ($(_do_ceph_lookup),)
+# Fetch shaman repo URL, the git SHA it corresponds to, and X.Y.Z version.
+# Output: <url> <sha> <version>
+CEPH_SHAMAN_FETCH := $(shell \
 	for i in $$(seq 1 $(SHAMAN_FETCH_ATTEMPTS)); do \
-		sha1="$(CEPH_SHA)"; \
-		if [ "$$sha1" = "latest" ]; then \
+		ceph_commit_sha="$(CEPH_SHA)"; \
+		ceph_version=; \
+		resolved_sha=; \
+		tag_sha=; \
+		tag_type=; \
+		extra_ver=; \
+		if [ "$$ceph_commit_sha" = "latest" ]; then \
 			idx=$$((i - 1)); \
-			sha1=$$(curl -s \
-				"https://shaman.ceph.com/api/search/?status=ready&project=ceph&ref=$(CEPH_BRANCH)&flavor=default&distros=centos/9/$(ceph_repo_arch)" \
-				| jq -r "sort_by(.modified) | reverse | .[$$idx].sha1"); \
-			>&2 echo "Attempt ($$i): Using 'latest' SHA1 for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH): $$sha1"; \
+			search_json=$$(curl -s \
+				"https://shaman.ceph.com/api/search/?status=ready&project=ceph&ref=$(CEPH_BRANCH)&flavor=default&distros=centos/9/$(ceph_repo_arch)"); \
+			rec=; \
+			if [ -n "$$search_json" ] && printf '%s' "$$search_json" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then \
+				rec=$$(printf '%s' "$$search_json" | jq -c "sort_by(.modified) | reverse | .[$$idx] // empty"); \
+			fi; \
+			if [ -z "$$rec" ] || [ "$$rec" = "null" ]; then \
+				>&2 echo "Attempt ($$i): No ready Shaman record at index $$idx for branch=$(CEPH_BRANCH) arch=$(ceph_repo_arch)"; \
+				sleep 2; \
+				continue; \
+			fi; \
+			ceph_commit_sha=$$(printf '%s' "$$rec" | jq -r '.sha1 // empty'); \
+			extra_ver=$$(printf '%s' "$$rec" | jq -r '.extra.version // empty'); \
+			ceph_version=$$(printf '%s' "$$extra_ver" | cut -d- -f1); \
+			>&2 echo "Attempt ($$i): Using 'latest' commit SHA for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH): $$ceph_commit_sha version=$$ceph_version"; \
+		elif printf '%s' "$$ceph_commit_sha" | grep -qE '^[vV]?[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+			ceph_version=$$(printf '%s' "$$ceph_commit_sha" | sed 's/^[vV]//'); \
+			tag_name="v$$ceph_version"; \
+			>&2 echo "Attempt ($$i): Resolving release tag '$$tag_name' to git commit SHA..."; \
+			tag_response=$$(curl -s "https://api.github.com/repos/ceph/ceph/git/ref/tags/$$tag_name"); \
+			tag_sha=$$(echo "$$tag_response" | jq -r '.object.sha'); \
+			tag_type=$$(echo "$$tag_response" | jq -r '.object.type'); \
+			if [ "$$tag_type" = "tag" ]; then \
+				>&2 echo "Attempt ($$i): Dereferencing annotated tag..."; \
+				resolved_sha=$$(curl -s "https://api.github.com/repos/ceph/ceph/git/tags/$$tag_sha" | jq -r '.object.sha'); \
+			elif [ "$$tag_type" = "commit" ]; then \
+				resolved_sha="$$tag_sha"; \
+			fi; \
+			if [ -n "$$resolved_sha" ] && [ "$$resolved_sha" != "null" ]; then \
+				>&2 echo "Attempt ($$i): Resolved tag '$$tag_name' to commit SHA: $$resolved_sha"; \
+				ceph_commit_sha="$$resolved_sha"; \
+			else \
+				>&2 echo "Attempt ($$i): Failed to resolve tag '$$tag_name' to a commit SHA"; \
+				sleep 2; \
+				continue; \
+			fi; \
 		fi; \
-		>&2 echo "Attempt ($$i): Fetching URL for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH), sha=$(CEPH_SHA)..."; \
-		url=$$(curl -s "https://shaman.ceph.com/api/repos/ceph/$(CEPH_BRANCH)/$$sha1/centos/9/" | jq -r '.[] | select(.status == "ready" and .archs[] == "$(ceph_repo_arch)") | .url'); \
-		if [ -n "$$url" ]; then \
-			>&2 echo "Success: Retrieved URL for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH), sha=$(CEPH_SHA): $$url"; \
-			echo "$$url"; \
+		if ! printf '%s' "$$ceph_commit_sha" | grep -qE '^[0-9a-fA-F]{40}$$'; then \
+			>&2 echo "Attempt ($$i): Refused non-SHA value '$$ceph_commit_sha' (expected a 40-char commit SHA)"; \
+			sleep 2; \
+			continue; \
+		fi; \
+		ceph_commit_sha=$$(printf '%s' "$$ceph_commit_sha" | tr 'A-F' 'a-f'); \
+		>&2 echo "Attempt ($$i): Fetching URL for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH), sha=$$ceph_commit_sha..."; \
+		repo_json=$$(curl -s "https://shaman.ceph.com/api/repos/ceph/$(CEPH_BRANCH)/$$ceph_commit_sha/centos/9/"); \
+		url=$$(echo "$$repo_json" | jq -r '[.[] | select(.status == "ready" and .archs[] == "$(ceph_repo_arch)")] | first | .url // empty'); \
+		if [ -n "$$url" ] && [ "$$url" != "null" ]; then \
+			if printf '%s' "$$url" | grep -q '[[:space:]]'; then \
+				>&2 echo "Attempt ($$i): Refused shaman URL with whitespace: $$url"; \
+				sleep 2; \
+				continue; \
+			fi; \
+			if [ -z "$$ceph_version" ]; then \
+				extra_ver=$$(echo "$$repo_json" | jq -r '[.[] | select(.status == "ready" and .archs[] == "$(ceph_repo_arch)")] | first | .extra.version // empty'); \
+				ceph_version=$$(printf '%s' "$$extra_ver" | cut -d- -f1); \
+			fi; \
+			if ! printf '%s' "$$ceph_version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+				>&2 echo "Attempt ($$i): Refused CEPH_VERSION '$$ceph_version' (from extra.version='$$extra_ver')"; \
+				sleep 2; \
+				continue; \
+			fi; \
+			>&2 echo "Success: Retrieved URL for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH), sha=$$ceph_commit_sha, version=$$ceph_version: $$url"; \
+			printf "%s %s %s" "$$url" "$$ceph_commit_sha" "$$ceph_version"; \
 			break; \
 		fi; \
-		>&2 echo "Retrying... Failed attempt ($$i) for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH), sha=$(CEPH_SHA)"; \
+		>&2 echo "Retrying... Failed attempt ($$i) for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH), sha=$$ceph_commit_sha"; \
 		sleep 2; \
-	done; \
-	if [ -z "$$url" ]; then \
-		>&2 echo "Failure: Unable to retrieve a valid URL for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH), sha=$(CEPH_SHA) after $(SHAMAN_FETCH_ATTEMPTS) attempts"; \
-		exit 1; \
-	fi
+	done)
+CEPH_CLUSTER_CEPH_REPO_BASEURL := $(word 1,$(CEPH_SHAMAN_FETCH))
+CEPH_CLUSTER_CEPH_SHA := $(word 2,$(CEPH_SHAMAN_FETCH))
+CEPH_SHAMAN_VERSION := $(word 3,$(CEPH_SHAMAN_FETCH))
+ifneq ($(CEPH_SHAMAN_VERSION),)
+CEPH_VERSION := $(CEPH_SHAMAN_VERSION)
+endif
+endif
+
+ifneq ($(CEPH_VERSION),)
+CEPH_CLUSTER_VERSION ?= $(CEPH_VERSION)
+NVMEOF_CEPH_VERSION ?= $(CEPH_VERSION)
+SPDK_CEPH_VERSION ?= $(CEPH_VERSION)
+endif
+
+CEPH_COMPOSE_EXPORT_TARGETS := up image_name $(DOCKER_COMPOSE_COMMANDS)
+$(CEPH_COMPOSE_EXPORT_TARGETS): export CEPH_VERSION := $(CEPH_VERSION)
+$(CEPH_COMPOSE_EXPORT_TARGETS): export CEPH_CLUSTER_VERSION := $(CEPH_CLUSTER_VERSION)
+$(CEPH_COMPOSE_EXPORT_TARGETS): export NVMEOF_CEPH_VERSION := $(NVMEOF_CEPH_VERSION)
+$(CEPH_COMPOSE_EXPORT_TARGETS): export SPDK_CEPH_VERSION := $(SPDK_CEPH_VERSION)
+
+build: export CEPH_CLUSTER_CEPH_REPO_BASEURL := $(CEPH_CLUSTER_CEPH_REPO_BASEURL)
+build: export CEPH_CLUSTER_CEPH_SHA := $(CEPH_CLUSTER_CEPH_SHA)
+build: check-ceph-repo-url check-ceph-version
+pull: check-ceph-version
+up: check-ceph-version
+
+check-ceph-repo-url:
+	@test -n "$(CEPH_CLUSTER_CEPH_REPO_BASEURL)" && test "$(CEPH_CLUSTER_CEPH_REPO_BASEURL)" != "null" || \
+		(>&2 echo "Failure: No ready Ceph Shaman repo for arch=$(ceph_repo_arch), branch=$(CEPH_BRANCH), sha=$(CEPH_CLUSTER_CEPH_SHA) (CEPH_SHA=$(CEPH_SHA)) on centos/9"; \
+		 >&2 echo "Shaman currently provides centos/9 repos only for x86_64 in this branch/ref combination."; \
+		 exit 1)
+	@printf '%s' "$(CEPH_CLUSTER_CEPH_SHA)" | grep -qE '^[0-9a-fA-F]{40}$$' || \
+		(>&2 echo "Failure: CEPH_CLUSTER_CEPH_SHA is not a 40-char commit SHA: '$(CEPH_CLUSTER_CEPH_SHA)'"; \
+		 exit 1)
+
+check-ceph-version:
+	@printf '%s' "$(CEPH_VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$' || \
+		(>&2 echo "Failure: could not derive CEPH_VERSION from CEPH_SHA=$(CEPH_SHA) CEPH_BRANCH=$(CEPH_BRANCH) (got '$(CEPH_VERSION)')"; \
+		 exit 1)
+
+ceph-version: ## Print CEPH_VERSION derived from CEPH_BRANCH and CEPH_SHA
+ceph-version: check-ceph-version
+	@echo $(CEPH_VERSION)
+
+ceph-env: ## Print export CEPH_* lines for docker compose
+ceph-env: check-ceph-version
+	@printf 'export CEPH_VERSION=%s\n' '$(CEPH_VERSION)'
+	@printf 'export CEPH_CLUSTER_VERSION=%s\n' '$(CEPH_CLUSTER_VERSION)'
+	@printf 'export NVMEOF_CEPH_VERSION=%s\n' '$(NVMEOF_CEPH_VERSION)'
+	@printf 'export SPDK_CEPH_VERSION=%s\n' '$(SPDK_CEPH_VERSION)'
 
 build: export TARGET_PLATFORM := $(TARGET_PLATFORM)
 build: export SPDK_TARGET_ARCH := $(SPDK_TARGET_ARCH)
@@ -130,4 +261,4 @@ export-python: run ## Build Ceph NVMe-oF Gateway Python package and copy it to /
 help: AUTOHELP_SUMMARY = Makefile to build and deploy the Ceph NVMe-oF Gateway
 help: autohelp
 
-.PHONY: all setup clean help update-lockfile protoc export-rpms export-python
+.PHONY: all setup clean help update-lockfile protoc export-rpms export-python check-ceph-repo-url check-ceph-version ceph-version ceph-env

--- a/tests/ha/start_up.sh
+++ b/tests/ha/start_up.sh
@@ -1,6 +1,23 @@
 set -e
 SCALE=2
 POOL="${RBD_POOL:-rbd}"
+# Compose needs CEPH_CLUSTER_VERSION, NVMEOF_CEPH_VERSION, and SPDK_CEPH_VERSION.
+# Preserve already-set overrides; derive any missing values from CEPH_VERSION.
+if [ -z "${CEPH_VERSION:-}" ]; then
+  _repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+  if ! derived="$(make -C "$_repo_root" -s ceph-version)"; then
+    echo "Failed to derive CEPH_VERSION" >&2
+    exit 1
+  fi
+  if [ -z "$derived" ]; then
+    echo "Failed to derive CEPH_VERSION: empty result" >&2
+    exit 1
+  fi
+  export CEPH_VERSION="$derived"
+fi
+export CEPH_CLUSTER_VERSION="${CEPH_CLUSTER_VERSION:-$CEPH_VERSION}"
+export NVMEOF_CEPH_VERSION="${NVMEOF_CEPH_VERSION:-$CEPH_VERSION}"
+export SPDK_CEPH_VERSION="${SPDK_CEPH_VERSION:-$CEPH_VERSION}"
 # Check if argument is provided
 if [ $# -ge 1 ]; then
     # Check if argument is an integer larger or equal than 1


### PR DESCRIPTION
# Tentacle 9.1 ceph version
backport of #2114

Pin `CEPH_SHA` to `20.2.2` (official release). Numbered tentacle branches track a release, not `latest`.