### PR TITLE
tentacle 9.1: pin CEPH_SHA to v20.2.2

### DIFF
--- a/.env
+++ b/.env
@@ -66,10 +66,10 @@ SPDK_CENTOS_REPO_VER="9.0-38.el9"
 # are derived by the Makefile. `make` exports them for compose. For a direct
 # `docker compose` invocation, run: eval "$(make -s ceph-env)"
 CEPH_BRANCH=tentacle
-CEPH_SHA=20.2.2
+CEPH_SHA=v20.2.1
 # Note: CEPH_SHA supports three formats:
 # - "latest" - fetches the most recent ready build from Shaman for CEPH_BRANCH
-# - Release number (e.g., "v20.2.1" or "20.2.1") - resolves the GitHub tag to a commit SHA
+# - "v*" (e.g., "v20.2.1") - resolves Ceph release tag to commit SHA via GitHub API
 # - Direct commit SHA (e.g., "6a49aff47758778a5f5951e731d437c317f72fb2")
 
 CEPH_DEVEL_MGR_PATH=../ceph

--- a/.env
+++ b/.env
@@ -66,7 +66,7 @@ SPDK_CENTOS_REPO_VER="9.0-38.el9"
 # are derived by the Makefile. `make` exports them for compose. For a direct
 # `docker compose` invocation, run: eval "$(make -s ceph-env)"
 CEPH_BRANCH=tentacle
-CEPH_SHA=v20.2.1
+CEPH_SHA=v20.2.2
 # Note: CEPH_SHA supports three formats:
 # - "latest" - fetches the most recent ready build from Shaman for CEPH_BRANCH
 # - "v*" (e.g., "v20.2.1") - resolves Ceph release tag to commit SHA via GitHub API


### PR DESCRIPTION
# Tentacle 9.1 Ceph pin

Correct `CEPH_SHA` to `v20.2.2`.

9.1 includes ceph-nvmeof#1429 (crc32c write path) and needs librbd `rbd_aio_write_with_crc32c`, which first shipped in Ceph 20.2.2.